### PR TITLE
feat(GH-49): Add sample poems and preset library

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jsdom": "^27.0.0",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
@@ -1932,6 +1933,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",

--- a/web/src/components/SamplePoemPicker/SamplePoemPicker.css
+++ b/web/src/components/SamplePoemPicker/SamplePoemPicker.css
@@ -1,0 +1,537 @@
+/**
+ * SamplePoemPicker Component Styles
+ *
+ * CSS for the poem browser and selection interface.
+ */
+
+/* Main container */
+.sample-poem-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 1200px;
+}
+
+/* Controls section */
+.picker-controls {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* Search input container */
+.search-container {
+  flex: 1;
+  min-width: 200px;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background-color: white;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.search-input:disabled {
+  background-color: #f3f4f6;
+  cursor: not-allowed;
+}
+
+/* Filter section */
+.filter-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-label {
+  font-weight: 500;
+  color: #374151;
+  font-size: 0.875rem;
+}
+
+.form-select {
+  padding: 0.75rem 2rem 0.75rem 1rem;
+  font-size: 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background-color: white;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236b7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  background-size: 1.25rem;
+}
+
+.form-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.form-select:disabled {
+  background-color: #f3f4f6;
+  cursor: not-allowed;
+}
+
+/* Content area - list and preview */
+.picker-content {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr;
+  gap: 1.5rem;
+  min-height: 400px;
+}
+
+/* Poem list */
+.poem-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 500px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.poem-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.poem-list::-webkit-scrollbar-track {
+  background: #f1f5f9;
+  border-radius: 3px;
+}
+
+.poem-list::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 3px;
+}
+
+.poem-list::-webkit-scrollbar-thumb:hover {
+  background: #94a3b8;
+}
+
+/* Individual poem item */
+.poem-item {
+  padding: 0.875rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background-color: white;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.poem-item:hover {
+  border-color: #3b82f6;
+  background-color: #f8fafc;
+}
+
+.poem-item:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.poem-item.selected {
+  border-color: #3b82f6;
+  background-color: #eff6ff;
+}
+
+.poem-item.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.poem-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.poem-title {
+  font-weight: 600;
+  color: #1f2937;
+  font-size: 0.9375rem;
+}
+
+.poem-form {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  background-color: #e5e7eb;
+  border-radius: 1rem;
+  color: #4b5563;
+  white-space: nowrap;
+}
+
+.poem-meta {
+  display: flex;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: #6b7280;
+}
+
+.poem-author {
+  color: #4b5563;
+}
+
+.poem-year {
+  color: #9ca3af;
+}
+
+/* No results message */
+.no-results {
+  padding: 2rem;
+  text-align: center;
+  color: #6b7280;
+  font-style: italic;
+}
+
+/* Poem preview panel */
+.poem-preview {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background-color: #fafafa;
+  overflow: hidden;
+}
+
+.preview-header {
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.preview-title {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.preview-attribution {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: #6b7280;
+}
+
+.preview-author {
+  font-style: italic;
+}
+
+.preview-year {
+  color: #9ca3af;
+}
+
+/* Poem text display */
+.preview-text {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background-color: white;
+  border-radius: 0.375rem;
+  border: 1px solid #e5e7eb;
+  max-height: 250px;
+}
+
+.preview-text pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: #374151;
+}
+
+/* Preview footer */
+.preview-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.preview-description {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #4b5563;
+  font-style: italic;
+}
+
+.preview-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.8125rem;
+  color: #6b7280;
+}
+
+.detail-item strong {
+  color: #4b5563;
+}
+
+/* Tags */
+.preview-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.tag {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.625rem;
+  background-color: #dbeafe;
+  color: #1e40af;
+  border-radius: 1rem;
+}
+
+.preview-source {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #9ca3af;
+}
+
+/* Select button */
+.select-button {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: white;
+  background-color: #3b82f6;
+  border: none;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.select-button:hover:not(:disabled) {
+  background-color: #2563eb;
+}
+
+.select-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+.select-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Footer */
+.picker-footer {
+  padding-top: 0.75rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.results-count {
+  font-size: 0.8125rem;
+  color: #6b7280;
+}
+
+/* Visually hidden (for screen readers) */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .picker-content {
+    grid-template-columns: 1fr;
+  }
+
+  .poem-preview {
+    order: -1;
+  }
+
+  .preview-text {
+    max-height: 200px;
+  }
+
+  .picker-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filter-container {
+    justify-content: space-between;
+  }
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .search-input {
+    background-color: #1f2937;
+    border-color: #374151;
+    color: #f3f4f6;
+  }
+
+  .search-input:focus {
+    border-color: #60a5fa;
+    box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.2);
+  }
+
+  .search-input:disabled {
+    background-color: #111827;
+  }
+
+  .search-input::placeholder {
+    color: #9ca3af;
+  }
+
+  .filter-label {
+    color: #d1d5db;
+  }
+
+  .form-select {
+    background-color: #1f2937;
+    border-color: #374151;
+    color: #f3f4f6;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%239ca3af'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E");
+  }
+
+  .form-select:focus {
+    border-color: #60a5fa;
+    box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.2);
+  }
+
+  .form-select:disabled {
+    background-color: #111827;
+  }
+
+  .poem-item {
+    background-color: #1f2937;
+    border-color: #374151;
+  }
+
+  .poem-item:hover {
+    border-color: #60a5fa;
+    background-color: #111827;
+  }
+
+  .poem-item:focus {
+    border-color: #60a5fa;
+    box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.2);
+  }
+
+  .poem-item.selected {
+    border-color: #60a5fa;
+    background-color: #1e3a5f;
+  }
+
+  .poem-title {
+    color: #f3f4f6;
+  }
+
+  .poem-form {
+    background-color: #374151;
+    color: #d1d5db;
+  }
+
+  .poem-author {
+    color: #d1d5db;
+  }
+
+  .poem-preview {
+    background-color: #111827;
+    border-color: #374151;
+  }
+
+  .preview-header {
+    border-color: #374151;
+  }
+
+  .preview-title {
+    color: #f3f4f6;
+  }
+
+  .preview-attribution {
+    color: #9ca3af;
+  }
+
+  .preview-text {
+    background-color: #1f2937;
+    border-color: #374151;
+  }
+
+  .preview-text pre {
+    color: #e5e7eb;
+  }
+
+  .preview-description {
+    color: #d1d5db;
+  }
+
+  .preview-details {
+    color: #9ca3af;
+  }
+
+  .detail-item strong {
+    color: #d1d5db;
+  }
+
+  .tag {
+    background-color: #1e3a5f;
+    color: #93c5fd;
+  }
+
+  .preview-source {
+    color: #6b7280;
+  }
+
+  .select-button {
+    background-color: #2563eb;
+  }
+
+  .select-button:hover:not(:disabled) {
+    background-color: #1d4ed8;
+  }
+
+  .picker-footer {
+    border-color: #374151;
+  }
+
+  .results-count {
+    color: #9ca3af;
+  }
+
+  .no-results {
+    color: #9ca3af;
+  }
+
+  .poem-list::-webkit-scrollbar-track {
+    background: #1f2937;
+  }
+
+  .poem-list::-webkit-scrollbar-thumb {
+    background: #4b5563;
+  }
+
+  .poem-list::-webkit-scrollbar-thumb:hover {
+    background: #6b7280;
+  }
+}

--- a/web/src/components/SamplePoemPicker/SamplePoemPicker.test.tsx
+++ b/web/src/components/SamplePoemPicker/SamplePoemPicker.test.tsx
@@ -1,0 +1,445 @@
+/**
+ * Tests for SamplePoemPicker Component
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SamplePoemPicker, type SamplePoemPickerProps } from './SamplePoemPicker';
+import { samplePoems } from '@/data/samplePoems';
+
+describe('SamplePoemPicker', () => {
+  const defaultProps: SamplePoemPickerProps = {
+    onSelect: vi.fn(),
+  };
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders the picker container', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const picker = screen.getByTestId('sample-poem-picker');
+      expect(picker).toBeInTheDocument();
+    });
+
+    it('renders the search input', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText(/search by title/i);
+      expect(searchInput).toBeInTheDocument();
+    });
+
+    it('renders the form filter dropdown', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const formFilter = screen.getByLabelText(/filter by poem form/i);
+      expect(formFilter).toBeInTheDocument();
+    });
+
+    it('renders all sample poems in the list', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      // Each poem should have a testid
+      samplePoems.forEach((poem) => {
+        expect(screen.getByTestId(`poem-item-${poem.id}`)).toBeInTheDocument();
+      });
+    });
+
+    it('renders the results count', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const count = screen.getByText(new RegExp(`${samplePoems.length} poems`));
+      expect(count).toBeInTheDocument();
+    });
+
+    it('applies custom className', () => {
+      render(<SamplePoemPicker {...defaultProps} className="custom-class" />);
+
+      const picker = screen.getByTestId('sample-poem-picker');
+      expect(picker).toHaveClass('sample-poem-picker', 'custom-class');
+    });
+  });
+
+  describe('preview panel', () => {
+    it('shows preview panel by default', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const preview = screen.getByTestId('poem-preview');
+      expect(preview).toBeInTheDocument();
+    });
+
+    it('hides preview panel when showPreview is false', () => {
+      render(<SamplePoemPicker {...defaultProps} showPreview={false} />);
+
+      expect(screen.queryByTestId('poem-preview')).not.toBeInTheDocument();
+    });
+
+    it('shows the first poem in preview by default', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const preview = screen.getByTestId('poem-preview');
+      const firstPoem = samplePoems[0];
+      // Use class selector for the title in preview
+      const previewTitle = within(preview).getByRole('heading', { level: 3 });
+      expect(previewTitle).toHaveTextContent(firstPoem.title);
+    });
+
+    it('shows poem details in preview', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const preview = screen.getByTestId('poem-preview');
+      const firstPoem = samplePoems[0];
+
+      // Check for meter info
+      expect(preview).toHaveTextContent(firstPoem.expectedMeter.name);
+
+      // Check for description
+      expect(preview).toHaveTextContent(firstPoem.description);
+    });
+
+    it('shows poem tags in preview', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const preview = screen.getByTestId('poem-preview');
+      const firstPoem = samplePoems[0];
+      const tagsContainer = within(preview).getByText(firstPoem.tags[0]);
+      expect(tagsContainer).toBeInTheDocument();
+    });
+
+    it('shows "Use This Poem" button', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const button = screen.getByRole('button', { name: /use this poem/i });
+      expect(button).toBeInTheDocument();
+    });
+  });
+
+  describe('selection', () => {
+    it('calls onSelect when a poem is clicked', async () => {
+      const onSelect = vi.fn();
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} onSelect={onSelect} />);
+
+      const poemItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      await user.click(poemItem);
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'shakespeare-sonnet-18',
+          title: 'Sonnet 18',
+        })
+      );
+    });
+
+    it('calls onSelect when "Use This Poem" button is clicked', async () => {
+      const onSelect = vi.fn();
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} onSelect={onSelect} />);
+
+      const button = screen.getByRole('button', { name: /use this poem/i });
+      await user.click(button);
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it('highlights the selected poem', () => {
+      render(
+        <SamplePoemPicker
+          {...defaultProps}
+          selectedPoemId="shakespeare-sonnet-18"
+        />
+      );
+
+      const poemItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      expect(poemItem).toHaveClass('selected');
+    });
+
+    it('supports keyboard selection with Enter', async () => {
+      const onSelect = vi.fn();
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} onSelect={onSelect} />);
+
+      const poemItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      poemItem.focus();
+      await user.keyboard('{Enter}');
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports keyboard selection with Space', async () => {
+      const onSelect = vi.fn();
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} onSelect={onSelect} />);
+
+      const poemItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      poemItem.focus();
+      await user.keyboard(' ');
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('search', () => {
+    it('filters poems by title', async () => {
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText(/search by title/i);
+      await user.type(searchInput, 'Sonnet');
+
+      // Should find Shakespeare's Sonnet
+      expect(screen.getByTestId('poem-item-shakespeare-sonnet-18')).toBeInTheDocument();
+
+      // Should not show other poems
+      expect(screen.queryByTestId('poem-item-frost-road-not-taken')).not.toBeInTheDocument();
+    });
+
+    it('filters poems by author', async () => {
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText(/search by title/i);
+      await user.type(searchInput, 'Shakespeare');
+
+      expect(screen.getByTestId('poem-item-shakespeare-sonnet-18')).toBeInTheDocument();
+    });
+
+    it('shows no results message when search has no matches', async () => {
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText(/search by title/i);
+      await user.type(searchInput, 'xyznonexistent123');
+
+      expect(screen.getByText(/no poems found/i)).toBeInTheDocument();
+    });
+
+    it('updates results count when filtering', async () => {
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText(/search by title/i);
+      await user.type(searchInput, 'Shakespeare');
+
+      expect(screen.getByText(/showing 1 of/i)).toBeInTheDocument();
+    });
+
+    it('is case insensitive', async () => {
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText(/search by title/i);
+      await user.type(searchInput, 'SHAKESPEARE');
+
+      expect(screen.getByTestId('poem-item-shakespeare-sonnet-18')).toBeInTheDocument();
+    });
+  });
+
+  describe('form filter', () => {
+    it('shows all forms in dropdown', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const formFilter = screen.getByLabelText(/filter by poem form/i);
+      expect(within(formFilter).getByText('All Forms')).toBeInTheDocument();
+    });
+
+    it('filters poems by form', async () => {
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const formFilter = screen.getByLabelText(/filter by poem form/i);
+      await user.selectOptions(formFilter, 'sonnet');
+
+      // Should show sonnet
+      expect(screen.getByTestId('poem-item-shakespeare-sonnet-18')).toBeInTheDocument();
+
+      // Should not show haiku
+      expect(screen.queryByTestId('poem-item-basho-old-pond')).not.toBeInTheDocument();
+    });
+
+    it('combines with search filter', async () => {
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      // First filter by form
+      const formFilter = screen.getByLabelText(/filter by poem form/i);
+      await user.selectOptions(formFilter, 'lyric');
+
+      // Then search within that form
+      const searchInput = screen.getByPlaceholderText(/search by title/i);
+      await user.type(searchInput, 'Tyger');
+
+      expect(screen.getByTestId('poem-item-blake-tyger')).toBeInTheDocument();
+    });
+  });
+
+  describe('hover preview', () => {
+    it('updates preview when hovering over a poem', async () => {
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const preview = screen.getByTestId('poem-preview');
+
+      // Hover over a different poem
+      const frostPoem = screen.getByTestId('poem-item-frost-road-not-taken');
+      await user.hover(frostPoem);
+
+      // Preview should show Frost poem
+      const previewTitle = within(preview).getByRole('heading', { level: 3 });
+      expect(previewTitle).toHaveTextContent('The Road Not Taken');
+    });
+  });
+
+  describe('disabled state', () => {
+    it('disables search input when disabled', () => {
+      render(<SamplePoemPicker {...defaultProps} disabled />);
+
+      const searchInput = screen.getByPlaceholderText(/search by title/i);
+      expect(searchInput).toBeDisabled();
+    });
+
+    it('disables form filter when disabled', () => {
+      render(<SamplePoemPicker {...defaultProps} disabled />);
+
+      const formFilter = screen.getByLabelText(/filter by poem form/i);
+      expect(formFilter).toBeDisabled();
+    });
+
+    it('disables poem selection when disabled', async () => {
+      const onSelect = vi.fn();
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} onSelect={onSelect} disabled />);
+
+      const poemItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      await user.click(poemItem);
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('disables Use This Poem button when disabled', () => {
+      render(<SamplePoemPicker {...defaultProps} disabled />);
+
+      const button = screen.getByRole('button', { name: /use this poem/i });
+      expect(button).toBeDisabled();
+    });
+
+    it('applies disabled class to poem items', () => {
+      render(<SamplePoemPicker {...defaultProps} disabled />);
+
+      const poemItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      expect(poemItem).toHaveClass('disabled');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has proper ARIA labels on search input', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const searchInput = screen.getByRole('textbox', { name: /search poems/i });
+      expect(searchInput).toBeInTheDocument();
+    });
+
+    it('has proper ARIA labels on form filter', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const formFilter = screen.getByRole('combobox', { name: /filter by poem form/i });
+      expect(formFilter).toBeInTheDocument();
+    });
+
+    it('has listbox role on poem list', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const list = screen.getByRole('listbox', { name: /sample poems/i });
+      expect(list).toBeInTheDocument();
+    });
+
+    it('has option role on poem items', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      // Get options within the poem list specifically (not the dropdown)
+      const poemList = screen.getByRole('listbox', { name: /sample poems/i });
+      const options = within(poemList).getAllByRole('option');
+      expect(options.length).toBe(samplePoems.length);
+    });
+
+    it('sets aria-selected on selected poem', () => {
+      render(
+        <SamplePoemPicker
+          {...defaultProps}
+          selectedPoemId="shakespeare-sonnet-18"
+        />
+      );
+
+      const selectedItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      expect(selectedItem).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('has aria-live on preview panel', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const preview = screen.getByTestId('poem-preview');
+      expect(preview).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('has status role on no results message', async () => {
+      const user = userEvent.setup();
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText(/search by title/i);
+      await user.type(searchInput, 'xyznonexistent123');
+
+      const noResults = screen.getByRole('status');
+      expect(noResults).toHaveTextContent(/no poems found/i);
+    });
+
+    it('poem items are focusable', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const poemItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      expect(poemItem).toHaveAttribute('tabindex', '0');
+    });
+
+    it('disabled poem items are not focusable', () => {
+      render(<SamplePoemPicker {...defaultProps} disabled />);
+
+      const poemItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      expect(poemItem).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  describe('poem data display', () => {
+    it('displays poem form badge correctly', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      // Check that at least one sonnet badge exists
+      const sonnetPoem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      expect(sonnetPoem).toHaveTextContent('Sonnet');
+    });
+
+    it('displays year when available', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      // Shakespeare's sonnet has year 1609
+      const poemItem = screen.getByTestId('poem-item-shakespeare-sonnet-18');
+      expect(poemItem).toHaveTextContent('1609');
+    });
+
+    it('displays source in preview when available', () => {
+      render(<SamplePoemPicker {...defaultProps} />);
+
+      const preview = screen.getByTestId('poem-preview');
+      const firstPoem = samplePoems[0];
+
+      if (firstPoem.source) {
+        // Check that the source text is displayed
+        expect(preview).toHaveTextContent('Source:');
+        expect(preview).toHaveTextContent(firstPoem.source);
+      }
+    });
+  });
+});

--- a/web/src/components/SamplePoemPicker/SamplePoemPicker.tsx
+++ b/web/src/components/SamplePoemPicker/SamplePoemPicker.tsx
@@ -1,0 +1,305 @@
+/**
+ * SamplePoemPicker Component
+ *
+ * A component that allows users to browse and select from a library
+ * of sample poems. Provides filtering, search, and poem preview.
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import {
+  samplePoems,
+  getSamplePoemById,
+  searchSamplePoems,
+  getAllForms,
+  type SamplePoem,
+  type PoemForm,
+} from '@/data/samplePoems';
+import './SamplePoemPicker.css';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[SamplePoemPicker] ${message}`, ...args);
+  }
+};
+
+/**
+ * Props for SamplePoemPicker component
+ */
+export interface SamplePoemPickerProps {
+  /** Callback when a poem is selected */
+  onSelect: (poem: SamplePoem) => void;
+  /** Optional currently selected poem ID */
+  selectedPoemId?: string;
+  /** Whether to show the preview panel */
+  showPreview?: boolean;
+  /** Custom CSS class name */
+  className?: string;
+  /** Whether the picker is disabled */
+  disabled?: boolean;
+}
+
+/**
+ * Formats a form name for display
+ */
+function formatFormName(form: PoemForm): string {
+  return form
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * SamplePoemPicker provides a UI for browsing and selecting sample poems.
+ *
+ * Features:
+ * - Search by title, author, or description
+ * - Filter by poem form (sonnet, haiku, etc.)
+ * - Poem preview with metadata
+ * - Keyboard navigation support
+ *
+ * @example
+ * ```tsx
+ * <SamplePoemPicker
+ *   onSelect={(poem) => console.log('Selected:', poem.title)}
+ *   showPreview
+ * />
+ * ```
+ */
+export function SamplePoemPicker({
+  onSelect,
+  selectedPoemId,
+  showPreview = true,
+  className = '',
+  disabled = false,
+}: SamplePoemPickerProps): React.ReactElement {
+  // State
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedForm, setSelectedForm] = useState<PoemForm | 'all'>('all');
+  const [hoveredPoemId, setHoveredPoemId] = useState<string | null>(null);
+
+  // Get all available forms
+  const availableForms = useMemo(() => getAllForms(), []);
+
+  // Filter poems based on search and form
+  const filteredPoems = useMemo(() => {
+    log('Filtering poems, query:', searchQuery, 'form:', selectedForm);
+
+    let poems = searchQuery ? searchSamplePoems(searchQuery) : samplePoems;
+
+    if (selectedForm !== 'all') {
+      poems = poems.filter((poem) => poem.form === selectedForm);
+    }
+
+    return poems;
+  }, [searchQuery, selectedForm]);
+
+  // Get the poem to preview (hovered or selected)
+  const previewPoem = useMemo(() => {
+    if (hoveredPoemId) {
+      return getSamplePoemById(hoveredPoemId);
+    }
+    if (selectedPoemId) {
+      return getSamplePoemById(selectedPoemId);
+    }
+    return filteredPoems[0];
+  }, [hoveredPoemId, selectedPoemId, filteredPoems]);
+
+  // Handle poem selection
+  const handleSelect = useCallback(
+    (poem: SamplePoem) => {
+      if (disabled) return;
+      log('Poem selected:', poem.title);
+      onSelect(poem);
+    },
+    [onSelect, disabled]
+  );
+
+  // Handle search input change
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setSearchQuery(e.target.value);
+    },
+    []
+  );
+
+  // Handle form filter change
+  const handleFormChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = e.target.value as PoemForm | 'all';
+      setSelectedForm(value);
+    },
+    []
+  );
+
+  // Handle keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, poem: SamplePoem) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleSelect(poem);
+      }
+    },
+    [handleSelect]
+  );
+
+  return (
+    <div
+      className={`sample-poem-picker ${className}`.trim()}
+      data-testid="sample-poem-picker"
+    >
+      {/* Search and Filter Controls */}
+      <div className="picker-controls">
+        <div className="search-container">
+          <label htmlFor="poem-search" className="visually-hidden">
+            Search poems
+          </label>
+          <input
+            id="poem-search"
+            type="text"
+            placeholder="Search by title, author, or description..."
+            value={searchQuery}
+            onChange={handleSearchChange}
+            disabled={disabled}
+            className="search-input"
+            aria-label="Search poems"
+          />
+        </div>
+
+        <div className="filter-container">
+          <label htmlFor="form-filter" className="filter-label">
+            Form:
+          </label>
+          <select
+            id="form-filter"
+            value={selectedForm}
+            onChange={handleFormChange}
+            disabled={disabled}
+            className="form-select"
+            aria-label="Filter by poem form"
+          >
+            <option value="all">All Forms</option>
+            {availableForms.map((form) => (
+              <option key={form} value={form}>
+                {formatFormName(form)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="picker-content">
+        {/* Poem List */}
+        <div className="poem-list" role="listbox" aria-label="Sample poems">
+          {filteredPoems.length === 0 ? (
+            <div className="no-results" role="status">
+              No poems found matching your criteria.
+            </div>
+          ) : (
+            filteredPoems.map((poem) => (
+              <div
+                key={poem.id}
+                role="option"
+                aria-selected={selectedPoemId === poem.id}
+                tabIndex={disabled ? -1 : 0}
+                className={`poem-item ${
+                  selectedPoemId === poem.id ? 'selected' : ''
+                } ${disabled ? 'disabled' : ''}`}
+                onClick={() => handleSelect(poem)}
+                onKeyDown={(e) => handleKeyDown(e, poem)}
+                onMouseEnter={() => setHoveredPoemId(poem.id)}
+                onMouseLeave={() => setHoveredPoemId(null)}
+                data-testid={`poem-item-${poem.id}`}
+              >
+                <div className="poem-item-header">
+                  <span className="poem-title">{poem.title}</span>
+                  <span className="poem-form">{formatFormName(poem.form)}</span>
+                </div>
+                <div className="poem-meta">
+                  <span className="poem-author">{poem.author}</span>
+                  {poem.year && (
+                    <span className="poem-year">({poem.year})</span>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Poem Preview */}
+        {showPreview && previewPoem && (
+          <div
+            className="poem-preview"
+            data-testid="poem-preview"
+            aria-live="polite"
+          >
+            <div className="preview-header">
+              <h3 className="preview-title">{previewPoem.title}</h3>
+              <p className="preview-attribution">
+                by <span className="preview-author">{previewPoem.author}</span>
+                {previewPoem.year && (
+                  <span className="preview-year"> ({previewPoem.year})</span>
+                )}
+              </p>
+            </div>
+
+            <div className="preview-text">
+              <pre>{previewPoem.text}</pre>
+            </div>
+
+            <div className="preview-footer">
+              <p className="preview-description">{previewPoem.description}</p>
+
+              <div className="preview-details">
+                <span className="detail-item">
+                  <strong>Form:</strong> {formatFormName(previewPoem.form)}
+                </span>
+                <span className="detail-item">
+                  <strong>Meter:</strong> {previewPoem.expectedMeter.name}
+                </span>
+                <span className="detail-item">
+                  <strong>Style:</strong>{' '}
+                  {previewPoem.style.charAt(0).toUpperCase() +
+                    previewPoem.style.slice(1)}
+                </span>
+              </div>
+
+              <div className="preview-tags">
+                {previewPoem.tags.map((tag) => (
+                  <span key={tag} className="tag">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+
+              {previewPoem.source && (
+                <p className="preview-source">
+                  <em>Source: {previewPoem.source}</em>
+                </p>
+              )}
+
+              <button
+                type="button"
+                onClick={() => handleSelect(previewPoem)}
+                disabled={disabled}
+                className="select-button"
+              >
+                Use This Poem
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Results count */}
+      <div className="picker-footer">
+        <span className="results-count">
+          Showing {filteredPoems.length} of {samplePoems.length} poems
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default SamplePoemPicker;

--- a/web/src/components/SamplePoemPicker/index.ts
+++ b/web/src/components/SamplePoemPicker/index.ts
@@ -1,0 +1,8 @@
+/**
+ * SamplePoemPicker Component
+ *
+ * @module components/SamplePoemPicker
+ */
+
+export { SamplePoemPicker, default } from './SamplePoemPicker';
+export type { SamplePoemPickerProps } from './SamplePoemPicker';

--- a/web/src/data/index.ts
+++ b/web/src/data/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Ghost Note - Data Module
+ *
+ * Exports data collections and utilities.
+ *
+ * @module data
+ */
+
+export * from './samplePoems';

--- a/web/src/data/samplePoems.test.ts
+++ b/web/src/data/samplePoems.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Tests for Sample Poems Data Module
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  samplePoems,
+  getSamplePoemById,
+  getSamplePoemsByStyle,
+  getSamplePoemsByForm,
+  getSamplePoemsByTag,
+  getAllTags,
+  getAllStyles,
+  getAllForms,
+  searchSamplePoems,
+  getRandomSamplePoem,
+  getSamplePoemCount,
+  type PoemStyle,
+  type PoemForm,
+} from './samplePoems';
+
+describe('samplePoems', () => {
+  describe('collection', () => {
+    it('contains at least 6 poems', () => {
+      expect(samplePoems.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('contains the required poems', () => {
+      const requiredPoems = [
+        'shakespeare-sonnet-18',
+        'frost-road-not-taken',
+        'dickinson-hope-feathers',
+      ];
+
+      requiredPoems.forEach((id) => {
+        expect(samplePoems.find((p) => p.id === id)).toBeDefined();
+      });
+    });
+
+    it('has unique IDs for all poems', () => {
+      const ids = samplePoems.map((p) => p.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it('has all required fields for each poem', () => {
+      samplePoems.forEach((poem) => {
+        expect(poem.id).toBeTruthy();
+        expect(poem.title).toBeTruthy();
+        expect(poem.author).toBeTruthy();
+        expect(poem.text).toBeTruthy();
+        expect(poem.style).toBeTruthy();
+        expect(poem.form).toBeTruthy();
+        expect(poem.expectedMeter).toBeDefined();
+        expect(poem.description).toBeTruthy();
+        expect(poem.tags).toBeInstanceOf(Array);
+        expect(poem.tags.length).toBeGreaterThan(0);
+        expect(poem.publicDomain).toBe(true);
+      });
+    });
+
+    it('has valid expected meter for each poem', () => {
+      samplePoems.forEach((poem) => {
+        expect(poem.expectedMeter.type).toBeTruthy();
+        expect(poem.expectedMeter.footType).toBeTruthy();
+        expect(typeof poem.expectedMeter.feetPerLine).toBe('number');
+        expect(poem.expectedMeter.name).toBeTruthy();
+      });
+    });
+
+    it('includes diverse poem forms', () => {
+      const forms = new Set(samplePoems.map((p) => p.form));
+      // Expect at least 4 different forms
+      expect(forms.size).toBeGreaterThanOrEqual(4);
+      // Check for specific forms
+      expect(forms.has('sonnet')).toBe(true);
+      expect(forms.has('haiku')).toBe(true);
+      expect(forms.has('limerick')).toBe(true);
+    });
+
+    it('includes diverse poem styles', () => {
+      const styles = new Set(samplePoems.map((p) => p.style));
+      // Expect at least 3 different styles
+      expect(styles.size).toBeGreaterThanOrEqual(3);
+    });
+
+    it('includes free verse example', () => {
+      const freeVerse = samplePoems.find((p) => p.form === 'free_verse');
+      expect(freeVerse).toBeDefined();
+      expect(freeVerse?.expectedMeter.type).toBe('irregular');
+    });
+  });
+
+  describe('getSamplePoemById', () => {
+    it('returns the correct poem for a valid ID', () => {
+      const poem = getSamplePoemById('shakespeare-sonnet-18');
+      expect(poem).toBeDefined();
+      expect(poem?.title).toBe('Sonnet 18');
+      expect(poem?.author).toBe('William Shakespeare');
+    });
+
+    it('returns undefined for an invalid ID', () => {
+      const poem = getSamplePoemById('non-existent-poem');
+      expect(poem).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      const poem = getSamplePoemById('');
+      expect(poem).toBeUndefined();
+    });
+  });
+
+  describe('getSamplePoemsByStyle', () => {
+    it('returns poems matching the style', () => {
+      const romanticPoems = getSamplePoemsByStyle('romantic');
+      expect(romanticPoems.length).toBeGreaterThan(0);
+      romanticPoems.forEach((poem) => {
+        expect(poem.style).toBe('romantic');
+      });
+    });
+
+    it('returns empty array for non-existent style', () => {
+      const poems = getSamplePoemsByStyle('nonexistent' as PoemStyle);
+      expect(poems).toEqual([]);
+    });
+
+    it('filters correctly for multiple styles', () => {
+      const styles: PoemStyle[] = ['classical', 'romantic', 'victorian', 'modern'];
+      styles.forEach((style) => {
+        const poems = getSamplePoemsByStyle(style);
+        poems.forEach((poem) => {
+          expect(poem.style).toBe(style);
+        });
+      });
+    });
+  });
+
+  describe('getSamplePoemsByForm', () => {
+    it('returns poems matching the form', () => {
+      const sonnets = getSamplePoemsByForm('sonnet');
+      expect(sonnets.length).toBeGreaterThan(0);
+      sonnets.forEach((poem) => {
+        expect(poem.form).toBe('sonnet');
+      });
+    });
+
+    it('returns haiku when filtering by haiku form', () => {
+      const haikus = getSamplePoemsByForm('haiku');
+      expect(haikus.length).toBeGreaterThan(0);
+      haikus.forEach((poem) => {
+        expect(poem.form).toBe('haiku');
+      });
+    });
+
+    it('returns empty array for non-existent form', () => {
+      const poems = getSamplePoemsByForm('nonexistent' as PoemForm);
+      expect(poems).toEqual([]);
+    });
+  });
+
+  describe('getSamplePoemsByTag', () => {
+    it('returns poems containing the tag', () => {
+      const lovePoems = getSamplePoemsByTag('love');
+      expect(lovePoems.length).toBeGreaterThan(0);
+      lovePoems.forEach((poem) => {
+        expect(poem.tags.map((t) => t.toLowerCase())).toContain('love');
+      });
+    });
+
+    it('is case insensitive', () => {
+      const lowercaseResult = getSamplePoemsByTag('nature');
+      const uppercaseResult = getSamplePoemsByTag('NATURE');
+      const mixedResult = getSamplePoemsByTag('NaTuRe');
+
+      expect(lowercaseResult.length).toBe(uppercaseResult.length);
+      expect(lowercaseResult.length).toBe(mixedResult.length);
+    });
+
+    it('returns empty array for non-existent tag', () => {
+      const poems = getSamplePoemsByTag('nonexistenttag12345');
+      expect(poems).toEqual([]);
+    });
+  });
+
+  describe('getAllTags', () => {
+    it('returns an array of unique tags', () => {
+      const tags = getAllTags();
+      expect(Array.isArray(tags)).toBe(true);
+      expect(tags.length).toBeGreaterThan(0);
+
+      // Check for uniqueness
+      const uniqueTags = new Set(tags);
+      expect(uniqueTags.size).toBe(tags.length);
+    });
+
+    it('returns sorted tags', () => {
+      const tags = getAllTags();
+      const sortedTags = [...tags].sort();
+      expect(tags).toEqual(sortedTags);
+    });
+
+    it('includes expected common tags', () => {
+      const tags = getAllTags();
+      expect(tags).toContain('love');
+      expect(tags).toContain('nature');
+    });
+  });
+
+  describe('getAllStyles', () => {
+    it('returns an array of unique styles', () => {
+      const styles = getAllStyles();
+      expect(Array.isArray(styles)).toBe(true);
+      expect(styles.length).toBeGreaterThan(0);
+
+      // Check for uniqueness
+      const uniqueStyles = new Set(styles);
+      expect(uniqueStyles.size).toBe(styles.length);
+    });
+
+    it('includes expected styles', () => {
+      const styles = getAllStyles();
+      expect(styles).toContain('romantic');
+    });
+  });
+
+  describe('getAllForms', () => {
+    it('returns an array of unique forms', () => {
+      const forms = getAllForms();
+      expect(Array.isArray(forms)).toBe(true);
+      expect(forms.length).toBeGreaterThan(0);
+
+      // Check for uniqueness
+      const uniqueForms = new Set(forms);
+      expect(uniqueForms.size).toBe(forms.length);
+    });
+
+    it('includes expected forms', () => {
+      const forms = getAllForms();
+      expect(forms).toContain('sonnet');
+      expect(forms).toContain('haiku');
+      expect(forms).toContain('limerick');
+    });
+  });
+
+  describe('searchSamplePoems', () => {
+    it('returns all poems for empty query', () => {
+      const results = searchSamplePoems('');
+      expect(results.length).toBe(samplePoems.length);
+    });
+
+    it('returns all poems for whitespace query', () => {
+      const results = searchSamplePoems('   ');
+      expect(results.length).toBe(samplePoems.length);
+    });
+
+    it('finds poems by title', () => {
+      const results = searchSamplePoems('Sonnet');
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.some((p) => p.title.includes('Sonnet'))).toBe(true);
+    });
+
+    it('finds poems by author', () => {
+      const results = searchSamplePoems('Shakespeare');
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.some((p) => p.author.includes('Shakespeare'))).toBe(true);
+    });
+
+    it('finds poems by description', () => {
+      const results = searchSamplePoems('summer');
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('is case insensitive', () => {
+      const lowercaseResults = searchSamplePoems('shakespeare');
+      const uppercaseResults = searchSamplePoems('SHAKESPEARE');
+      expect(lowercaseResults.length).toBe(uppercaseResults.length);
+    });
+
+    it('returns empty array when no matches found', () => {
+      const results = searchSamplePoems('xyznonexistent123');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('getRandomSamplePoem', () => {
+    beforeEach(() => {
+      vi.spyOn(Math, 'random');
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('returns a valid poem', () => {
+      const poem = getRandomSamplePoem();
+      expect(poem).toBeDefined();
+      expect(poem.id).toBeTruthy();
+      expect(poem.title).toBeTruthy();
+      expect(samplePoems).toContainEqual(poem);
+    });
+
+    it('can return different poems', () => {
+      // Mock random to return different values
+      vi.mocked(Math.random)
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0.5)
+        .mockReturnValueOnce(0.99);
+
+      const poem1 = getRandomSamplePoem();
+      const poem2 = getRandomSamplePoem();
+      const poem3 = getRandomSamplePoem();
+
+      // At least one should be different (unless there's only one poem)
+      if (samplePoems.length > 1) {
+        expect(poem1.id !== poem2.id || poem2.id !== poem3.id).toBe(true);
+      }
+    });
+
+    it('returns first poem when random is 0', () => {
+      vi.mocked(Math.random).mockReturnValue(0);
+      const poem = getRandomSamplePoem();
+      expect(poem).toEqual(samplePoems[0]);
+    });
+  });
+
+  describe('getSamplePoemCount', () => {
+    it('returns the correct count', () => {
+      const count = getSamplePoemCount();
+      expect(count).toBe(samplePoems.length);
+    });
+
+    it('returns at least 6', () => {
+      expect(getSamplePoemCount()).toBeGreaterThanOrEqual(6);
+    });
+  });
+
+  describe('poem content validation', () => {
+    it('Shakespeare Sonnet 18 has correct content', () => {
+      const poem = getSamplePoemById('shakespeare-sonnet-18');
+      expect(poem).toBeDefined();
+      expect(poem?.text).toContain("Shall I compare thee to a summer's day");
+      expect(poem?.expectedMeter.name).toBe('iambic pentameter');
+      expect(poem?.form).toBe('sonnet');
+    });
+
+    it('Frost Road Not Taken has correct content', () => {
+      const poem = getSamplePoemById('frost-road-not-taken');
+      expect(poem).toBeDefined();
+      expect(poem?.text).toContain('Two roads diverged in a yellow wood');
+      expect(poem?.author).toBe('Robert Frost');
+    });
+
+    it('Dickinson poem has correct content', () => {
+      const poem = getSamplePoemById('dickinson-hope-feathers');
+      expect(poem).toBeDefined();
+      expect(poem?.text).toContain('Hope');
+      expect(poem?.author).toBe('Emily Dickinson');
+    });
+
+    it('haiku has correct form', () => {
+      const poem = getSamplePoemById('basho-old-pond');
+      expect(poem).toBeDefined();
+      expect(poem?.form).toBe('haiku');
+      expect(poem?.author).toBe('Matsuo Bashō');
+    });
+
+    it('limerick has correct form', () => {
+      const poem = getSamplePoemById('lear-old-man-beard');
+      expect(poem).toBeDefined();
+      expect(poem?.form).toBe('limerick');
+      expect(poem?.expectedMeter.type).toBe('anapestic');
+    });
+
+    it('free verse poem has irregular meter', () => {
+      const poem = getSamplePoemById('whitman-song-myself-52');
+      expect(poem).toBeDefined();
+      expect(poem?.form).toBe('free_verse');
+      expect(poem?.expectedMeter.type).toBe('irregular');
+    });
+  });
+
+  describe('public domain compliance', () => {
+    it('all poems are marked as public domain', () => {
+      samplePoems.forEach((poem) => {
+        expect(poem.publicDomain).toBe(true);
+      });
+    });
+
+    it('all poems are verified public domain works', () => {
+      // Public domain status in the US:
+      // - Works published before 1928 are in the public domain
+      // - For newer works, author must have died 70+ years ago (life + 70 rule)
+      // Our poems are all either pre-1928 publications or from authors long deceased
+
+      // Verify each poem's publication year makes it public domain
+      // (all our poems were published before 1928)
+      const publicDomainCutoff = 1928;
+
+      samplePoems.forEach((poem) => {
+        // All our poems have years before 1928
+        if (poem.year) {
+          expect(poem.year).toBeLessThan(publicDomainCutoff);
+        }
+        // All poems should be marked as public domain
+        expect(poem.publicDomain).toBe(true);
+      });
+    });
+  });
+});

--- a/web/src/data/samplePoems.ts
+++ b/web/src/data/samplePoems.ts
@@ -1,0 +1,570 @@
+/**
+ * Ghost Note - Sample Poems Library
+ *
+ * A curated collection of public domain poems for users to try the app.
+ * All poems are either in the public domain or use works by authors
+ * who died more than 70 years ago.
+ *
+ * @module data/samplePoems
+ */
+
+import type { MeterType, FootType } from '@/types/analysis';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Style/period classification for a poem
+ */
+export type PoemStyle =
+  | 'classical'
+  | 'romantic'
+  | 'victorian'
+  | 'modern'
+  | 'contemporary'
+  | 'traditional';
+
+/**
+ * Form classification for a poem
+ */
+export type PoemForm =
+  | 'sonnet'
+  | 'free_verse'
+  | 'limerick'
+  | 'haiku'
+  | 'ballad'
+  | 'lyric'
+  | 'ode'
+  | 'quatrain'
+  | 'couplet'
+  | 'other';
+
+/**
+ * Expected meter information for validation purposes
+ */
+export interface ExpectedMeter {
+  /** The type of meter (iambic, trochaic, etc.) */
+  type: MeterType;
+  /** The type of metrical foot */
+  footType: FootType;
+  /** Number of feet per line (e.g., 5 for pentameter) */
+  feetPerLine: number;
+  /** Human-readable meter name (e.g., "iambic pentameter") */
+  name: string;
+}
+
+/**
+ * A sample poem with metadata
+ */
+export interface SamplePoem {
+  /** Unique identifier for the poem */
+  id: string;
+  /** Title of the poem */
+  title: string;
+  /** Author name */
+  author: string;
+  /** Year written or published (approximate) */
+  year?: number;
+  /** The full poem text */
+  text: string;
+  /** Style/period classification */
+  style: PoemStyle;
+  /** Form classification */
+  form: PoemForm;
+  /** Expected meter for validation */
+  expectedMeter: ExpectedMeter;
+  /** Brief description for display */
+  description: string;
+  /** Tags for categorization */
+  tags: string[];
+  /** Public domain confirmation */
+  publicDomain: true;
+  /** Source or attribution notes */
+  source?: string;
+}
+
+// =============================================================================
+// Sample Poems Collection
+// =============================================================================
+
+/**
+ * Shakespeare's Sonnet 18
+ * Classic example of English/Shakespearean sonnet form
+ */
+const sonnet18: SamplePoem = {
+  id: 'shakespeare-sonnet-18',
+  title: 'Sonnet 18',
+  author: 'William Shakespeare',
+  year: 1609,
+  text: `Shall I compare thee to a summer's day?
+Thou art more lovely and more temperate:
+Rough winds do shake the darling buds of May,
+And summer's lease hath all too short a date:
+
+Sometime too hot the eye of heaven shines,
+And often is his gold complexion dimmed;
+And every fair from fair sometime declines,
+By chance, or nature's changing course untrimmed;
+
+But thy eternal summer shall not fade,
+Nor lose possession of that fair thou ow'st;
+Nor shall death brag thou wand'rest in his shade,
+When in eternal lines to time thou grow'st:
+
+So long as men can breathe, or eyes can see,
+So long lives this, and this gives life to thee.`,
+  style: 'classical',
+  form: 'sonnet',
+  expectedMeter: {
+    type: 'iambic',
+    footType: 'iamb',
+    feetPerLine: 5,
+    name: 'iambic pentameter',
+  },
+  description: 'A beloved sonnet comparing the beloved to summer',
+  tags: ['love', 'beauty', 'immortality', 'nature', 'sonnet'],
+  publicDomain: true,
+  source: 'Shakespeare\'s Sonnets (1609)',
+};
+
+/**
+ * Robert Frost's "The Road Not Taken"
+ * American classic with regular meter and ABAAB rhyme scheme
+ */
+const roadNotTaken: SamplePoem = {
+  id: 'frost-road-not-taken',
+  title: 'The Road Not Taken',
+  author: 'Robert Frost',
+  year: 1916,
+  text: `Two roads diverged in a yellow wood,
+And sorry I could not travel both
+And be one traveler, long I stood
+And looked down one as far as I could
+To where it bent in the undergrowth;
+
+Then took the other, as just as fair,
+And having perhaps the better claim,
+Because it was grassy and wanted wear;
+Though as for that the passing there
+Had worn them really about the same,
+
+And both that morning equally lay
+In leaves no step had trodden black.
+Oh, I kept the first for another day!
+Yet knowing how way leads on to way,
+I doubted if I should ever come back.
+
+I shall be telling this with a sigh
+Somewhere ages and ages hence:
+Two roads diverged in a wood, and I—
+I took the one less traveled by,
+And that has made all the difference.`,
+  style: 'modern',
+  form: 'lyric',
+  expectedMeter: {
+    type: 'iambic',
+    footType: 'iamb',
+    feetPerLine: 4,
+    name: 'iambic tetrameter',
+  },
+  description: 'A meditation on choices and their consequences',
+  tags: ['choice', 'journey', 'nature', 'reflection', 'life'],
+  publicDomain: true,
+  source: 'Mountain Interval (1916)',
+};
+
+/**
+ * Emily Dickinson's "Hope is the thing with feathers"
+ * Short lyric poem with Dickinson's characteristic slant rhyme
+ */
+const hopeIsTheThing: SamplePoem = {
+  id: 'dickinson-hope-feathers',
+  title: '"Hope" is the thing with feathers',
+  author: 'Emily Dickinson',
+  year: 1861,
+  text: `"Hope" is the thing with feathers -
+That perches in the soul -
+And sings the tune without the words -
+And never stops - at all -
+
+And sweetest - in the Gale - is heard -
+And sore must be the storm -
+That could abash the little Bird
+That kept so many warm -
+
+I've heard it in the chillest land -
+And on the strangest Sea -
+Yet - never - in Extremity,
+It asked a crumb - of me.`,
+  style: 'victorian',
+  form: 'quatrain',
+  expectedMeter: {
+    type: 'iambic',
+    footType: 'iamb',
+    feetPerLine: 4,
+    name: 'common meter (alternating 4/3)',
+  },
+  description: 'A metaphor comparing hope to a bird',
+  tags: ['hope', 'nature', 'resilience', 'metaphor', 'bird'],
+  publicDomain: true,
+  source: 'Poems by Emily Dickinson (1891)',
+};
+
+/**
+ * Walt Whitman excerpt from "Song of Myself"
+ * Free verse example from a master of the form
+ */
+const songOfMyself: SamplePoem = {
+  id: 'whitman-song-myself-52',
+  title: 'from Song of Myself, 52',
+  author: 'Walt Whitman',
+  year: 1855,
+  text: `The spotted hawk swoops by and accuses me, he complains
+    of my gab and my loitering.
+
+I too am not a bit tamed, I too am untranslatable,
+I sound my barbaric yawp over the roofs of the world.
+
+The last scud of day holds back for me,
+It flings my likeness after the rest and true as any on the
+    shadow'd wilds,
+It coaxes me to the vapor and the dusk.
+
+I depart as air, I shake my white locks at the runaway sun,
+I effuse my flesh in eddies, and drift it in lacy jags.
+
+I bequeath myself to the dirt to grow from the grass I love,
+If you want me again look for me under your boot-soles.
+
+You will hardly know who I am or what I mean,
+But I shall be good health to you nevertheless,
+And filter and fibre your blood.
+
+Failing to fetch me at first keep encouraged,
+Missing me one place search another,
+I stop somewhere waiting for you.`,
+  style: 'romantic',
+  form: 'free_verse',
+  expectedMeter: {
+    type: 'irregular',
+    footType: 'unknown',
+    feetPerLine: 0,
+    name: 'free verse',
+  },
+  description: 'The transcendent conclusion of Whitman\'s epic poem',
+  tags: ['nature', 'identity', 'transcendence', 'freedom', 'american'],
+  publicDomain: true,
+  source: 'Leaves of Grass (1855)',
+};
+
+/**
+ * Traditional Limerick
+ * Classic humorous form with AABBA rhyme
+ */
+const limerick: SamplePoem = {
+  id: 'lear-old-man-beard',
+  title: 'There Was an Old Man with a Beard',
+  author: 'Edward Lear',
+  year: 1846,
+  text: `There was an Old Man with a beard,
+Who said, "It is just as I feared!—
+Two Owls and a Hen,
+Four Larks and a Wren,
+Have all built their nests in my beard!"`,
+  style: 'victorian',
+  form: 'limerick',
+  expectedMeter: {
+    type: 'anapestic',
+    footType: 'anapest',
+    feetPerLine: 3,
+    name: 'anapestic trimeter',
+  },
+  description: 'A classic nonsense limerick',
+  tags: ['humor', 'nonsense', 'limerick', 'birds', 'absurd'],
+  publicDomain: true,
+  source: 'A Book of Nonsense (1846)',
+};
+
+/**
+ * Traditional Haiku by Matsuo Bashō
+ * Classic Japanese form in English translation
+ */
+const oldPondHaiku: SamplePoem = {
+  id: 'basho-old-pond',
+  title: 'The Old Pond',
+  author: 'Matsuo Bashō',
+  year: 1686,
+  text: `An old silent pond
+A frog jumps into the pond—
+Splash! Silence again.`,
+  style: 'traditional',
+  form: 'haiku',
+  expectedMeter: {
+    type: 'irregular',
+    footType: 'unknown',
+    feetPerLine: 0,
+    name: 'haiku (5-7-5 syllables)',
+  },
+  description: 'The most famous haiku in Japanese literature',
+  tags: ['nature', 'zen', 'haiku', 'contemplation', 'japanese'],
+  publicDomain: true,
+  source: 'Traditional translation',
+};
+
+/**
+ * William Blake's "The Tyger"
+ * Powerful trochaic meter with memorable imagery
+ */
+const theTyger: SamplePoem = {
+  id: 'blake-tyger',
+  title: 'The Tyger',
+  author: 'William Blake',
+  year: 1794,
+  text: `Tyger Tyger, burning bright,
+In the forests of the night;
+What immortal hand or eye,
+Could frame thy fearful symmetry?
+
+In what distant deeps or skies,
+Burnt the fire of thine eyes?
+On what wings dare he aspire?
+What the hand, dare seize the fire?
+
+And what shoulder, & what art,
+Could twist the sinews of thy heart?
+And when thy heart began to beat,
+What dread hand? & what dread feet?
+
+What the hammer? what the chain,
+In what furnace was thy brain?
+What the anvil? what dread grasp,
+Dare its deadly terrors clasp!
+
+When the stars threw down their spears
+And water'd heaven with their tears:
+Did he smile his work to see?
+Did he who made the Lamb make thee?
+
+Tyger Tyger burning bright,
+In the forests of the night:
+What immortal hand or eye,
+Dare frame thy fearful symmetry?`,
+  style: 'romantic',
+  form: 'lyric',
+  expectedMeter: {
+    type: 'trochaic',
+    footType: 'trochee',
+    feetPerLine: 4,
+    name: 'trochaic tetrameter (catalectic)',
+  },
+  description: 'A powerful meditation on creation and the nature of evil',
+  tags: ['creation', 'god', 'nature', 'fear', 'sublime', 'tiger'],
+  publicDomain: true,
+  source: 'Songs of Experience (1794)',
+};
+
+/**
+ * Edgar Allan Poe's "Annabel Lee"
+ * Musical, haunting poem with anapestic rhythm
+ */
+const annabelLee: SamplePoem = {
+  id: 'poe-annabel-lee',
+  title: 'Annabel Lee',
+  author: 'Edgar Allan Poe',
+  year: 1849,
+  text: `It was many and many a year ago,
+In a kingdom by the sea,
+That a maiden there lived whom you may know
+By the name of Annabel Lee;
+And this maiden she lived with no other thought
+Than to love and be loved by me.
+
+I was a child and she was a child,
+In this kingdom by the sea,
+But we loved with a love that was more than love—
+I and my Annabel Lee—
+With a love that the wingèd seraphs of Heaven
+Coveted her and me.
+
+And this was the reason that, long ago,
+In this kingdom by the sea,
+A wind blew out of a cloud, chilling
+My beautiful Annabel Lee;
+So that her highborn kinsmen came
+And bore her away from me,
+To shut her up in a sepulchre
+In this kingdom by the sea.
+
+The angels, not half so happy in Heaven,
+Went envying her and me—
+Yes!—that was the reason (as all men know,
+In this kingdom by the sea)
+That the wind came out of the cloud by night,
+Chilling and killing my Annabel Lee.
+
+But our love it was stronger by far than the love
+Of those who were older than we—
+Of many far wiser than we—
+And neither the angels in Heaven above
+Nor the demons down under the sea
+Can ever dissever my soul from the soul
+Of the beautiful Annabel Lee;
+
+For the moon never beams, without bringing me dreams
+Of the beautiful Annabel Lee;
+And the stars never rise, but I feel the bright eyes
+Of the beautiful Annabel Lee;
+And so, all the night-tide, I lie down by the side
+Of my darling—my darling—my life and my bride,
+In her sepulchre there by the sea—
+In her tomb by the sounding sea.`,
+  style: 'romantic',
+  form: 'ballad',
+  expectedMeter: {
+    type: 'anapestic',
+    footType: 'anapest',
+    feetPerLine: 4,
+    name: 'anapestic tetrameter (mixed)',
+  },
+  description: 'A haunting ballad of eternal love and loss',
+  tags: ['love', 'death', 'loss', 'gothic', 'sea', 'romantic'],
+  publicDomain: true,
+  source: 'Published posthumously (1849)',
+};
+
+// =============================================================================
+// Exported Collection
+// =============================================================================
+
+/**
+ * All sample poems in the library
+ */
+export const samplePoems: SamplePoem[] = [
+  sonnet18,
+  roadNotTaken,
+  hopeIsTheThing,
+  songOfMyself,
+  limerick,
+  oldPondHaiku,
+  theTyger,
+  annabelLee,
+];
+
+/**
+ * Get a sample poem by its ID
+ * @param id - The unique identifier of the poem
+ * @returns The poem if found, undefined otherwise
+ */
+export function getSamplePoemById(id: string): SamplePoem | undefined {
+  console.log('[samplePoems] Looking up poem by id:', id);
+  return samplePoems.find((poem) => poem.id === id);
+}
+
+/**
+ * Get sample poems filtered by style
+ * @param style - The style to filter by
+ * @returns Array of poems matching the style
+ */
+export function getSamplePoemsByStyle(style: PoemStyle): SamplePoem[] {
+  console.log('[samplePoems] Filtering poems by style:', style);
+  return samplePoems.filter((poem) => poem.style === style);
+}
+
+/**
+ * Get sample poems filtered by form
+ * @param form - The form to filter by
+ * @returns Array of poems matching the form
+ */
+export function getSamplePoemsByForm(form: PoemForm): SamplePoem[] {
+  console.log('[samplePoems] Filtering poems by form:', form);
+  return samplePoems.filter((poem) => poem.form === form);
+}
+
+/**
+ * Get sample poems filtered by tag
+ * @param tag - The tag to filter by
+ * @returns Array of poems containing the tag
+ */
+export function getSamplePoemsByTag(tag: string): SamplePoem[] {
+  console.log('[samplePoems] Filtering poems by tag:', tag);
+  const lowerTag = tag.toLowerCase();
+  return samplePoems.filter((poem) =>
+    poem.tags.some((t) => t.toLowerCase() === lowerTag)
+  );
+}
+
+/**
+ * Get all unique tags from the sample poems
+ * @returns Array of all unique tags
+ */
+export function getAllTags(): string[] {
+  const tagSet = new Set<string>();
+  samplePoems.forEach((poem) => {
+    poem.tags.forEach((tag) => tagSet.add(tag));
+  });
+  return Array.from(tagSet).sort();
+}
+
+/**
+ * Get all unique styles from the sample poems
+ * @returns Array of all unique styles
+ */
+export function getAllStyles(): PoemStyle[] {
+  const styleSet = new Set<PoemStyle>();
+  samplePoems.forEach((poem) => styleSet.add(poem.style));
+  return Array.from(styleSet);
+}
+
+/**
+ * Get all unique forms from the sample poems
+ * @returns Array of all unique forms
+ */
+export function getAllForms(): PoemForm[] {
+  const formSet = new Set<PoemForm>();
+  samplePoems.forEach((poem) => formSet.add(poem.form));
+  return Array.from(formSet);
+}
+
+/**
+ * Search sample poems by title or author (case-insensitive)
+ * @param query - Search query string
+ * @returns Array of poems matching the query
+ */
+export function searchSamplePoems(query: string): SamplePoem[] {
+  console.log('[samplePoems] Searching for:', query);
+  const lowerQuery = query.toLowerCase().trim();
+  if (!lowerQuery) {
+    return samplePoems;
+  }
+  return samplePoems.filter(
+    (poem) =>
+      poem.title.toLowerCase().includes(lowerQuery) ||
+      poem.author.toLowerCase().includes(lowerQuery) ||
+      poem.description.toLowerCase().includes(lowerQuery)
+  );
+}
+
+/**
+ * Get a random sample poem
+ * @returns A randomly selected poem
+ */
+export function getRandomSamplePoem(): SamplePoem {
+  const index = Math.floor(Math.random() * samplePoems.length);
+  console.log('[samplePoems] Getting random poem, index:', index);
+  return samplePoems[index];
+}
+
+/**
+ * Get the total count of sample poems
+ * @returns Number of poems in the library
+ */
+export function getSamplePoemCount(): number {
+  return samplePoems.length;
+}
+
+// =============================================================================
+// Default Export
+// =============================================================================
+
+export default samplePoems;


### PR DESCRIPTION
## Summary
Add a curated library of 8 public domain poems with diverse styles and forms for users to try the Ghost Note app. Includes a SamplePoemPicker component for easy browsing and selection.

## Changes
- `web/src/data/samplePoems.ts` - 8 sample poems with full metadata:
  - Shakespeare's Sonnet 18 (sonnet, iambic pentameter)
  - Robert Frost's "The Road Not Taken" (lyric, iambic tetrameter)
  - Emily Dickinson's "Hope is the thing with feathers" (quatrain, common meter)
  - Walt Whitman's "Song of Myself" excerpt (free verse)
  - Edward Lear's limerick (anapestic trimeter)
  - Matsuo Bashō's "The Old Pond" haiku (5-7-5 syllables)
  - William Blake's "The Tyger" (trochaic tetrameter)
  - Edgar Allan Poe's "Annabel Lee" (ballad, anapestic)
- `web/src/data/samplePoems.test.ts` - Comprehensive tests for data module
- `web/src/components/SamplePoemPicker/` - Interactive poem browser:
  - Search by title, author, or description
  - Filter by poem form
  - Live preview with metadata
  - Full accessibility support (ARIA, keyboard navigation)
  - Dark mode styling
- `web/src/components/SamplePoemPicker/SamplePoemPicker.test.tsx` - Component tests

## Testing
- [x] Unit tests pass (`npm test` - 729 tests passing)
- [x] Linter passes (`npm run lint`)
- [x] All poems verified public domain (published before 1928)

## Notes
- Each poem includes expected meter information for validation purposes
- Utility functions provided for filtering/searching poems
- Component follows existing patterns from NotationDisplay

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)