### PR TITLE
feat(GH-26): Implement microphone access and level meter

### DIFF
--- a/web/src/components/Recording/AudioLevelMeter.test.tsx
+++ b/web/src/components/Recording/AudioLevelMeter.test.tsx
@@ -1,0 +1,334 @@
+/**
+ * AudioLevelMeter Component Tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AudioLevelMeter } from './AudioLevelMeter';
+
+// Mock the microphone module
+vi.mock('@/lib/audio/microphone', () => ({
+  createAudioAnalyzer: vi.fn(),
+  createAudioLevelMonitor: vi.fn(),
+}));
+
+import { createAudioAnalyzer, createAudioLevelMonitor } from '@/lib/audio/microphone';
+
+const mockCreateAudioAnalyzer = createAudioAnalyzer as ReturnType<typeof vi.fn>;
+const mockCreateAudioLevelMonitor = createAudioLevelMonitor as ReturnType<typeof vi.fn>;
+
+// Mock MediaStream
+class MockMediaStream {
+  getTracks() {
+    return [{ stop: vi.fn() }];
+  }
+  getAudioTracks() {
+    return this.getTracks();
+  }
+}
+
+describe('AudioLevelMeter', () => {
+  const mockAnalyzer = {
+    analyser: {},
+    audioContext: {},
+    source: {},
+    dispose: vi.fn(),
+  };
+
+  const mockMonitor = {
+    start: vi.fn(),
+    stop: vi.fn(),
+    getLevel: vi.fn(() => 0),
+    getPeak: vi.fn(() => 0),
+    resetPeak: vi.fn(),
+    isActive: vi.fn(() => false),
+    dispose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateAudioAnalyzer.mockReturnValue(mockAnalyzer);
+    mockCreateAudioLevelMonitor.mockReturnValue(mockMonitor);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render with default props', () => {
+      render(<AudioLevelMeter />);
+
+      expect(screen.getByTestId('audio-level-meter')).toBeInTheDocument();
+      expect(screen.getByRole('meter')).toBeInTheDocument();
+    });
+
+    it('should render with gradient style by default', () => {
+      render(<AudioLevelMeter />);
+
+      const meter = screen.getByTestId('audio-level-meter');
+      expect(meter).toHaveClass('audio-level-meter--gradient');
+    });
+
+    it('should render with bar style when specified', () => {
+      render(<AudioLevelMeter meterStyle="bar" />);
+
+      const meter = screen.getByTestId('audio-level-meter');
+      expect(meter).toHaveClass('audio-level-meter--bar');
+    });
+
+    it('should render with segments style when specified', () => {
+      render(<AudioLevelMeter meterStyle="segments" segments={10} />);
+
+      const meter = screen.getByTestId('audio-level-meter');
+      expect(meter).toHaveClass('audio-level-meter--segments');
+    });
+
+    it('should render with horizontal orientation by default', () => {
+      render(<AudioLevelMeter />);
+
+      const meter = screen.getByTestId('audio-level-meter');
+      expect(meter).toHaveClass('audio-level-meter--horizontal');
+    });
+
+    it('should render with vertical orientation when specified', () => {
+      render(<AudioLevelMeter orientation="vertical" />);
+
+      const meter = screen.getByTestId('audio-level-meter');
+      expect(meter).toHaveClass('audio-level-meter--vertical');
+    });
+  });
+
+  describe('Manual Level Display', () => {
+    it('should display level fill based on manual level prop', () => {
+      render(<AudioLevelMeter level={0.5} />);
+
+      const levelFill = screen.getByTestId('level-fill');
+      expect(levelFill).toBeInTheDocument();
+    });
+
+    it('should display peak indicator when showPeak is true and peak > 0', () => {
+      render(<AudioLevelMeter level={0.3} peak={0.5} showPeak />);
+
+      expect(screen.getByTestId('peak-indicator')).toBeInTheDocument();
+    });
+
+    it('should not display peak indicator when showPeak is false', () => {
+      render(<AudioLevelMeter level={0.3} peak={0.5} showPeak={false} />);
+
+      expect(screen.queryByTestId('peak-indicator')).not.toBeInTheDocument();
+    });
+
+    it('should not display peak indicator when peak is 0', () => {
+      render(<AudioLevelMeter level={0.3} peak={0} showPeak />);
+
+      expect(screen.queryByTestId('peak-indicator')).not.toBeInTheDocument();
+    });
+
+    it('should update when level prop changes', () => {
+      const { rerender } = render(<AudioLevelMeter level={0.3} />);
+
+      const meter = screen.getByRole('meter');
+      expect(meter).toHaveAttribute('aria-valuenow', '30');
+
+      rerender(<AudioLevelMeter level={0.7} />);
+
+      expect(meter).toHaveAttribute('aria-valuenow', '70');
+    });
+  });
+
+  describe('Stream-Based Level Display', () => {
+    it('should create audio analyzer when stream is provided', () => {
+      const mockStream = new MockMediaStream() as unknown as MediaStream;
+
+      render(<AudioLevelMeter stream={mockStream} />);
+
+      expect(mockCreateAudioAnalyzer).toHaveBeenCalledWith(mockStream);
+    });
+
+    it('should start level monitor when stream is provided', () => {
+      const mockStream = new MockMediaStream() as unknown as MediaStream;
+
+      render(<AudioLevelMeter stream={mockStream} />);
+
+      expect(mockCreateAudioLevelMonitor).toHaveBeenCalled();
+      expect(mockMonitor.start).toHaveBeenCalled();
+    });
+
+    it('should pass update options to level monitor', () => {
+      const mockStream = new MockMediaStream() as unknown as MediaStream;
+
+      render(
+        <AudioLevelMeter
+          stream={mockStream}
+          updateInterval={100}
+          smoothing={0.5}
+        />
+      );
+
+      expect(mockCreateAudioLevelMonitor).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          updateInterval: 100,
+          smoothing: 0.5,
+        })
+      );
+    });
+
+    it('should dispose analyzer on unmount', () => {
+      const mockStream = new MockMediaStream() as unknown as MediaStream;
+
+      const { unmount } = render(<AudioLevelMeter stream={mockStream} />);
+
+      unmount();
+
+      expect(mockMonitor.dispose).toHaveBeenCalled();
+      expect(mockAnalyzer.dispose).toHaveBeenCalled();
+    });
+
+    it('should dispose and recreate analyzer when stream changes', () => {
+      const mockStream1 = new MockMediaStream() as unknown as MediaStream;
+      const mockStream2 = new MockMediaStream() as unknown as MediaStream;
+
+      const { rerender } = render(<AudioLevelMeter stream={mockStream1} />);
+
+      expect(mockCreateAudioAnalyzer).toHaveBeenCalledTimes(1);
+
+      rerender(<AudioLevelMeter stream={mockStream2} />);
+
+      expect(mockMonitor.dispose).toHaveBeenCalled();
+      expect(mockAnalyzer.dispose).toHaveBeenCalled();
+      expect(mockCreateAudioAnalyzer).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Segments Style', () => {
+    it('should render correct number of segments', () => {
+      render(<AudioLevelMeter meterStyle="segments" segments={10} level={0.5} />);
+
+      const meter = screen.getByTestId('audio-level-meter');
+      const segments = meter.querySelectorAll('.audio-level-meter__segment');
+
+      expect(segments).toHaveLength(10);
+    });
+
+    it('should mark active segments based on level', () => {
+      render(<AudioLevelMeter meterStyle="segments" segments={10} level={0.5} />);
+
+      const meter = screen.getByTestId('audio-level-meter');
+      const segments = meter.querySelectorAll('.audio-level-meter__segment');
+
+      // With level 0.5 and 10 segments, 5 segments should be active
+      const activeSegments = Array.from(segments).filter(
+        (s) => s.getAttribute('data-active') === 'true'
+      );
+
+      expect(activeSegments).toHaveLength(5);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have correct ARIA attributes', () => {
+      render(<AudioLevelMeter level={0.5} />);
+
+      const meter = screen.getByRole('meter');
+
+      expect(meter).toHaveAttribute('aria-valuenow', '50');
+      expect(meter).toHaveAttribute('aria-valuemin', '0');
+      expect(meter).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('should have custom aria-label', () => {
+      render(<AudioLevelMeter aria-label="Input level" />);
+
+      const meter = screen.getByRole('meter');
+      expect(meter).toHaveAttribute('aria-label', 'Input level');
+    });
+
+    it('should update aria-valuenow based on level', () => {
+      const { rerender } = render(<AudioLevelMeter level={0.25} />);
+
+      expect(screen.getByRole('meter')).toHaveAttribute('aria-valuenow', '25');
+
+      rerender(<AudioLevelMeter level={0.75} />);
+
+      expect(screen.getByRole('meter')).toHaveAttribute('aria-valuenow', '75');
+    });
+  });
+
+  describe('Custom Styling', () => {
+    it('should apply custom className', () => {
+      render(<AudioLevelMeter className="custom-meter" />);
+
+      expect(screen.getByTestId('audio-level-meter')).toHaveClass('custom-meter');
+    });
+
+    it('should apply custom width and height', () => {
+      render(<AudioLevelMeter width="200px" height="20px" />);
+
+      const meter = screen.getByTestId('audio-level-meter');
+      expect(meter).toHaveStyle({ width: '200px', height: '20px' });
+    });
+  });
+
+  describe('Color Thresholds', () => {
+    it('should apply low color for levels below mid threshold', () => {
+      render(
+        <AudioLevelMeter
+          level={0.3}
+          meterStyle="bar"
+          colorLow="#00ff00"
+          midThreshold={0.6}
+        />
+      );
+
+      const levelFill = screen.getByTestId('level-fill');
+      expect(levelFill).toHaveStyle({ backgroundColor: '#00ff00' });
+    });
+
+    it('should apply mid color for levels between thresholds', () => {
+      render(
+        <AudioLevelMeter
+          level={0.7}
+          meterStyle="bar"
+          colorMid="#ffff00"
+          midThreshold={0.6}
+          highThreshold={0.85}
+        />
+      );
+
+      const levelFill = screen.getByTestId('level-fill');
+      expect(levelFill).toHaveStyle({ backgroundColor: '#ffff00' });
+    });
+
+    it('should apply high color for levels above high threshold', () => {
+      render(
+        <AudioLevelMeter
+          level={0.9}
+          meterStyle="bar"
+          colorHigh="#ff0000"
+          highThreshold={0.85}
+        />
+      );
+
+      const levelFill = screen.getByTestId('level-fill');
+      expect(levelFill).toHaveStyle({ backgroundColor: '#ff0000' });
+    });
+  });
+
+  describe('Level Clamping', () => {
+    it('should clamp level to 0 for negative values', () => {
+      render(<AudioLevelMeter level={-0.5} />);
+
+      const meter = screen.getByRole('meter');
+      expect(meter).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('should clamp level to 100 for values above 1', () => {
+      render(<AudioLevelMeter level={1.5} />);
+
+      const meter = screen.getByRole('meter');
+      expect(meter).toHaveAttribute('aria-valuenow', '100');
+    });
+  });
+});

--- a/web/src/components/Recording/AudioLevelMeter.tsx
+++ b/web/src/components/Recording/AudioLevelMeter.tsx
@@ -1,0 +1,389 @@
+/**
+ * AudioLevelMeter Component
+ *
+ * A visual audio level meter that displays real-time audio input levels.
+ * Supports both bar and gradient styles with peak hold indicator.
+ */
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import {
+  createAudioAnalyzer,
+  createAudioLevelMonitor,
+  type AudioAnalyzerResult,
+  type AudioLevelMonitor,
+} from '@/lib/audio/microphone';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[AudioLevelMeter] ${message}`, ...args);
+  }
+};
+
+/**
+ * Visual style options for the level meter
+ */
+export type LevelMeterStyle = 'bar' | 'gradient' | 'segments';
+
+/**
+ * Orientation options for the level meter
+ */
+export type LevelMeterOrientation = 'horizontal' | 'vertical';
+
+/**
+ * Props for AudioLevelMeter component
+ */
+export interface AudioLevelMeterProps {
+  /** The media stream to visualize (required for active visualization) */
+  stream?: MediaStream | null;
+  /** Manual level value to display (0-1), used when stream is not provided */
+  level?: number;
+  /** Peak level value (0-1), used when stream is not provided */
+  peak?: number;
+  /** Visual style of the meter */
+  meterStyle?: LevelMeterStyle;
+  /** Orientation of the meter */
+  orientation?: LevelMeterOrientation;
+  /** Whether to show the peak indicator */
+  showPeak?: boolean;
+  /** Width of the meter (CSS value) */
+  width?: string;
+  /** Height of the meter (CSS value) */
+  height?: string;
+  /** Custom CSS class name */
+  className?: string;
+  /** Update interval in milliseconds */
+  updateInterval?: number;
+  /** Smoothing factor (0-1) */
+  smoothing?: number;
+  /** Number of segments for segmented display */
+  segments?: number;
+  /** Color for low levels (safe zone) */
+  colorLow?: string;
+  /** Color for mid levels (warning zone) */
+  colorMid?: string;
+  /** Color for high levels (danger zone) */
+  colorHigh?: string;
+  /** Threshold for mid level color (0-1) */
+  midThreshold?: number;
+  /** Threshold for high level color (0-1) */
+  highThreshold?: number;
+  /** Label for accessibility */
+  'aria-label'?: string;
+}
+
+/**
+ * Default colors for level visualization
+ */
+const DEFAULT_COLORS = {
+  low: '#22c55e', // Green
+  mid: '#eab308', // Yellow
+  high: '#ef4444', // Red
+  background: '#1f2937', // Gray-800
+  inactive: '#374151', // Gray-700
+};
+
+/**
+ * Default thresholds for color changes
+ */
+const DEFAULT_THRESHOLDS = {
+  mid: 0.6,
+  high: 0.85,
+};
+
+/**
+ * AudioLevelMeter displays a real-time audio level visualization.
+ *
+ * Features:
+ * - Three visual styles: bar, gradient, segments
+ * - Peak level indicator with hold/decay
+ * - Horizontal or vertical orientation
+ * - Configurable colors and thresholds
+ * - Automatic resource cleanup
+ *
+ * @example
+ * ```tsx
+ * // With media stream
+ * <AudioLevelMeter
+ *   stream={mediaStream}
+ *   meterStyle="gradient"
+ *   showPeak
+ * />
+ *
+ * // With manual level
+ * <AudioLevelMeter
+ *   level={0.5}
+ *   peak={0.7}
+ *   meterStyle="segments"
+ * />
+ * ```
+ */
+export function AudioLevelMeter({
+  stream,
+  level: manualLevel,
+  peak: manualPeak,
+  meterStyle = 'gradient',
+  orientation = 'horizontal',
+  showPeak = true,
+  width = '100%',
+  height = '12px',
+  className = '',
+  updateInterval = 50,
+  smoothing = 0.8,
+  segments = 20,
+  colorLow = DEFAULT_COLORS.low,
+  colorMid = DEFAULT_COLORS.mid,
+  colorHigh = DEFAULT_COLORS.high,
+  midThreshold = DEFAULT_THRESHOLDS.mid,
+  highThreshold = DEFAULT_THRESHOLDS.high,
+  'aria-label': ariaLabel = 'Audio level meter',
+}: AudioLevelMeterProps): React.ReactElement {
+  // State for stream-based levels (updated from monitor callback)
+  const [streamLevel, setStreamLevel] = useState(0);
+  const [streamPeak, setStreamPeak] = useState(0);
+
+  const analyzerRef = useRef<AudioAnalyzerResult | null>(null);
+  const monitorRef = useRef<AudioLevelMonitor | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Determine which level values to use: stream-based or manual props
+  // When stream is provided, use stream levels; otherwise use manual props
+  // Clamp values to 0-1 range for consistent display
+  const rawLevel = stream ? streamLevel : (manualLevel ?? 0);
+  const rawPeak = stream ? streamPeak : (manualPeak ?? 0);
+  const currentLevel = Math.max(0, Math.min(1, rawLevel));
+  const peakLevel = Math.max(0, Math.min(1, rawPeak));
+
+  // Level update callback for stream monitoring
+  const handleLevelUpdate = useCallback((level: number, peak: number) => {
+    setStreamLevel(level);
+    setStreamPeak(peak);
+  }, []);
+
+  // Setup analyzer and monitor when stream changes
+  useEffect(() => {
+    // Skip if no stream
+    if (!stream) {
+      return;
+    }
+
+    log('Setting up audio analysis for stream');
+
+    // Create analyzer
+    try {
+      const analyzer = createAudioAnalyzer(stream);
+      analyzerRef.current = analyzer;
+
+      // Create monitor
+      const monitor = createAudioLevelMonitor(analyzer.analyser, {
+        updateInterval,
+        smoothing,
+        onLevel: handleLevelUpdate,
+      });
+      monitorRef.current = monitor;
+
+      // Start monitoring
+      monitor.start();
+      log('Audio level monitoring started');
+    } catch (error) {
+      log('Failed to setup audio analysis:', error);
+    }
+
+    // Cleanup
+    return () => {
+      log('Cleaning up audio analysis');
+      monitorRef.current?.dispose();
+      analyzerRef.current?.dispose();
+      monitorRef.current = null;
+      analyzerRef.current = null;
+    };
+  }, [stream, updateInterval, smoothing, handleLevelUpdate]);
+
+  // Get color based on level
+  const getColor = (level: number): string => {
+    if (level >= highThreshold) return colorHigh;
+    if (level >= midThreshold) return colorMid;
+    return colorLow;
+  };
+
+  // Generate gradient stops
+  const getGradient = (): string => {
+    const isVertical = orientation === 'vertical';
+    const direction = isVertical ? 'to top' : 'to right';
+
+    return `linear-gradient(${direction},
+      ${colorLow} 0%,
+      ${colorLow} ${midThreshold * 100}%,
+      ${colorMid} ${midThreshold * 100}%,
+      ${colorMid} ${highThreshold * 100}%,
+      ${colorHigh} ${highThreshold * 100}%,
+      ${colorHigh} 100%)`;
+  };
+
+  // Calculate dimensions for the level bar
+  const getLevelStyle = (): React.CSSProperties => {
+    const percentage = Math.max(0, Math.min(100, currentLevel * 100));
+
+    if (orientation === 'vertical') {
+      return {
+        height: `${percentage}%`,
+        width: '100%',
+        bottom: 0,
+        left: 0,
+      };
+    }
+
+    return {
+      width: `${percentage}%`,
+      height: '100%',
+      top: 0,
+      left: 0,
+    };
+  };
+
+  // Calculate peak indicator position
+  const getPeakStyle = (): React.CSSProperties => {
+    const percentage = Math.max(0, Math.min(100, peakLevel * 100));
+
+    if (orientation === 'vertical') {
+      return {
+        bottom: `calc(${percentage}% - 2px)`,
+        left: 0,
+        right: 0,
+        height: '3px',
+      };
+    }
+
+    return {
+      left: `calc(${percentage}% - 2px)`,
+      top: 0,
+      bottom: 0,
+      width: '3px',
+    };
+  };
+
+  // Render segmented meter
+  const renderSegments = (): React.ReactElement[] => {
+    const activeSegments = Math.round(currentLevel * segments);
+    const peakSegment = Math.round(peakLevel * segments);
+
+    return Array.from({ length: segments }, (_, index) => {
+      const segmentLevel = (index + 1) / segments;
+      const isActive = index < activeSegments;
+      const isPeak = showPeak && index === peakSegment - 1 && peakSegment > activeSegments;
+      const color = isActive ? getColor(segmentLevel) : isPeak ? colorHigh : DEFAULT_COLORS.inactive;
+
+      const segmentStyle: React.CSSProperties = orientation === 'vertical'
+        ? {
+            width: '100%',
+            height: `${100 / segments}%`,
+            backgroundColor: color,
+            marginTop: index > 0 ? '1px' : 0,
+          }
+        : {
+            height: '100%',
+            width: `${100 / segments}%`,
+            backgroundColor: color,
+            marginLeft: index > 0 ? '1px' : 0,
+          };
+
+      return (
+        <div
+          key={index}
+          className="audio-level-meter__segment"
+          style={segmentStyle}
+          data-active={isActive}
+          data-peak={isPeak}
+        />
+      );
+    });
+  };
+
+  // Container styles
+  const containerStyle: React.CSSProperties = {
+    width,
+    height,
+    backgroundColor: DEFAULT_COLORS.background,
+    borderRadius: '4px',
+    overflow: 'hidden',
+    position: 'relative',
+    display: orientation === 'vertical' ? 'flex' : 'block',
+    flexDirection: orientation === 'vertical' ? 'column-reverse' : undefined,
+    ...((meterStyle === 'segments') && {
+      display: 'flex',
+      flexDirection: orientation === 'vertical' ? 'column-reverse' : 'row',
+      gap: '1px',
+      backgroundColor: 'transparent',
+    }),
+  };
+
+  // Level bar styles
+  const levelStyle: React.CSSProperties = {
+    ...getLevelStyle(),
+    position: 'absolute',
+    transition: 'width 0.05s ease-out, height 0.05s ease-out',
+    ...(meterStyle === 'gradient'
+      ? { background: getGradient() }
+      : { backgroundColor: getColor(currentLevel) }),
+  };
+
+  // Peak indicator styles
+  const peakStyle: React.CSSProperties = {
+    ...getPeakStyle(),
+    position: 'absolute',
+    backgroundColor: colorHigh,
+    opacity: 0.9,
+    transition: orientation === 'vertical'
+      ? 'bottom 0.1s ease-out'
+      : 'left 0.1s ease-out',
+  };
+
+  // Render segmented style
+  if (meterStyle === 'segments') {
+    return (
+      <div
+        ref={containerRef}
+        className={`audio-level-meter audio-level-meter--segments audio-level-meter--${orientation} ${className}`.trim()}
+        style={containerStyle}
+        role="meter"
+        aria-label={ariaLabel}
+        aria-valuenow={Math.round(currentLevel * 100)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        data-testid="audio-level-meter"
+      >
+        {renderSegments()}
+      </div>
+    );
+  }
+
+  // Render bar or gradient style
+  return (
+    <div
+      ref={containerRef}
+      className={`audio-level-meter audio-level-meter--${meterStyle} audio-level-meter--${orientation} ${className}`.trim()}
+      style={containerStyle}
+      role="meter"
+      aria-label={ariaLabel}
+      aria-valuenow={Math.round(currentLevel * 100)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      data-testid="audio-level-meter"
+    >
+      {/* Level fill */}
+      <div className="audio-level-meter__level" style={levelStyle} data-testid="level-fill" />
+
+      {/* Peak indicator */}
+      {showPeak && peakLevel > 0 && (
+        <div
+          className="audio-level-meter__peak"
+          style={peakStyle}
+          data-testid="peak-indicator"
+        />
+      )}
+    </div>
+  );
+}
+
+export default AudioLevelMeter;

--- a/web/src/components/Recording/MicrophoneSelect.test.tsx
+++ b/web/src/components/Recording/MicrophoneSelect.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * MicrophoneSelect Component Tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MicrophoneSelect } from './MicrophoneSelect';
+
+// Mock the microphone module
+vi.mock('@/lib/audio/microphone', () => ({
+  getMicrophoneDevices: vi.fn(),
+  onDeviceChange: vi.fn(() => vi.fn()),
+  isDeviceEnumerationSupported: vi.fn(() => true),
+}));
+
+import { getMicrophoneDevices, onDeviceChange, isDeviceEnumerationSupported } from '@/lib/audio/microphone';
+
+const mockGetMicrophoneDevices = getMicrophoneDevices as ReturnType<typeof vi.fn>;
+const mockOnDeviceChange = onDeviceChange as ReturnType<typeof vi.fn>;
+const mockIsDeviceEnumerationSupported = isDeviceEnumerationSupported as ReturnType<typeof vi.fn>;
+
+describe('MicrophoneSelect', () => {
+  const mockDevices = [
+    { deviceId: 'device-1', label: 'Built-in Microphone', groupId: 'g1', isDefault: true },
+    { deviceId: 'device-2', label: 'USB Microphone', groupId: 'g2', isDefault: false },
+    { deviceId: 'device-3', label: 'Headset Microphone', groupId: 'g3', isDefault: false },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMicrophoneDevices.mockResolvedValue(mockDevices);
+    mockIsDeviceEnumerationSupported.mockReturnValue(true);
+    mockOnDeviceChange.mockImplementation(() => vi.fn());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should show loading state initially', () => {
+      render(<MicrophoneSelect />);
+
+      expect(screen.getByTestId('microphone-select-loading')).toBeInTheDocument();
+      expect(screen.getByText('Loading devices...')).toBeInTheDocument();
+    });
+
+    it('should render device list after loading', async () => {
+      render(<MicrophoneSelect />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      const select = screen.getByRole('combobox');
+      expect(select).toBeInTheDocument();
+
+      // All devices should be rendered as options
+      expect(screen.getByText('Built-in Microphone (Default)')).toBeInTheDocument();
+      expect(screen.getByText('USB Microphone')).toBeInTheDocument();
+      expect(screen.getByText('Headset Microphone')).toBeInTheDocument();
+    });
+
+    it('should show placeholder when no device is selected', async () => {
+      render(<MicrophoneSelect placeholder="Choose a mic..." />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Choose a mic...')).toBeInTheDocument();
+    });
+
+    it('should show empty state when no devices found', async () => {
+      mockGetMicrophoneDevices.mockResolvedValue([]);
+
+      render(<MicrophoneSelect />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select-empty')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('No microphones found')).toBeInTheDocument();
+    });
+
+    it('should show error state when device enumeration not supported', async () => {
+      mockIsDeviceEnumerationSupported.mockReturnValue(false);
+
+      render(<MicrophoneSelect />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select-error')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Device enumeration is not supported in this browser')).toBeInTheDocument();
+    });
+  });
+
+  describe('Selection', () => {
+    it('should call onDeviceChange when selection changes', async () => {
+      const handleChange = vi.fn();
+
+      render(<MicrophoneSelect onDeviceChange={handleChange} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      const select = screen.getByRole('combobox');
+      fireEvent.change(select, { target: { value: 'device-2' } });
+
+      expect(handleChange).toHaveBeenCalledWith('device-2');
+    });
+
+    it('should auto-select default device when no device is selected', async () => {
+      const handleChange = vi.fn();
+
+      render(<MicrophoneSelect onDeviceChange={handleChange} />);
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith('device-1');
+      });
+    });
+
+    it('should not auto-select if device is already selected', async () => {
+      const handleChange = vi.fn();
+
+      render(<MicrophoneSelect selectedDeviceId="device-2" onDeviceChange={handleChange} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      // Should not call onDeviceChange since we already have a selected device
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it('should show selected device value', async () => {
+      render(<MicrophoneSelect selectedDeviceId="device-2" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      const select = screen.getByRole('combobox') as HTMLSelectElement;
+      expect(select.value).toBe('device-2');
+    });
+  });
+
+  describe('Disabled State', () => {
+    it('should disable select when disabled prop is true', async () => {
+      render(<MicrophoneSelect disabled />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      const select = screen.getByRole('combobox');
+      expect(select).toBeDisabled();
+    });
+  });
+
+  describe('Device Change Listener', () => {
+    it('should set up device change listener on mount', async () => {
+      render(<MicrophoneSelect />);
+
+      await waitFor(() => {
+        expect(mockOnDeviceChange).toHaveBeenCalled();
+      });
+    });
+
+    it('should refresh devices when device change is detected', async () => {
+      let deviceChangeCallback: () => void = () => {};
+
+      mockOnDeviceChange.mockImplementation((callback) => {
+        deviceChangeCallback = callback;
+        return vi.fn();
+      });
+
+      render(<MicrophoneSelect />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      expect(mockGetMicrophoneDevices).toHaveBeenCalledTimes(1);
+
+      // Simulate device change
+      const newDevices = [
+        { deviceId: 'device-new', label: 'New Microphone', groupId: 'gn', isDefault: true },
+      ];
+      mockGetMicrophoneDevices.mockResolvedValue(newDevices);
+
+      deviceChangeCallback();
+
+      await waitFor(() => {
+        expect(mockGetMicrophoneDevices).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should clean up device change listener on unmount', async () => {
+      const unsubscribe = vi.fn();
+      mockOnDeviceChange.mockReturnValue(unsubscribe);
+
+      const { unmount } = render(<MicrophoneSelect />);
+
+      await waitFor(() => {
+        expect(mockOnDeviceChange).toHaveBeenCalled();
+      });
+
+      unmount();
+
+      expect(unsubscribe).toHaveBeenCalled();
+    });
+  });
+
+  describe('Permission Changes', () => {
+    it('should refresh devices when permission changes', async () => {
+      const { rerender } = render(<MicrophoneSelect hasPermission={false} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      expect(mockGetMicrophoneDevices).toHaveBeenCalledTimes(1);
+
+      // Simulate permission granted
+      rerender(<MicrophoneSelect hasPermission={true} />);
+
+      await waitFor(() => {
+        expect(mockGetMicrophoneDevices).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('Label Formatting', () => {
+    it('should show default indicator for default device', async () => {
+      render(<MicrophoneSelect />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Built-in Microphone (Default)')).toBeInTheDocument();
+    });
+
+    it('should not duplicate default indicator if already in label', async () => {
+      const devicesWithDefault = [
+        { deviceId: 'device-1', label: 'Default Microphone', groupId: 'g1', isDefault: true },
+      ];
+      mockGetMicrophoneDevices.mockResolvedValue(devicesWithDefault);
+
+      render(<MicrophoneSelect />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      // Should not say "Default Microphone (Default)"
+      expect(screen.getByText('Default Microphone')).toBeInTheDocument();
+      expect(screen.queryByText('Default Microphone (Default)')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper aria-label', async () => {
+      render(<MicrophoneSelect aria-label="Choose microphone" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-label', 'Choose microphone');
+    });
+
+    it('should use default aria-label', async () => {
+      render(<MicrophoneSelect />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('combobox')).toHaveAttribute('aria-label', 'Select microphone');
+    });
+  });
+
+  describe('Custom Styling', () => {
+    it('should apply custom className', async () => {
+      render(<MicrophoneSelect className="custom-class" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('microphone-select')).toHaveClass('custom-class');
+    });
+
+    it('should apply custom style', async () => {
+      render(<MicrophoneSelect style={{ width: '300px' }} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('microphone-select')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('microphone-select')).toHaveStyle({ width: '300px' });
+    });
+  });
+});

--- a/web/src/components/Recording/MicrophoneSelect.tsx
+++ b/web/src/components/Recording/MicrophoneSelect.tsx
@@ -1,0 +1,232 @@
+/**
+ * MicrophoneSelect Component
+ *
+ * A dropdown component for selecting audio input devices (microphones).
+ * Automatically refreshes device list when devices are added or removed.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  getMicrophoneDevices,
+  onDeviceChange,
+  isDeviceEnumerationSupported,
+  type AudioDeviceInfo,
+} from '@/lib/audio/microphone';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[MicrophoneSelect] ${message}`, ...args);
+  }
+};
+
+/**
+ * Props for MicrophoneSelect component
+ */
+export interface MicrophoneSelectProps {
+  /** Currently selected device ID */
+  selectedDeviceId?: string;
+  /** Callback when device selection changes */
+  onDeviceChange?: (deviceId: string) => void;
+  /** Whether the component is disabled */
+  disabled?: boolean;
+  /** Custom CSS class name */
+  className?: string;
+  /** Whether permission has been granted (affects label visibility) */
+  hasPermission?: boolean;
+  /** Placeholder text when no device is selected */
+  placeholder?: string;
+  /** Custom styling for the select element */
+  style?: React.CSSProperties;
+  /** Label for accessibility */
+  'aria-label'?: string;
+}
+
+/**
+ * MicrophoneSelect renders a dropdown for selecting audio input devices.
+ *
+ * Features:
+ * - Lists all available microphones
+ * - Automatically refreshes when devices change
+ * - Shows "Microphone 1", "Microphone 2", etc. when labels are unavailable
+ * - Indicates the default device
+ *
+ * @example
+ * ```tsx
+ * <MicrophoneSelect
+ *   selectedDeviceId={deviceId}
+ *   onDeviceChange={(id) => setDeviceId(id)}
+ *   hasPermission={hasPermission}
+ * />
+ * ```
+ */
+export function MicrophoneSelect({
+  selectedDeviceId,
+  onDeviceChange: onDeviceChangeCallback,
+  disabled = false,
+  className = '',
+  hasPermission = false,
+  placeholder = 'Select microphone...',
+  style,
+  'aria-label': ariaLabel = 'Select microphone',
+}: MicrophoneSelectProps): React.ReactElement {
+  const [devices, setDevices] = useState<AudioDeviceInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const isMounted = useRef(true);
+
+  // Fetch devices
+  const fetchDevices = useCallback(async () => {
+    log('Fetching devices...');
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      if (!isDeviceEnumerationSupported()) {
+        setError('Device enumeration is not supported in this browser');
+        setDevices([]);
+        return;
+      }
+
+      const deviceList = await getMicrophoneDevices();
+
+      if (isMounted.current) {
+        log('Devices fetched:', deviceList.length);
+        setDevices(deviceList);
+
+        // If no device is selected and we have devices, select the default
+        if (!selectedDeviceId && deviceList.length > 0 && onDeviceChangeCallback) {
+          const defaultDevice = deviceList.find((d) => d.isDefault) || deviceList[0];
+          log('Auto-selecting default device:', defaultDevice.deviceId);
+          onDeviceChangeCallback(defaultDevice.deviceId);
+        }
+      }
+    } catch (err) {
+      log('Error fetching devices:', err);
+      if (isMounted.current) {
+        setError('Failed to get microphone list');
+        setDevices([]);
+      }
+    } finally {
+      if (isMounted.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [selectedDeviceId, onDeviceChangeCallback]);
+
+  // Fetch devices on mount and when permission changes
+  useEffect(() => {
+    isMounted.current = true;
+    fetchDevices();
+
+    return () => {
+      isMounted.current = false;
+    };
+  }, [fetchDevices, hasPermission]);
+
+  // Listen for device changes
+  useEffect(() => {
+    const unsubscribe = onDeviceChange(() => {
+      log('Device change detected, refreshing...');
+      fetchDevices();
+    });
+
+    return unsubscribe;
+  }, [fetchDevices]);
+
+  // Handle selection change
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newDeviceId = event.target.value;
+    log('Device selected:', newDeviceId);
+    onDeviceChangeCallback?.(newDeviceId);
+  };
+
+  // Format device label for display
+  const formatDeviceLabel = (device: AudioDeviceInfo): string => {
+    let label = device.label;
+
+    // If label is empty or generic, use a more descriptive name
+    if (!label || label === 'Default' || label.startsWith('audioinput')) {
+      label = device.isDefault ? 'Default Microphone' : `Microphone`;
+    }
+
+    // Add default indicator if this is the default device
+    if (device.isDefault && !label.includes('Default')) {
+      label = `${label} (Default)`;
+    }
+
+    return label;
+  };
+
+  // Render loading state
+  if (isLoading) {
+    return (
+      <div
+        className={`microphone-select microphone-select--loading ${className}`.trim()}
+        style={style}
+        data-testid="microphone-select-loading"
+      >
+        <select disabled aria-label={ariaLabel}>
+          <option>Loading devices...</option>
+        </select>
+      </div>
+    );
+  }
+
+  // Render error state
+  if (error) {
+    return (
+      <div
+        className={`microphone-select microphone-select--error ${className}`.trim()}
+        style={style}
+        data-testid="microphone-select-error"
+      >
+        <select disabled aria-label={ariaLabel}>
+          <option>{error}</option>
+        </select>
+      </div>
+    );
+  }
+
+  // Render no devices state
+  if (devices.length === 0) {
+    return (
+      <div
+        className={`microphone-select microphone-select--empty ${className}`.trim()}
+        style={style}
+        data-testid="microphone-select-empty"
+      >
+        <select disabled aria-label={ariaLabel}>
+          <option>No microphones found</option>
+        </select>
+      </div>
+    );
+  }
+
+  // Render normal state
+  return (
+    <div
+      className={`microphone-select ${className}`.trim()}
+      style={style}
+      data-testid="microphone-select"
+    >
+      <select
+        value={selectedDeviceId || ''}
+        onChange={handleChange}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        className="microphone-select__dropdown"
+      >
+        {!selectedDeviceId && <option value="">{placeholder}</option>}
+        {devices.map((device) => (
+          <option key={device.deviceId} value={device.deviceId}>
+            {formatDeviceLabel(device)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export default MicrophoneSelect;

--- a/web/src/components/Recording/PermissionPrompt.test.tsx
+++ b/web/src/components/Recording/PermissionPrompt.test.tsx
@@ -1,0 +1,507 @@
+/**
+ * PermissionPrompt Component Tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PermissionPrompt } from './PermissionPrompt';
+
+// Mock the microphone module
+vi.mock('@/lib/audio/microphone', () => ({
+  queryMicrophonePermission: vi.fn(),
+  requestMicrophoneAccess: vi.fn(),
+  stopMediaStream: vi.fn(),
+  isMicrophoneSupported: vi.fn(),
+}));
+
+import {
+  queryMicrophonePermission,
+  requestMicrophoneAccess,
+  stopMediaStream,
+  isMicrophoneSupported,
+} from '@/lib/audio/microphone';
+
+const mockQueryMicrophonePermission = queryMicrophonePermission as ReturnType<typeof vi.fn>;
+const mockRequestMicrophoneAccess = requestMicrophoneAccess as ReturnType<typeof vi.fn>;
+const mockStopMediaStream = stopMediaStream as ReturnType<typeof vi.fn>;
+const mockIsMicrophoneSupported = isMicrophoneSupported as ReturnType<typeof vi.fn>;
+
+// Mock MediaStream
+class MockMediaStream {
+  getTracks() {
+    return [{ stop: vi.fn() }];
+  }
+}
+
+describe('PermissionPrompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsMicrophoneSupported.mockReturnValue(true);
+    mockQueryMicrophonePermission.mockResolvedValue('prompt');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render prompt state by default', async () => {
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Microphone Access Required')).toBeInTheDocument();
+      expect(screen.getByText('Enable Microphone')).toBeInTheDocument();
+    });
+
+    it('should render with custom title and description', async () => {
+      render(
+        <PermissionPrompt
+          title="Custom Title"
+          description="Custom description text"
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Custom Title')).toBeInTheDocument();
+        expect(screen.getByText('Custom description text')).toBeInTheDocument();
+      });
+    });
+
+    it('should render with custom button text', async () => {
+      render(<PermissionPrompt buttonText="Allow Access" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Allow Access')).toBeInTheDocument();
+      });
+    });
+
+    it('should render with card variant by default', async () => {
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toHaveClass('permission-prompt--card');
+      });
+    });
+
+    it('should render with inline variant when specified', async () => {
+      render(<PermissionPrompt variant="inline" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toHaveClass('permission-prompt--inline');
+      });
+    });
+
+    it('should render with minimal variant when specified', async () => {
+      render(<PermissionPrompt variant="minimal" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toHaveClass('permission-prompt--minimal');
+      });
+    });
+  });
+
+  describe('Unsupported State', () => {
+    it('should render unsupported message when microphone is not supported', async () => {
+      mockIsMicrophoneSupported.mockReturnValue(false);
+
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt-unsupported')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Browser Not Supported')).toBeInTheDocument();
+    });
+  });
+
+  describe('Denied State', () => {
+    it('should render denied state when permission is denied', async () => {
+      mockQueryMicrophonePermission.mockResolvedValue('denied');
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: false,
+        stream: null,
+        error: 'Permission denied',
+        permissionState: 'denied',
+      });
+
+      render(<PermissionPrompt />);
+
+      // First request permission to trigger the denied state
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt-denied')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Microphone Access Denied')).toBeInTheDocument();
+      expect(screen.getByText('Try Again')).toBeInTheDocument();
+    });
+
+    it('should show browser-specific instructions when denied', async () => {
+      mockQueryMicrophonePermission.mockResolvedValue('denied');
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: false,
+        stream: null,
+        error: 'Permission denied',
+        permissionState: 'denied',
+      });
+
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText(/To enable access:/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Granted State', () => {
+    it('should not render when permission is already granted', async () => {
+      mockQueryMicrophonePermission.mockResolvedValue('granted');
+
+      const { container } = render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(container).toBeEmptyDOMElement();
+      });
+    });
+  });
+
+  describe('Permission Request', () => {
+    it('should request permission when button is clicked', async () => {
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: true,
+        stream: new MockMediaStream() as unknown as MediaStream,
+        error: null,
+        permissionState: 'granted',
+      });
+
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockRequestMicrophoneAccess).toHaveBeenCalled();
+      });
+    });
+
+    it('should show loading state during permission request', async () => {
+      let resolveRequest: (value: unknown) => void;
+      const requestPromise = new Promise((resolve) => {
+        resolveRequest = resolve;
+      });
+
+      mockRequestMicrophoneAccess.mockReturnValue(requestPromise);
+
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText('Requesting Access...')).toBeInTheDocument();
+      });
+
+      // Resolve the request
+      resolveRequest!({
+        success: true,
+        stream: new MockMediaStream(),
+        error: null,
+        permissionState: 'granted',
+      });
+    });
+
+    it('should disable button during loading', async () => {
+      let resolveRequest: (value: unknown) => void;
+      const requestPromise = new Promise((resolve) => {
+        resolveRequest = resolve;
+      });
+
+      mockRequestMicrophoneAccess.mockReturnValue(requestPromise);
+
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(button).toBeDisabled();
+      });
+
+      // Resolve to clean up
+      resolveRequest!({
+        success: false,
+        stream: null,
+        error: 'Test',
+        permissionState: 'prompt',
+      });
+    });
+  });
+
+  describe('Callbacks', () => {
+    it('should call onPermissionGranted when permission is granted', async () => {
+      const mockStream = new MockMediaStream() as unknown as MediaStream;
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: true,
+        stream: mockStream,
+        error: null,
+        permissionState: 'granted',
+      });
+
+      const handleGranted = vi.fn();
+
+      render(<PermissionPrompt onPermissionGranted={handleGranted} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(handleGranted).toHaveBeenCalledWith(mockStream);
+      });
+    });
+
+    it('should call onPermissionDenied when permission is denied', async () => {
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: false,
+        stream: null,
+        error: 'User denied access',
+        permissionState: 'denied',
+      });
+
+      const handleDenied = vi.fn();
+
+      render(<PermissionPrompt onPermissionDenied={handleDenied} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(handleDenied).toHaveBeenCalledWith('User denied access');
+      });
+    });
+
+    it('should call onPermissionChange when state changes', async () => {
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: true,
+        stream: new MockMediaStream() as unknown as MediaStream,
+        error: null,
+        permissionState: 'granted',
+      });
+
+      const handleChange = vi.fn();
+
+      render(<PermissionPrompt onPermissionChange={handleChange} />);
+
+      // Initial query
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith('prompt');
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith('granted');
+      });
+    });
+  });
+
+  describe('Stream Handling', () => {
+    it('should stop stream when keepStreamActive is false', async () => {
+      const mockStream = new MockMediaStream() as unknown as MediaStream;
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: true,
+        stream: mockStream,
+        error: null,
+        permissionState: 'granted',
+      });
+
+      render(<PermissionPrompt keepStreamActive={false} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockStopMediaStream).toHaveBeenCalledWith(mockStream);
+      });
+    });
+
+    it('should not stop stream when keepStreamActive is true', async () => {
+      const mockStream = new MockMediaStream() as unknown as MediaStream;
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: true,
+        stream: mockStream,
+        error: null,
+        permissionState: 'granted',
+      });
+
+      render(<PermissionPrompt keepStreamActive={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockStopMediaStream).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Auto Request', () => {
+    it('should automatically request permission when autoRequest is true', async () => {
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: true,
+        stream: new MockMediaStream() as unknown as MediaStream,
+        error: null,
+        permissionState: 'granted',
+      });
+
+      render(<PermissionPrompt autoRequest />);
+
+      await waitFor(() => {
+        expect(mockRequestMicrophoneAccess).toHaveBeenCalled();
+      });
+    });
+
+    it('should not auto request if permission is already granted', async () => {
+      mockQueryMicrophonePermission.mockResolvedValue('granted');
+
+      render(<PermissionPrompt autoRequest />);
+
+      await waitFor(() => {
+        expect(mockRequestMicrophoneAccess).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Error Display', () => {
+    it('should display error message from failed request', async () => {
+      mockRequestMicrophoneAccess.mockResolvedValue({
+        success: false,
+        stream: null,
+        error: 'Specific error message here',
+        permissionState: 'denied',
+      });
+
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText('Specific error message here')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper role attributes', async () => {
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('region')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('region')).toHaveAttribute(
+        'aria-label',
+        'Microphone permission request'
+      );
+    });
+
+    it('should have aria-busy on button during loading', async () => {
+      let resolveRequest: (value: unknown) => void;
+      const requestPromise = new Promise((resolve) => {
+        resolveRequest = resolve;
+      });
+
+      mockRequestMicrophoneAccess.mockReturnValue(requestPromise);
+
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toBeInTheDocument();
+      });
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(button).toHaveAttribute('aria-busy', 'true');
+      });
+
+      // Resolve to clean up
+      resolveRequest!({
+        success: false,
+        stream: null,
+        error: 'Test',
+        permissionState: 'prompt',
+      });
+    });
+
+    it('should use role="alert" for error states', async () => {
+      mockIsMicrophoneSupported.mockReturnValue(false);
+
+      render(<PermissionPrompt />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Custom Styling', () => {
+    it('should apply custom className', async () => {
+      render(<PermissionPrompt className="custom-prompt" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('permission-prompt')).toHaveClass('custom-prompt');
+      });
+    });
+  });
+});

--- a/web/src/components/Recording/PermissionPrompt.tsx
+++ b/web/src/components/Recording/PermissionPrompt.tsx
@@ -1,0 +1,363 @@
+/**
+ * PermissionPrompt Component
+ *
+ * A UI component for requesting and displaying microphone permission status.
+ * Provides clear messaging for different permission states and browsers.
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import {
+  queryMicrophonePermission,
+  requestMicrophoneAccess,
+  stopMediaStream,
+  isMicrophoneSupported,
+  type MicrophonePermissionState,
+} from '@/lib/audio/microphone';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[PermissionPrompt] ${message}`, ...args);
+  }
+};
+
+/**
+ * Display variant for the permission prompt
+ */
+export type PermissionPromptVariant = 'card' | 'inline' | 'minimal';
+
+/**
+ * Props for PermissionPrompt component
+ */
+export interface PermissionPromptProps {
+  /** Callback when permission is granted */
+  onPermissionGranted?: (stream: MediaStream) => void;
+  /** Callback when permission is denied or fails */
+  onPermissionDenied?: (error: string) => void;
+  /** Callback when permission state changes */
+  onPermissionChange?: (state: MicrophonePermissionState) => void;
+  /** Whether to automatically request permission on mount */
+  autoRequest?: boolean;
+  /** Whether to keep the stream active after permission is granted */
+  keepStreamActive?: boolean;
+  /** Display variant */
+  variant?: PermissionPromptVariant;
+  /** Custom CSS class name */
+  className?: string;
+  /** Custom button text for the request button */
+  buttonText?: string;
+  /** Title for the prompt */
+  title?: string;
+  /** Description for the prompt */
+  description?: string;
+}
+
+/**
+ * Browser-specific instructions for enabling microphone access
+ */
+const BROWSER_INSTRUCTIONS: Record<string, string> = {
+  chrome:
+    'Click the lock icon in the address bar, then set Microphone to "Allow".',
+  firefox:
+    'Click the microphone icon in the address bar, then click "Allow".',
+  safari:
+    'Go to Safari > Settings > Websites > Microphone, then allow this site.',
+  edge:
+    'Click the lock icon in the address bar, then set Microphone to "Allow".',
+  default:
+    'Check your browser settings to allow microphone access for this site.',
+};
+
+/**
+ * Detect the current browser
+ */
+function detectBrowser(): string {
+  const ua = navigator.userAgent.toLowerCase();
+
+  if (ua.includes('edg')) return 'edge';
+  if (ua.includes('chrome')) return 'chrome';
+  if (ua.includes('firefox')) return 'firefox';
+  if (ua.includes('safari')) return 'safari';
+
+  return 'default';
+}
+
+/**
+ * PermissionPrompt displays a UI for requesting microphone permission.
+ *
+ * Features:
+ * - Clear permission state visualization
+ * - Browser-specific instructions for denied permissions
+ * - Automatic permission checking
+ * - Loading state during permission request
+ * - Error handling with user-friendly messages
+ *
+ * @example
+ * ```tsx
+ * <PermissionPrompt
+ *   onPermissionGranted={(stream) => setStream(stream)}
+ *   onPermissionDenied={(error) => setError(error)}
+ *   variant="card"
+ * />
+ * ```
+ */
+export function PermissionPrompt({
+  onPermissionGranted,
+  onPermissionDenied,
+  onPermissionChange,
+  autoRequest = false,
+  keepStreamActive = false,
+  variant = 'card',
+  className = '',
+  buttonText = 'Enable Microphone',
+  title = 'Microphone Access Required',
+  description = 'To record your voice, we need access to your microphone.',
+}: PermissionPromptProps): React.ReactElement | null {
+  const [permissionState, setPermissionState] =
+    useState<MicrophonePermissionState>('prompt');
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [hasCheckedInitial, setHasCheckedInitial] = useState(false);
+
+  // Check initial permission state
+  useEffect(() => {
+    const checkPermission = async () => {
+      log('Checking initial permission state...');
+      const state = await queryMicrophonePermission();
+      log('Initial permission state:', state);
+      setPermissionState(state);
+      onPermissionChange?.(state);
+      setHasCheckedInitial(true);
+
+      // Auto-request if enabled and permission is prompt
+      if (autoRequest && state === 'prompt') {
+        log('Auto-requesting permission...');
+        requestPermission();
+      }
+    };
+
+    checkPermission();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Request permission
+  const requestPermission = useCallback(async () => {
+    log('Requesting microphone permission...');
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    const result = await requestMicrophoneAccess();
+
+    setIsLoading(false);
+    setPermissionState(result.permissionState);
+    onPermissionChange?.(result.permissionState);
+
+    if (result.success && result.stream) {
+      log('Permission granted');
+      onPermissionGranted?.(result.stream);
+
+      // Stop stream if we don't need to keep it active
+      if (!keepStreamActive) {
+        log('Stopping stream (keepStreamActive=false)');
+        stopMediaStream(result.stream);
+      }
+    } else {
+      log('Permission denied or failed:', result.error);
+      setErrorMessage(result.error);
+      onPermissionDenied?.(result.error || 'Permission denied');
+    }
+  }, [onPermissionGranted, onPermissionDenied, onPermissionChange, keepStreamActive]);
+
+  // Get browser-specific instructions
+  const getBrowserInstructions = (): string => {
+    const browser = detectBrowser();
+    return BROWSER_INSTRUCTIONS[browser] || BROWSER_INSTRUCTIONS.default;
+  };
+
+  // Don't render if not supported
+  if (!isMicrophoneSupported()) {
+    return (
+      <div
+        className={`permission-prompt permission-prompt--${variant} permission-prompt--unsupported ${className}`.trim()}
+        data-testid="permission-prompt-unsupported"
+        role="alert"
+      >
+        <div className="permission-prompt__content">
+          <div className="permission-prompt__icon">
+            <UnsupportedIcon />
+          </div>
+          <h3 className="permission-prompt__title">Browser Not Supported</h3>
+          <p className="permission-prompt__description">
+            Your browser does not support microphone access. Please use a modern
+            browser like Chrome, Firefox, Safari, or Edge.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Don't render if permission is already granted
+  if (permissionState === 'granted' && hasCheckedInitial) {
+    return null;
+  }
+
+  // Render denied state
+  if (permissionState === 'denied') {
+    return (
+      <div
+        className={`permission-prompt permission-prompt--${variant} permission-prompt--denied ${className}`.trim()}
+        data-testid="permission-prompt-denied"
+        role="alert"
+      >
+        <div className="permission-prompt__content">
+          <div className="permission-prompt__icon permission-prompt__icon--error">
+            <DeniedIcon />
+          </div>
+          <h3 className="permission-prompt__title">Microphone Access Denied</h3>
+          <p className="permission-prompt__description">
+            {errorMessage || 'Microphone access was denied.'}
+          </p>
+          <p className="permission-prompt__instructions">
+            <strong>To enable access:</strong> {getBrowserInstructions()}
+          </p>
+          <button
+            onClick={requestPermission}
+            className="permission-prompt__button"
+            disabled={isLoading}
+            type="button"
+          >
+            {isLoading ? 'Checking...' : 'Try Again'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Render prompt/request state
+  return (
+    <div
+      className={`permission-prompt permission-prompt--${variant} permission-prompt--prompt ${className}`.trim()}
+      data-testid="permission-prompt"
+      role="region"
+      aria-label="Microphone permission request"
+    >
+      <div className="permission-prompt__content">
+        <div className="permission-prompt__icon">
+          <MicrophoneIcon />
+        </div>
+        <h3 className="permission-prompt__title">{title}</h3>
+        <p className="permission-prompt__description">{description}</p>
+        {errorMessage && (
+          <p className="permission-prompt__error" role="alert">
+            {errorMessage}
+          </p>
+        )}
+        <button
+          onClick={requestPermission}
+          className="permission-prompt__button"
+          disabled={isLoading}
+          type="button"
+          aria-busy={isLoading}
+        >
+          {isLoading ? (
+            <>
+              <LoadingSpinner />
+              <span>Requesting Access...</span>
+            </>
+          ) : (
+            buttonText
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Icon Components
+// =============================================================================
+
+function MicrophoneIcon(): React.ReactElement {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" x2="12" y1="19" y2="22" />
+    </svg>
+  );
+}
+
+function DeniedIcon(): React.ReactElement {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="m4.9 4.9 14.2 14.2" />
+    </svg>
+  );
+}
+
+function UnsupportedIcon(): React.ReactElement {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+      <line x1="12" x2="12" y1="9" y2="13" />
+      <line x1="12" x2="12.01" y1="17" y2="17" />
+    </svg>
+  );
+}
+
+function LoadingSpinner(): React.ReactElement {
+  return (
+    <svg
+      className="permission-prompt__spinner"
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  );
+}
+
+export default PermissionPrompt;

--- a/web/src/components/Recording/Recording.css
+++ b/web/src/components/Recording/Recording.css
@@ -1,0 +1,266 @@
+/**
+ * Recording Components Styles
+ *
+ * Styles for MicrophoneSelect, AudioLevelMeter, and PermissionPrompt components.
+ */
+
+/* =============================================================================
+   MicrophoneSelect
+   ============================================================================= */
+
+.microphone-select {
+  position: relative;
+  display: inline-block;
+  min-width: 200px;
+}
+
+.microphone-select__dropdown {
+  width: 100%;
+  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: #e5e7eb;
+  background-color: #1f2937;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%239ca3af' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-position: right 0.5rem center;
+  background-repeat: no-repeat;
+  background-size: 1.25rem;
+  border: 1px solid #374151;
+  border-radius: 0.375rem;
+  appearance: none;
+  cursor: pointer;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.microphone-select__dropdown:hover:not(:disabled) {
+  border-color: #4b5563;
+}
+
+.microphone-select__dropdown:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.microphone-select__dropdown:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.microphone-select--loading .microphone-select__dropdown,
+.microphone-select--error .microphone-select__dropdown,
+.microphone-select--empty .microphone-select__dropdown {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+/* =============================================================================
+   AudioLevelMeter
+   ============================================================================= */
+
+.audio-level-meter {
+  border-radius: 4px;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.audio-level-meter__level {
+  border-radius: 2px;
+}
+
+.audio-level-meter__peak {
+  border-radius: 1px;
+  box-shadow: 0 0 4px rgba(239, 68, 68, 0.5);
+}
+
+.audio-level-meter__segment {
+  border-radius: 2px;
+  transition: background-color 0.05s ease-out;
+}
+
+.audio-level-meter--vertical {
+  writing-mode: vertical-rl;
+}
+
+.audio-level-meter--segments {
+  background: transparent;
+}
+
+/* =============================================================================
+   PermissionPrompt
+   ============================================================================= */
+
+.permission-prompt {
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+/* Card variant */
+.permission-prompt--card {
+  background-color: #1f2937;
+  border: 1px solid #374151;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  max-width: 400px;
+  margin: 0 auto;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+/* Inline variant */
+.permission-prompt--inline {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  background-color: #1f2937;
+  border: 1px solid #374151;
+  border-radius: 0.5rem;
+}
+
+.permission-prompt--inline .permission-prompt__content {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.permission-prompt--inline .permission-prompt__icon {
+  margin: 0;
+}
+
+.permission-prompt--inline .permission-prompt__title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.permission-prompt--inline .permission-prompt__description {
+  flex: 1;
+  margin: 0;
+  min-width: 200px;
+}
+
+/* Minimal variant */
+.permission-prompt--minimal {
+  text-align: center;
+}
+
+.permission-prompt--minimal .permission-prompt__icon,
+.permission-prompt--minimal .permission-prompt__title {
+  display: none;
+}
+
+.permission-prompt--minimal .permission-prompt__description {
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+/* Content */
+.permission-prompt__content {
+  text-align: center;
+}
+
+.permission-prompt__icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 1rem;
+  border-radius: 50%;
+  background-color: #374151;
+  color: #60a5fa;
+}
+
+.permission-prompt__icon--error {
+  background-color: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
+}
+
+.permission-prompt__title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #f3f4f6;
+  margin: 0 0 0.5rem;
+}
+
+.permission-prompt__description {
+  font-size: 0.875rem;
+  color: #9ca3af;
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+.permission-prompt__instructions {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin: 0 0 1rem;
+  padding: 0.75rem;
+  background-color: #111827;
+  border-radius: 0.375rem;
+  text-align: left;
+  line-height: 1.5;
+}
+
+.permission-prompt__instructions strong {
+  color: #9ca3af;
+}
+
+.permission-prompt__error {
+  font-size: 0.75rem;
+  color: #f87171;
+  margin: 0 0 1rem;
+  padding: 0.5rem;
+  background-color: rgba(239, 68, 68, 0.1);
+  border-radius: 0.375rem;
+}
+
+.permission-prompt__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #3b82f6;
+  border: none;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.permission-prompt__button:hover:not(:disabled) {
+  background-color: #2563eb;
+}
+
+.permission-prompt__button:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.5);
+}
+
+.permission-prompt__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.permission-prompt__spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* State variants */
+.permission-prompt--unsupported .permission-prompt__icon {
+  background-color: rgba(245, 158, 11, 0.2);
+  color: #f59e0b;
+}
+
+.permission-prompt--denied {
+  border-color: rgba(239, 68, 68, 0.3);
+}

--- a/web/src/components/Recording/index.ts
+++ b/web/src/components/Recording/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Recording Components
+ *
+ * Components for microphone access and audio visualization.
+ *
+ * @module components/Recording
+ */
+
+export { MicrophoneSelect } from './MicrophoneSelect';
+export type { MicrophoneSelectProps } from './MicrophoneSelect';
+
+export { AudioLevelMeter } from './AudioLevelMeter';
+export type {
+  AudioLevelMeterProps,
+  LevelMeterStyle,
+  LevelMeterOrientation,
+} from './AudioLevelMeter';
+
+export { PermissionPrompt } from './PermissionPrompt';
+export type {
+  PermissionPromptProps,
+  PermissionPromptVariant,
+} from './PermissionPrompt';

--- a/web/src/lib/audio/index.ts
+++ b/web/src/lib/audio/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Audio Module
+ *
+ * Re-exports microphone access and audio analysis utilities.
+ *
+ * @module lib/audio
+ */
+
+export * from './microphone';
+export { default as microphone } from './microphone';

--- a/web/src/lib/audio/microphone.test.ts
+++ b/web/src/lib/audio/microphone.test.ts
@@ -1,0 +1,676 @@
+/**
+ * Microphone Module Tests
+ *
+ * Tests for microphone access, device enumeration, and audio analysis.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isMicrophoneSupported,
+  isDeviceEnumerationSupported,
+  isWebAudioSupported,
+  queryMicrophonePermission,
+  requestMicrophoneAccess,
+  stopMediaStream,
+  getMicrophoneDevices,
+  onDeviceChange,
+  createAudioAnalyzer,
+  getAudioLevel,
+  getPeakLevel,
+  createAudioLevelMonitor,
+} from './microphone';
+
+// =============================================================================
+// Mock Setup
+// =============================================================================
+
+// Mock MediaStream
+class MockMediaStreamTrack {
+  kind = 'audio';
+  label = 'Mock Microphone';
+  enabled = true;
+  muted = false;
+  readyState: 'live' | 'ended' = 'live';
+  stop = vi.fn(() => {
+    this.readyState = 'ended';
+  });
+}
+
+class MockMediaStream {
+  private tracks: MockMediaStreamTrack[] = [new MockMediaStreamTrack()];
+
+  getTracks() {
+    return this.tracks;
+  }
+
+  getAudioTracks() {
+    return this.tracks.filter((t) => t.kind === 'audio');
+  }
+}
+
+// Mock AnalyserNode
+class MockAnalyserNode {
+  fftSize = 2048;
+  frequencyBinCount = 1024;
+  smoothingTimeConstant = 0.8;
+  minDecibels = -100;
+  maxDecibels = -30;
+
+  getByteTimeDomainData(array: Uint8Array) {
+    // Fill with mid-level values (128 = silence, 0 or 255 = max amplitude)
+    for (let i = 0; i < array.length; i++) {
+      // Simulate some audio with moderate amplitude
+      array[i] = 128 + Math.sin(i * 0.1) * 50;
+    }
+  }
+
+  getByteFrequencyData(array: Uint8Array) {
+    for (let i = 0; i < array.length; i++) {
+      array[i] = Math.random() * 128;
+    }
+  }
+}
+
+// Mock AudioContext
+class MockAudioContext {
+  state: 'running' | 'suspended' | 'closed' = 'running';
+  sampleRate = 44100;
+
+  createAnalyser() {
+    return new MockAnalyserNode();
+  }
+
+  createMediaStreamSource() {
+    return {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+  }
+
+  resume = vi.fn(() => Promise.resolve());
+  close = vi.fn(() => Promise.resolve());
+}
+
+// Store original globals
+const originalNavigator = global.navigator;
+const originalWindow = global.window;
+
+// =============================================================================
+// Test Suites
+// =============================================================================
+
+describe('Microphone Module', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore navigator
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('Browser Support Detection', () => {
+    describe('isMicrophoneSupported', () => {
+      it('should return true when mediaDevices.getUserMedia is available', () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: {
+              getUserMedia: vi.fn(),
+            },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        expect(isMicrophoneSupported()).toBe(true);
+      });
+
+      it('should return false when navigator is undefined', () => {
+        Object.defineProperty(global, 'navigator', {
+          value: undefined,
+          writable: true,
+          configurable: true,
+        });
+
+        expect(isMicrophoneSupported()).toBe(false);
+      });
+
+      it('should return false when mediaDevices is undefined', () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {},
+          writable: true,
+          configurable: true,
+        });
+
+        expect(isMicrophoneSupported()).toBe(false);
+      });
+
+      it('should return false when getUserMedia is not a function', () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: {},
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        expect(isMicrophoneSupported()).toBe(false);
+      });
+    });
+
+    describe('isDeviceEnumerationSupported', () => {
+      it('should return true when enumerateDevices is available', () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: {
+              enumerateDevices: vi.fn(),
+            },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        expect(isDeviceEnumerationSupported()).toBe(true);
+      });
+
+      it('should return false when not available', () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {},
+          writable: true,
+          configurable: true,
+        });
+
+        expect(isDeviceEnumerationSupported()).toBe(false);
+      });
+    });
+
+    describe('isWebAudioSupported', () => {
+      it('should return true when AudioContext is available', () => {
+        Object.defineProperty(global, 'window', {
+          value: {
+            AudioContext: MockAudioContext,
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        expect(isWebAudioSupported()).toBe(true);
+      });
+
+      it('should return true when webkitAudioContext is available', () => {
+        Object.defineProperty(global, 'window', {
+          value: {
+            webkitAudioContext: MockAudioContext,
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        expect(isWebAudioSupported()).toBe(true);
+      });
+
+      it('should return false when neither is available', () => {
+        Object.defineProperty(global, 'window', {
+          value: {},
+          writable: true,
+          configurable: true,
+        });
+
+        expect(isWebAudioSupported()).toBe(false);
+      });
+    });
+  });
+
+  describe('Permission Handling', () => {
+    describe('queryMicrophonePermission', () => {
+      it('should return "unsupported" when microphone is not supported', async () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {},
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await queryMicrophonePermission();
+        expect(result).toBe('unsupported');
+      });
+
+      it('should query permissions API when available', async () => {
+        const mockQuery = vi.fn().mockResolvedValue({ state: 'granted' });
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: { getUserMedia: vi.fn() },
+            permissions: { query: mockQuery },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await queryMicrophonePermission();
+        expect(result).toBe('granted');
+        expect(mockQuery).toHaveBeenCalledWith({ name: 'microphone' });
+      });
+
+      it('should return "prompt" when permissions API is not available', async () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: { getUserMedia: vi.fn() },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await queryMicrophonePermission();
+        expect(result).toBe('prompt');
+      });
+
+      it('should return "prompt" when permissions query throws', async () => {
+        const mockQuery = vi.fn().mockRejectedValue(new Error('Not supported'));
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: { getUserMedia: vi.fn() },
+            permissions: { query: mockQuery },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await queryMicrophonePermission();
+        expect(result).toBe('prompt');
+      });
+    });
+
+    describe('requestMicrophoneAccess', () => {
+      it('should return error when microphone is not supported', async () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {},
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await requestMicrophoneAccess();
+        expect(result.success).toBe(false);
+        expect(result.stream).toBeNull();
+        expect(result.permissionState).toBe('unsupported');
+        expect(result.error).toContain('not supported');
+      });
+
+      it('should return stream on success', async () => {
+        const mockStream = new MockMediaStream();
+        const mockGetUserMedia = vi.fn().mockResolvedValue(mockStream);
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: { getUserMedia: mockGetUserMedia },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await requestMicrophoneAccess();
+
+        expect(result.success).toBe(true);
+        expect(result.stream).toBe(mockStream);
+        expect(result.error).toBeNull();
+        expect(result.permissionState).toBe('granted');
+        expect(mockGetUserMedia).toHaveBeenCalledWith({
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+          },
+          video: false,
+        });
+      });
+
+      it('should include device ID in constraints when specified', async () => {
+        const mockStream = new MockMediaStream();
+        const mockGetUserMedia = vi.fn().mockResolvedValue(mockStream);
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: { getUserMedia: mockGetUserMedia },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        await requestMicrophoneAccess('device-123');
+
+        expect(mockGetUserMedia).toHaveBeenCalledWith({
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+            deviceId: { exact: 'device-123' },
+          },
+          video: false,
+        });
+      });
+
+      it('should handle NotAllowedError', async () => {
+        const error = new Error('Permission denied');
+        error.name = 'NotAllowedError';
+        const mockGetUserMedia = vi.fn().mockRejectedValue(error);
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: { getUserMedia: mockGetUserMedia },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await requestMicrophoneAccess();
+
+        expect(result.success).toBe(false);
+        expect(result.stream).toBeNull();
+        expect(result.permissionState).toBe('denied');
+        expect(result.error).toContain('denied');
+      });
+
+      it('should handle NotFoundError', async () => {
+        const error = new Error('No microphone found');
+        error.name = 'NotFoundError';
+        const mockGetUserMedia = vi.fn().mockRejectedValue(error);
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: { getUserMedia: mockGetUserMedia },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await requestMicrophoneAccess();
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('No microphone');
+      });
+    });
+  });
+
+  describe('stopMediaStream', () => {
+    it('should stop all tracks in the stream', () => {
+      const mockStream = new MockMediaStream();
+      const tracks = mockStream.getTracks();
+
+      stopMediaStream(mockStream as unknown as MediaStream);
+
+      tracks.forEach((track) => {
+        expect(track.stop).toHaveBeenCalled();
+        expect(track.readyState).toBe('ended');
+      });
+    });
+
+    it('should handle null stream gracefully', () => {
+      expect(() => stopMediaStream(null)).not.toThrow();
+    });
+  });
+
+  describe('Device Enumeration', () => {
+    describe('getMicrophoneDevices', () => {
+      it('should return empty array when not supported', async () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {},
+          writable: true,
+          configurable: true,
+        });
+
+        const devices = await getMicrophoneDevices();
+        expect(devices).toEqual([]);
+      });
+
+      it('should return audio input devices', async () => {
+        const mockDevices = [
+          { kind: 'audioinput', deviceId: 'mic1', label: 'Microphone 1', groupId: 'g1' },
+          { kind: 'audioinput', deviceId: 'mic2', label: 'Microphone 2', groupId: 'g2' },
+          { kind: 'videoinput', deviceId: 'cam1', label: 'Camera 1', groupId: 'g3' },
+          { kind: 'audiooutput', deviceId: 'spk1', label: 'Speaker 1', groupId: 'g1' },
+        ];
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: {
+              enumerateDevices: vi.fn().mockResolvedValue(mockDevices),
+            },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const devices = await getMicrophoneDevices();
+
+        expect(devices).toHaveLength(2);
+        expect(devices[0].deviceId).toBe('mic1');
+        expect(devices[0].label).toBe('Microphone 1');
+        expect(devices[0].isDefault).toBe(true); // First device
+        expect(devices[1].deviceId).toBe('mic2');
+        expect(devices[1].isDefault).toBe(false);
+      });
+
+      it('should provide fallback labels when empty', async () => {
+        const mockDevices = [
+          { kind: 'audioinput', deviceId: 'mic1', label: '', groupId: 'g1' },
+          { kind: 'audioinput', deviceId: 'mic2', label: '', groupId: 'g2' },
+        ];
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: {
+              enumerateDevices: vi.fn().mockResolvedValue(mockDevices),
+            },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const devices = await getMicrophoneDevices();
+
+        expect(devices[0].label).toBe('Microphone 1');
+        expect(devices[1].label).toBe('Microphone 2');
+      });
+
+      it('should handle enumeration errors', async () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: {
+              enumerateDevices: vi.fn().mockRejectedValue(new Error('Enumeration failed')),
+            },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const devices = await getMicrophoneDevices();
+        expect(devices).toEqual([]);
+      });
+    });
+
+    describe('onDeviceChange', () => {
+      it('should add and remove event listener', () => {
+        const mockAddEventListener = vi.fn();
+        const mockRemoveEventListener = vi.fn();
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            mediaDevices: {
+              addEventListener: mockAddEventListener,
+              removeEventListener: mockRemoveEventListener,
+            },
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const callback = vi.fn();
+        const unsubscribe = onDeviceChange(callback);
+
+        expect(mockAddEventListener).toHaveBeenCalledWith('devicechange', expect.any(Function));
+
+        unsubscribe();
+
+        expect(mockRemoveEventListener).toHaveBeenCalledWith(
+          'devicechange',
+          expect.any(Function)
+        );
+      });
+
+      it('should return no-op when mediaDevices is not available', () => {
+        Object.defineProperty(global, 'navigator', {
+          value: {},
+          writable: true,
+          configurable: true,
+        });
+
+        const callback = vi.fn();
+        const unsubscribe = onDeviceChange(callback);
+
+        expect(() => unsubscribe()).not.toThrow();
+      });
+    });
+  });
+
+  describe('Audio Analysis', () => {
+    beforeEach(() => {
+      Object.defineProperty(global, 'window', {
+        value: {
+          AudioContext: MockAudioContext,
+        },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(global, 'window', {
+        value: originalWindow,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    describe('createAudioAnalyzer', () => {
+      it('should create analyzer with default options', () => {
+        const mockStream = new MockMediaStream();
+
+        const result = createAudioAnalyzer(mockStream as unknown as MediaStream);
+
+        expect(result.analyser).toBeDefined();
+        expect(result.audioContext).toBeDefined();
+        expect(result.source).toBeDefined();
+        expect(result.dispose).toBeDefined();
+        expect(result.source.connect).toHaveBeenCalledWith(result.analyser);
+      });
+
+      it('should apply custom options', () => {
+        const mockStream = new MockMediaStream();
+
+        const result = createAudioAnalyzer(mockStream as unknown as MediaStream, {
+          fftSize: 4096,
+          smoothingTimeConstant: 0.5,
+          minDecibels: -90,
+          maxDecibels: -20,
+        });
+
+        expect(result.analyser.fftSize).toBe(4096);
+        expect(result.analyser.smoothingTimeConstant).toBe(0.5);
+        expect(result.analyser.minDecibels).toBe(-90);
+        expect(result.analyser.maxDecibels).toBe(-20);
+      });
+
+      it('should clean up on dispose', () => {
+        const mockStream = new MockMediaStream();
+
+        const result = createAudioAnalyzer(mockStream as unknown as MediaStream);
+
+        result.dispose();
+
+        expect(result.source.disconnect).toHaveBeenCalled();
+        expect(result.audioContext.close).toHaveBeenCalled();
+      });
+    });
+
+    describe('getAudioLevel', () => {
+      it('should return normalized level between 0 and 1', () => {
+        const analyser = new MockAnalyserNode();
+
+        const level = getAudioLevel(analyser as unknown as AnalyserNode);
+
+        expect(level).toBeGreaterThanOrEqual(0);
+        expect(level).toBeLessThanOrEqual(1);
+      });
+    });
+
+    describe('getPeakLevel', () => {
+      it('should return normalized peak between 0 and 1', () => {
+        const analyser = new MockAnalyserNode();
+
+        const peak = getPeakLevel(analyser as unknown as AnalyserNode);
+
+        expect(peak).toBeGreaterThanOrEqual(0);
+        expect(peak).toBeLessThanOrEqual(1);
+      });
+    });
+
+    describe('createAudioLevelMonitor', () => {
+      it('should create monitor with default options', () => {
+        const analyser = new MockAnalyserNode();
+
+        const monitor = createAudioLevelMonitor(analyser as unknown as AnalyserNode);
+
+        expect(monitor.start).toBeDefined();
+        expect(monitor.stop).toBeDefined();
+        expect(monitor.getLevel).toBeDefined();
+        expect(monitor.getPeak).toBeDefined();
+        expect(monitor.resetPeak).toBeDefined();
+        expect(monitor.isActive).toBeDefined();
+        expect(monitor.dispose).toBeDefined();
+      });
+
+      it('should start and stop monitoring', () => {
+        const analyser = new MockAnalyserNode();
+
+        const monitor = createAudioLevelMonitor(analyser as unknown as AnalyserNode);
+
+        expect(monitor.isActive()).toBe(false);
+
+        monitor.start();
+        expect(monitor.isActive()).toBe(true);
+
+        monitor.stop();
+        expect(monitor.isActive()).toBe(false);
+      });
+
+      it('should reset peak level', () => {
+        const analyser = new MockAnalyserNode();
+
+        const monitor = createAudioLevelMonitor(analyser as unknown as AnalyserNode);
+
+        // Simulate some activity
+        monitor.start();
+        monitor.stop();
+
+        monitor.resetPeak();
+        expect(monitor.getPeak()).toBe(0);
+      });
+
+      it('should dispose properly', () => {
+        const analyser = new MockAnalyserNode();
+
+        const monitor = createAudioLevelMonitor(analyser as unknown as AnalyserNode);
+        monitor.start();
+        monitor.dispose();
+
+        expect(monitor.isActive()).toBe(false);
+        expect(monitor.getLevel()).toBe(0);
+        expect(monitor.getPeak()).toBe(0);
+      });
+    });
+  });
+});

--- a/web/src/lib/audio/microphone.ts
+++ b/web/src/lib/audio/microphone.ts
@@ -1,0 +1,650 @@
+/**
+ * Microphone Access and Audio Analysis Module
+ *
+ * Provides utilities for requesting microphone access, enumerating audio devices,
+ * and creating audio analyzers for visualization.
+ *
+ * @module lib/audio/microphone
+ */
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[Microphone] ${message}`, ...args);
+  }
+};
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Permission state for microphone access
+ */
+export type MicrophonePermissionState = 'granted' | 'denied' | 'prompt' | 'unsupported';
+
+/**
+ * Result from requesting microphone access
+ */
+export interface MicrophoneAccessResult {
+  /** Whether access was granted */
+  success: boolean;
+  /** The media stream if access was granted */
+  stream: MediaStream | null;
+  /** Error message if access failed */
+  error: string | null;
+  /** The permission state */
+  permissionState: MicrophonePermissionState;
+}
+
+/**
+ * Audio device information
+ */
+export interface AudioDeviceInfo {
+  /** Unique device identifier */
+  deviceId: string;
+  /** Human-readable device label */
+  label: string;
+  /** Device group ID (for matching input/output pairs) */
+  groupId: string;
+  /** Whether this is the default device */
+  isDefault: boolean;
+}
+
+/**
+ * Options for creating an audio analyzer
+ */
+export interface AnalyzerOptions {
+  /** FFT size for frequency analysis (must be power of 2, default: 2048) */
+  fftSize?: number;
+  /** Smoothing time constant for frequency data (0-1, default: 0.8) */
+  smoothingTimeConstant?: number;
+  /** Minimum decibels for frequency data (default: -100) */
+  minDecibels?: number;
+  /** Maximum decibels for frequency data (default: -30) */
+  maxDecibels?: number;
+}
+
+/**
+ * Audio analyzer result with both the analyzer node and supporting objects
+ */
+export interface AudioAnalyzerResult {
+  /** The AnalyserNode for getting audio data */
+  analyser: AnalyserNode;
+  /** The AudioContext used */
+  audioContext: AudioContext;
+  /** The MediaStreamAudioSourceNode */
+  source: MediaStreamAudioSourceNode;
+  /** Function to clean up resources */
+  dispose: () => void;
+}
+
+/**
+ * Callback for audio level changes
+ */
+export type AudioLevelCallback = (level: number, peak: number) => void;
+
+/**
+ * Options for the audio level monitor
+ */
+export interface AudioLevelMonitorOptions {
+  /** How often to update the level in milliseconds (default: 50) */
+  updateInterval?: number;
+  /** Smoothing factor for level changes (0-1, default: 0.8) */
+  smoothing?: number;
+  /** Callback for level updates */
+  onLevel?: AudioLevelCallback;
+}
+
+/**
+ * Audio level monitor that continuously reports audio levels
+ */
+export interface AudioLevelMonitor {
+  /** Start monitoring */
+  start: () => void;
+  /** Stop monitoring */
+  stop: () => void;
+  /** Get the current level (0-1) */
+  getLevel: () => number;
+  /** Get the peak level (0-1) */
+  getPeak: () => number;
+  /** Reset peak level */
+  resetPeak: () => void;
+  /** Check if monitoring is active */
+  isActive: () => boolean;
+  /** Dispose of resources */
+  dispose: () => void;
+}
+
+// =============================================================================
+// Browser Compatibility
+// =============================================================================
+
+/**
+ * Check if microphone access is supported in the current browser
+ */
+export function isMicrophoneSupported(): boolean {
+  const supported =
+    typeof navigator !== 'undefined' &&
+    navigator.mediaDevices !== undefined &&
+    typeof navigator.mediaDevices.getUserMedia === 'function';
+
+  log('Microphone support check:', supported);
+  return supported;
+}
+
+/**
+ * Check if device enumeration is supported
+ */
+export function isDeviceEnumerationSupported(): boolean {
+  const supported =
+    typeof navigator !== 'undefined' &&
+    navigator.mediaDevices !== undefined &&
+    typeof navigator.mediaDevices.enumerateDevices === 'function';
+
+  log('Device enumeration support check:', supported);
+  return supported;
+}
+
+/**
+ * Check if Web Audio API is supported
+ */
+export function isWebAudioSupported(): boolean {
+  const supported =
+    typeof window !== 'undefined' &&
+    (window.AudioContext !== undefined ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).webkitAudioContext !== undefined);
+
+  log('Web Audio API support check:', supported);
+  return supported;
+}
+
+// =============================================================================
+// Permission Handling
+// =============================================================================
+
+/**
+ * Query the current microphone permission state
+ *
+ * @returns The current permission state
+ */
+export async function queryMicrophonePermission(): Promise<MicrophonePermissionState> {
+  log('Querying microphone permission...');
+
+  if (!isMicrophoneSupported()) {
+    log('Microphone not supported');
+    return 'unsupported';
+  }
+
+  try {
+    // Check if the Permissions API is available
+    if (navigator.permissions && navigator.permissions.query) {
+      const result = await navigator.permissions.query({
+        name: 'microphone' as PermissionName,
+      });
+
+      log('Permission state:', result.state);
+      return result.state as MicrophonePermissionState;
+    }
+
+    // Permissions API not available, return 'prompt' as we don't know
+    log('Permissions API not available, returning prompt');
+    return 'prompt';
+  } catch (error) {
+    // Some browsers throw for microphone permission query
+    log('Permission query failed:', error);
+    return 'prompt';
+  }
+}
+
+/**
+ * Request microphone access
+ *
+ * @param deviceId - Optional specific device ID to request
+ * @returns Result object with stream or error information
+ */
+export async function requestMicrophoneAccess(
+  deviceId?: string
+): Promise<MicrophoneAccessResult> {
+  log('Requesting microphone access...', deviceId ? `Device: ${deviceId}` : 'Default device');
+
+  if (!isMicrophoneSupported()) {
+    log('Microphone not supported in this browser');
+    return {
+      success: false,
+      stream: null,
+      error: 'Microphone access is not supported in this browser. Please use a modern browser like Chrome, Firefox, or Safari.',
+      permissionState: 'unsupported',
+    };
+  }
+
+  try {
+    // Build audio constraints
+    const audioConstraints: MediaTrackConstraints = {
+      // Request echo cancellation and noise suppression for better recording
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    };
+
+    // Add device ID if specified
+    if (deviceId) {
+      audioConstraints.deviceId = { exact: deviceId };
+    }
+
+    log('Requesting getUserMedia with constraints:', audioConstraints);
+
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: audioConstraints,
+      video: false,
+    });
+
+    log('Microphone access granted, tracks:', stream.getAudioTracks().length);
+
+    // Log track details
+    stream.getAudioTracks().forEach((track, index) => {
+      log(`Track ${index}:`, {
+        label: track.label,
+        enabled: track.enabled,
+        muted: track.muted,
+        readyState: track.readyState,
+      });
+    });
+
+    return {
+      success: true,
+      stream,
+      error: null,
+      permissionState: 'granted',
+    };
+  } catch (error) {
+    const errorMessage = getErrorMessage(error);
+    const permissionState = getPermissionStateFromError(error);
+
+    log('Microphone access failed:', errorMessage, 'State:', permissionState);
+
+    return {
+      success: false,
+      stream: null,
+      error: errorMessage,
+      permissionState,
+    };
+  }
+}
+
+/**
+ * Stop all tracks in a media stream and release resources
+ *
+ * @param stream - The media stream to stop
+ */
+export function stopMediaStream(stream: MediaStream | null): void {
+  if (!stream) return;
+
+  log('Stopping media stream...');
+
+  stream.getTracks().forEach((track) => {
+    log('Stopping track:', track.label);
+    track.stop();
+  });
+
+  log('Media stream stopped');
+}
+
+// =============================================================================
+// Device Enumeration
+// =============================================================================
+
+/**
+ * Get a list of available audio input devices (microphones)
+ *
+ * Note: Device labels may be empty until permission is granted.
+ * Call requestMicrophoneAccess first to get device labels.
+ *
+ * @returns List of audio input devices
+ */
+export async function getMicrophoneDevices(): Promise<AudioDeviceInfo[]> {
+  log('Getting microphone devices...');
+
+  if (!isDeviceEnumerationSupported()) {
+    log('Device enumeration not supported');
+    return [];
+  }
+
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+
+    // Filter to audio input devices
+    const audioInputs = devices
+      .filter((device) => device.kind === 'audioinput')
+      .map((device, index) => ({
+        deviceId: device.deviceId,
+        label: device.label || `Microphone ${index + 1}`,
+        groupId: device.groupId,
+        isDefault: device.deviceId === 'default' || index === 0,
+      }));
+
+    log('Found', audioInputs.length, 'microphone devices:', audioInputs);
+
+    return audioInputs;
+  } catch (error) {
+    log('Failed to enumerate devices:', error);
+    return [];
+  }
+}
+
+/**
+ * Set up a listener for device changes (plugging in/removing microphones)
+ *
+ * @param callback - Function to call when devices change
+ * @returns Function to remove the listener
+ */
+export function onDeviceChange(callback: () => void): () => void {
+  log('Setting up device change listener');
+
+  if (!navigator.mediaDevices) {
+    log('mediaDevices not available');
+    return () => {};
+  }
+
+  const handler = () => {
+    log('Device change detected');
+    callback();
+  };
+
+  navigator.mediaDevices.addEventListener('devicechange', handler);
+
+  return () => {
+    log('Removing device change listener');
+    navigator.mediaDevices.removeEventListener('devicechange', handler);
+  };
+}
+
+// =============================================================================
+// Audio Analysis
+// =============================================================================
+
+/**
+ * Create an audio analyzer node for visualizing audio levels
+ *
+ * @param stream - The media stream to analyze
+ * @param options - Analyzer configuration options
+ * @returns The analyzer result with cleanup function
+ */
+export function createAudioAnalyzer(
+  stream: MediaStream,
+  options: AnalyzerOptions = {}
+): AudioAnalyzerResult {
+  log('Creating audio analyzer...');
+
+  const {
+    fftSize = 2048,
+    smoothingTimeConstant = 0.8,
+    minDecibels = -100,
+    maxDecibels = -30,
+  } = options;
+
+  // Create audio context
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
+  const audioContext = new AudioContextClass();
+
+  log('AudioContext created, sample rate:', audioContext.sampleRate);
+
+  // Create source from stream
+  const source = audioContext.createMediaStreamSource(stream);
+  log('MediaStreamAudioSourceNode created');
+
+  // Create analyzer node
+  const analyser = audioContext.createAnalyser();
+  analyser.fftSize = fftSize;
+  analyser.smoothingTimeConstant = smoothingTimeConstant;
+  analyser.minDecibels = minDecibels;
+  analyser.maxDecibels = maxDecibels;
+
+  log('AnalyserNode created with config:', {
+    fftSize: analyser.fftSize,
+    frequencyBinCount: analyser.frequencyBinCount,
+    smoothingTimeConstant: analyser.smoothingTimeConstant,
+  });
+
+  // Connect source to analyzer
+  source.connect(analyser);
+  log('Source connected to analyzer');
+
+  // Cleanup function
+  const dispose = () => {
+    log('Disposing audio analyzer...');
+    try {
+      source.disconnect();
+    } catch {
+      // Already disconnected
+    }
+    if (audioContext.state !== 'closed') {
+      audioContext.close().catch((e) => log('Error closing AudioContext:', e));
+    }
+    log('Audio analyzer disposed');
+  };
+
+  return {
+    analyser,
+    audioContext,
+    source,
+    dispose,
+  };
+}
+
+/**
+ * Get the current audio level from an analyzer (0-1)
+ *
+ * @param analyser - The AnalyserNode to read from
+ * @returns Normalized audio level (0-1)
+ */
+export function getAudioLevel(analyser: AnalyserNode): number {
+  const dataArray = new Uint8Array(analyser.frequencyBinCount);
+  analyser.getByteTimeDomainData(dataArray);
+
+  // Calculate RMS (Root Mean Square) for a more accurate level
+  let sum = 0;
+  for (let i = 0; i < dataArray.length; i++) {
+    // Convert from 0-255 range to -1 to 1 range
+    const value = (dataArray[i] - 128) / 128;
+    sum += value * value;
+  }
+
+  const rms = Math.sqrt(sum / dataArray.length);
+
+  // Scale RMS to 0-1 range (RMS of full-scale sine wave is ~0.707)
+  const level = Math.min(1, rms * 1.414);
+
+  return level;
+}
+
+/**
+ * Get the peak audio level from an analyzer (0-1)
+ *
+ * @param analyser - The AnalyserNode to read from
+ * @returns Normalized peak level (0-1)
+ */
+export function getPeakLevel(analyser: AnalyserNode): number {
+  const dataArray = new Uint8Array(analyser.frequencyBinCount);
+  analyser.getByteTimeDomainData(dataArray);
+
+  // Find the peak value
+  let peak = 0;
+  for (let i = 0; i < dataArray.length; i++) {
+    // Convert to absolute value in 0-1 range
+    const value = Math.abs(dataArray[i] - 128) / 128;
+    if (value > peak) {
+      peak = value;
+    }
+  }
+
+  return peak;
+}
+
+/**
+ * Create an audio level monitor that continuously reports audio levels
+ *
+ * @param analyser - The AnalyserNode to monitor
+ * @param options - Monitor options
+ * @returns Audio level monitor object
+ */
+export function createAudioLevelMonitor(
+  analyser: AnalyserNode,
+  options: AudioLevelMonitorOptions = {}
+): AudioLevelMonitor {
+  log('Creating audio level monitor...');
+
+  const { updateInterval = 50, smoothing = 0.8, onLevel } = options;
+
+  let animationFrameId: number | null = null;
+  let lastUpdateTime = 0;
+  let currentLevel = 0;
+  let peakLevel = 0;
+  let active = false;
+
+  const update = (timestamp: number) => {
+    if (!active) return;
+
+    // Throttle updates to the configured interval
+    if (timestamp - lastUpdateTime >= updateInterval) {
+      const rawLevel = getAudioLevel(analyser);
+      const rawPeak = getPeakLevel(analyser);
+
+      // Apply smoothing
+      currentLevel = currentLevel * smoothing + rawLevel * (1 - smoothing);
+
+      // Update peak (with slow decay)
+      if (rawPeak > peakLevel) {
+        peakLevel = rawPeak;
+      } else {
+        peakLevel = peakLevel * 0.995; // Slow decay
+      }
+
+      // Call callback
+      onLevel?.(currentLevel, peakLevel);
+
+      lastUpdateTime = timestamp;
+    }
+
+    animationFrameId = requestAnimationFrame(update);
+  };
+
+  const monitor: AudioLevelMonitor = {
+    start: () => {
+      if (active) return;
+      log('Starting audio level monitor');
+      active = true;
+      lastUpdateTime = 0;
+      animationFrameId = requestAnimationFrame(update);
+    },
+
+    stop: () => {
+      if (!active) return;
+      log('Stopping audio level monitor');
+      active = false;
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
+        animationFrameId = null;
+      }
+    },
+
+    getLevel: () => currentLevel,
+
+    getPeak: () => peakLevel,
+
+    resetPeak: () => {
+      peakLevel = 0;
+      log('Peak level reset');
+    },
+
+    isActive: () => active,
+
+    dispose: () => {
+      monitor.stop();
+      currentLevel = 0;
+      peakLevel = 0;
+      log('Audio level monitor disposed');
+    },
+  };
+
+  return monitor;
+}
+
+// =============================================================================
+// Error Handling Helpers
+// =============================================================================
+
+/**
+ * Get a user-friendly error message from a getUserMedia error
+ */
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const name = error.name;
+    const message = error.message;
+
+    switch (name) {
+      case 'NotAllowedError':
+      case 'PermissionDeniedError':
+        return 'Microphone access was denied. Please allow microphone access in your browser settings and try again.';
+
+      case 'NotFoundError':
+      case 'DevicesNotFoundError':
+        return 'No microphone was found. Please connect a microphone and try again.';
+
+      case 'NotReadableError':
+      case 'TrackStartError':
+        return 'Could not access the microphone. It may be in use by another application.';
+
+      case 'OverconstrainedError':
+        return 'The requested microphone settings are not supported.';
+
+      case 'SecurityError':
+        return 'Microphone access is not allowed in this context. Please ensure you are using HTTPS.';
+
+      case 'AbortError':
+        return 'Microphone access was cancelled.';
+
+      default:
+        return message || 'An unknown error occurred while accessing the microphone.';
+    }
+  }
+
+  return 'An unknown error occurred while accessing the microphone.';
+}
+
+/**
+ * Determine permission state from an error
+ */
+function getPermissionStateFromError(error: unknown): MicrophonePermissionState {
+  if (error instanceof Error) {
+    const name = error.name;
+
+    if (name === 'NotAllowedError' || name === 'PermissionDeniedError') {
+      return 'denied';
+    }
+  }
+
+  return 'prompt';
+}
+
+// =============================================================================
+// Exports
+// =============================================================================
+
+export default {
+  isMicrophoneSupported,
+  isDeviceEnumerationSupported,
+  isWebAudioSupported,
+  queryMicrophonePermission,
+  requestMicrophoneAccess,
+  stopMediaStream,
+  getMicrophoneDevices,
+  onDeviceChange,
+  createAudioAnalyzer,
+  getAudioLevel,
+  getPeakLevel,
+  createAudioLevelMonitor,
+};

--- a/web/src/lib/index.ts
+++ b/web/src/lib/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from './phonetics/index.ts'
+export * from './audio/index.ts'


### PR DESCRIPTION
## Summary
Implements microphone access with permission handling and audio visualization components for the recording feature.

## Changes
- `web/src/lib/audio/microphone.ts` - Core audio utilities for microphone access, device enumeration, and Web Audio API visualization
- `web/src/lib/audio/microphone.test.ts` - Comprehensive tests for all audio utilities
- `web/src/components/Recording/MicrophoneSelect.tsx` - Device dropdown component with auto-refresh on device changes
- `web/src/components/Recording/AudioLevelMeter.tsx` - Real-time level display with bar/gradient/segments styles
- `web/src/components/Recording/PermissionPrompt.tsx` - Permission request UI with browser-specific instructions
- `web/src/components/Recording/Recording.css` - Styles for recording components
- `web/src/components/Recording/index.ts` - Component exports
- `web/src/lib/index.ts` - Added audio module export

## Features
- **Microphone Access**: `requestMicrophoneAccess()` with proper permission handling
- **Device Enumeration**: `getMicrophoneDevices()` with device change detection
- **Audio Analysis**: `createAudioAnalyzer()` and `createAudioLevelMonitor()` for visualization
- **Permission Handling**: Browser-specific instructions when access is denied
- **Device Selection**: Auto-refresh when microphones are plugged/unplugged
- **Level Meter**: Three visual styles (bar, gradient, segments) with peak hold

## Browser Support
- Chrome, Firefox, Safari, Edge
- Graceful degradation for unsupported browsers

## Testing
- [x] Unit tests pass (`npm test`)
- [x] Linter passes (`npm run lint`)
- [x] 747 tests passing

## Notes
- Components use the established patterns from existing codebase
- All utilities include debug logging in development mode
- CSS follows existing project conventions

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)