### PR TITLE
feat(GH-12): Implement stress-to-rhythm mapping

### DIFF
--- a/web/src/lib/melody/index.ts
+++ b/web/src/lib/melody/index.ts
@@ -6,3 +6,4 @@
 
 export * from './types';
 export * from './abcGenerator';
+export * from './rhythm';

--- a/web/src/lib/melody/rhythm.test.ts
+++ b/web/src/lib/melody/rhythm.test.ts
@@ -1,0 +1,843 @@
+/**
+ * Tests for Stress-to-Rhythm Mapping Module
+ *
+ * Tests all rhythm mapping functions including:
+ * - stressToNoteDuration
+ * - mapLineToRhythm
+ * - insertBreathRests
+ * - fitToMeasure
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  stressToNoteDuration,
+  mapLineToRhythm,
+  insertBreathRests,
+  fitToMeasure,
+  calculateTotalDuration,
+  countMeasures,
+  validateRhythm,
+  createRhythmContext,
+  getStrongBeats,
+  isStrongBeat,
+  durationsToBeats,
+  createIambicRhythm,
+  createTrochaicRhythm,
+  alignStressToBeats,
+  type RhythmContext,
+  type NoteDuration,
+  type FitToMeasureOptions,
+} from './rhythm';
+import type { TimeSignature } from './types';
+
+// =============================================================================
+// stressToNoteDuration Tests
+// =============================================================================
+
+describe('stressToNoteDuration', () => {
+  const defaultContext: RhythmContext = {
+    timeSignature: '4/4',
+    tempo: 100,
+    position: 0,
+  };
+
+  describe('basic stress level mapping', () => {
+    it('should return longer duration for primary stress (1)', () => {
+      const duration = stressToNoteDuration('1', defaultContext);
+      expect(duration).toBeGreaterThanOrEqual(1.0);
+    });
+
+    it('should return shorter duration for unstressed (0)', () => {
+      const duration = stressToNoteDuration('0', defaultContext);
+      expect(duration).toBeLessThanOrEqual(0.5);
+    });
+
+    it('should return medium duration for secondary stress (2)', () => {
+      const duration = stressToNoteDuration('2', defaultContext);
+      expect(duration).toBeGreaterThan(0.5);
+      expect(duration).toBeLessThanOrEqual(1.0);
+    });
+
+    it('should make stressed syllables longer than unstressed', () => {
+      const stressed = stressToNoteDuration('1', defaultContext);
+      const unstressed = stressToNoteDuration('0', defaultContext);
+      expect(stressed).toBeGreaterThan(unstressed);
+    });
+
+    it('should make secondary stress longer than unstressed', () => {
+      const secondary = stressToNoteDuration('2', defaultContext);
+      const unstressed = stressToNoteDuration('0', defaultContext);
+      expect(secondary).toBeGreaterThan(unstressed);
+    });
+  });
+
+  describe('time signature handling', () => {
+    it('should handle 4/4 time', () => {
+      const context: RhythmContext = { timeSignature: '4/4', tempo: 100, position: 0 };
+      const duration = stressToNoteDuration('1', context);
+      expect(duration).toBeGreaterThan(0);
+    });
+
+    it('should handle 3/4 time', () => {
+      const context: RhythmContext = { timeSignature: '3/4', tempo: 100, position: 0 };
+      const duration = stressToNoteDuration('1', context);
+      expect(duration).toBeGreaterThan(0);
+    });
+
+    it('should handle 6/8 time with shorter durations', () => {
+      const context44: RhythmContext = { timeSignature: '4/4', tempo: 100, position: 0 };
+      const context68: RhythmContext = { timeSignature: '6/8', tempo: 100, position: 0 };
+      const duration44 = stressToNoteDuration('0', context44);
+      const duration68 = stressToNoteDuration('0', context68);
+      // 6/8 should have shorter note values due to compound meter
+      expect(duration68).toBeLessThanOrEqual(duration44);
+    });
+
+    it('should handle 2/4 time', () => {
+      const context: RhythmContext = { timeSignature: '2/4', tempo: 100, position: 0 };
+      const duration = stressToNoteDuration('1', context);
+      expect(duration).toBeGreaterThan(0);
+    });
+  });
+
+  describe('strong beat positioning', () => {
+    it('should potentially lengthen stressed syllables on strong beats', () => {
+      const onStrongBeat: RhythmContext = { timeSignature: '4/4', tempo: 100, position: 0 };
+      const onWeakBeat: RhythmContext = { timeSignature: '4/4', tempo: 100, position: 1 };
+      const strongBeatDuration = stressToNoteDuration('1', onStrongBeat);
+      const weakBeatDuration = stressToNoteDuration('1', onWeakBeat);
+      // Strong beat may allow longer duration
+      expect(strongBeatDuration).toBeGreaterThanOrEqual(weakBeatDuration);
+    });
+  });
+
+  describe('tempo adjustments', () => {
+    it('should handle fast tempo', () => {
+      const fastContext: RhythmContext = { timeSignature: '4/4', tempo: 150, position: 0 };
+      const normalContext: RhythmContext = { timeSignature: '4/4', tempo: 100, position: 0 };
+      const fastDuration = stressToNoteDuration('1', fastContext);
+      const normalDuration = stressToNoteDuration('1', normalContext);
+      // Fast tempo may result in slightly shorter notes
+      expect(fastDuration).toBeLessThanOrEqual(normalDuration);
+    });
+
+    it('should handle slow tempo', () => {
+      const slowContext: RhythmContext = { timeSignature: '4/4', tempo: 50, position: 0 };
+      const normalContext: RhythmContext = { timeSignature: '4/4', tempo: 100, position: 0 };
+      const slowDuration = stressToNoteDuration('1', slowContext);
+      const normalDuration = stressToNoteDuration('1', normalContext);
+      // Slow tempo may allow slightly longer notes
+      expect(slowDuration).toBeGreaterThanOrEqual(normalDuration);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle invalid stress level by defaulting to unstressed', () => {
+      // @ts-expect-error - testing invalid input
+      const duration = stressToNoteDuration('3', defaultContext);
+      expect(duration).toBe(0.5); // Should default to unstressed
+    });
+  });
+});
+
+// =============================================================================
+// mapLineToRhythm Tests
+// =============================================================================
+
+describe('mapLineToRhythm', () => {
+  describe('basic pattern mapping', () => {
+    it('should map empty pattern to empty array', () => {
+      const result = mapLineToRhythm('', '4/4');
+      expect(result).toEqual([]);
+    });
+
+    it('should map single stressed syllable', () => {
+      const result = mapLineToRhythm('1', '4/4');
+      expect(result).toHaveLength(1);
+      expect(result[0].syllableIndex).toBe(0);
+      expect(result[0].isRest).toBe(false);
+      expect(result[0].beats).toBeGreaterThan(0);
+    });
+
+    it('should map single unstressed syllable', () => {
+      const result = mapLineToRhythm('0', '4/4');
+      expect(result).toHaveLength(1);
+      expect(result[0].syllableIndex).toBe(0);
+      expect(result[0].beats).toBeGreaterThan(0);
+    });
+
+    it('should correctly index multiple syllables', () => {
+      const result = mapLineToRhythm('0101', '4/4');
+      expect(result).toHaveLength(4);
+      expect(result[0].syllableIndex).toBe(0);
+      expect(result[1].syllableIndex).toBe(1);
+      expect(result[2].syllableIndex).toBe(2);
+      expect(result[3].syllableIndex).toBe(3);
+    });
+  });
+
+  describe('iambic patterns', () => {
+    it('should create alternating short-long pattern for iambic', () => {
+      const result = mapLineToRhythm('01010101', '4/4');
+      expect(result).toHaveLength(8);
+
+      // Check that stressed syllables are longer
+      for (let i = 0; i < result.length; i++) {
+        if (i % 2 === 0) {
+          // Unstressed positions
+          expect(result[i].beats).toBeLessThanOrEqual(result[i + 1]?.beats ?? Infinity);
+        }
+      }
+    });
+
+    it('should handle iambic tetrameter (8 syllables)', () => {
+      const result = mapLineToRhythm('01010101', '4/4');
+      expect(result).toHaveLength(8);
+      const totalBeats = calculateTotalDuration(result);
+      expect(totalBeats).toBeGreaterThan(0);
+    });
+
+    it('should handle iambic pentameter (10 syllables)', () => {
+      const result = mapLineToRhythm('0101010101', '4/4');
+      expect(result).toHaveLength(10);
+    });
+  });
+
+  describe('trochaic patterns', () => {
+    it('should create alternating long-short pattern for trochaic', () => {
+      const result = mapLineToRhythm('10101010', '4/4');
+      expect(result).toHaveLength(8);
+
+      // Check pattern: long-short-long-short
+      for (let i = 0; i < result.length - 1; i += 2) {
+        expect(result[i].beats).toBeGreaterThanOrEqual(result[i + 1].beats);
+      }
+    });
+  });
+
+  describe('anapestic patterns', () => {
+    it('should handle anapestic pattern (001)', () => {
+      const result = mapLineToRhythm('001001001', '4/4');
+      expect(result).toHaveLength(9);
+      // Every third note should be longer
+      expect(result[2].beats).toBeGreaterThan(result[0].beats);
+      expect(result[5].beats).toBeGreaterThan(result[3].beats);
+    });
+  });
+
+  describe('dactylic patterns', () => {
+    it('should handle dactylic pattern (100)', () => {
+      const result = mapLineToRhythm('100100100', '4/4');
+      expect(result).toHaveLength(9);
+      // First of every three should be longer
+      expect(result[0].beats).toBeGreaterThan(result[1].beats);
+      expect(result[3].beats).toBeGreaterThan(result[4].beats);
+    });
+  });
+
+  describe('time signature variations', () => {
+    it('should work with 3/4 time', () => {
+      const result = mapLineToRhythm('010101', '3/4');
+      expect(result).toHaveLength(6);
+      result.forEach((d) => {
+        expect(d.isRest).toBe(false);
+        expect(d.beats).toBeGreaterThan(0);
+      });
+    });
+
+    it('should work with 6/8 time', () => {
+      const result = mapLineToRhythm('010101', '6/8');
+      expect(result).toHaveLength(6);
+    });
+
+    it('should work with 2/4 time', () => {
+      const result = mapLineToRhythm('0101', '2/4');
+      expect(result).toHaveLength(4);
+    });
+  });
+
+  describe('tempo parameter', () => {
+    it('should accept custom tempo', () => {
+      const slow = mapLineToRhythm('01', '4/4', 60);
+      const fast = mapLineToRhythm('01', '4/4', 140);
+      expect(slow).toHaveLength(2);
+      expect(fast).toHaveLength(2);
+    });
+  });
+
+  describe('secondary stress', () => {
+    it('should handle secondary stress (2) appropriately', () => {
+      const result = mapLineToRhythm('0210', '4/4');
+      expect(result).toHaveLength(4);
+      // Secondary stress should be between unstressed and primary
+      expect(result[1].beats).toBeGreaterThan(result[0].beats);
+      expect(result[1].beats).toBeLessThanOrEqual(result[2]?.beats ?? Infinity);
+    });
+  });
+});
+
+// =============================================================================
+// insertBreathRests Tests
+// =============================================================================
+
+describe('insertBreathRests', () => {
+  const sampleDurations: NoteDuration[] = [
+    { syllableIndex: 0, beats: 0.5, isRest: false },
+    { syllableIndex: 1, beats: 1.0, isRest: false },
+    { syllableIndex: 2, beats: 0.5, isRest: false },
+    { syllableIndex: 3, beats: 1.0, isRest: false },
+    { syllableIndex: 4, beats: 0.5, isRest: false },
+    { syllableIndex: 5, beats: 1.0, isRest: false },
+  ];
+
+  describe('basic rest insertion', () => {
+    it('should return empty array for empty input', () => {
+      const result = insertBreathRests([], [1, 2]);
+      expect(result).toEqual([]);
+    });
+
+    it('should return original array when no breath points', () => {
+      const result = insertBreathRests(sampleDurations, []);
+      expect(result).toHaveLength(sampleDurations.length);
+    });
+
+    it('should insert rest after specified position', () => {
+      const result = insertBreathRests(sampleDurations, [2]);
+      expect(result).toHaveLength(sampleDurations.length + 1);
+      expect(result[3].isRest).toBe(true);
+      expect(result[3].syllableIndex).toBe(-1);
+    });
+
+    it('should insert multiple rests', () => {
+      const result = insertBreathRests(sampleDurations, [1, 4]);
+      expect(result).toHaveLength(sampleDurations.length + 2);
+    });
+  });
+
+  describe('rest properties', () => {
+    it('should create rests with default duration of 0.5', () => {
+      const result = insertBreathRests(sampleDurations, [2]);
+      const rest = result.find((d) => d.isRest);
+      expect(rest?.beats).toBe(0.5);
+    });
+
+    it('should use custom rest duration', () => {
+      const result = insertBreathRests(sampleDurations, [2], 1.0);
+      const rest = result.find((d) => d.isRest);
+      expect(rest?.beats).toBe(1.0);
+    });
+
+    it('should mark rests with syllableIndex -1', () => {
+      const result = insertBreathRests(sampleDurations, [2]);
+      const rest = result.find((d) => d.isRest);
+      expect(rest?.syllableIndex).toBe(-1);
+    });
+  });
+
+  describe('order preservation', () => {
+    it('should preserve order of original notes', () => {
+      const result = insertBreathRests(sampleDurations, [2]);
+      const notes = result.filter((d) => !d.isRest);
+      expect(notes).toHaveLength(sampleDurations.length);
+      notes.forEach((note, i) => {
+        expect(note.syllableIndex).toBe(i);
+      });
+    });
+
+    it('should handle multiple breath points in order', () => {
+      const result = insertBreathRests(sampleDurations, [0, 2, 4]);
+      // Should have 3 additional rests
+      expect(result).toHaveLength(sampleDurations.length + 3);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle breath point at last position', () => {
+      const result = insertBreathRests(sampleDurations, [5]);
+      expect(result).toHaveLength(sampleDurations.length + 1);
+      expect(result[result.length - 1].isRest).toBe(true);
+    });
+
+    it('should handle breath point at first position', () => {
+      const result = insertBreathRests(sampleDurations, [0]);
+      expect(result).toHaveLength(sampleDurations.length + 1);
+      expect(result[1].isRest).toBe(true);
+    });
+
+    it('should skip invalid breath points (negative)', () => {
+      const result = insertBreathRests(sampleDurations, [-1]);
+      expect(result).toHaveLength(sampleDurations.length);
+    });
+
+    it('should skip invalid breath points (out of range)', () => {
+      const result = insertBreathRests(sampleDurations, [100]);
+      expect(result).toHaveLength(sampleDurations.length);
+    });
+  });
+
+  describe('non-mutation', () => {
+    it('should not mutate original array', () => {
+      const original = [...sampleDurations];
+      insertBreathRests(sampleDurations, [2]);
+      expect(sampleDurations).toEqual(original);
+    });
+  });
+});
+
+// =============================================================================
+// fitToMeasure Tests
+// =============================================================================
+
+describe('fitToMeasure', () => {
+  describe('basic measure fitting', () => {
+    it('should return empty array for empty input', () => {
+      const result = fitToMeasure([], 4);
+      expect(result).toEqual([]);
+    });
+
+    it('should return original if invalid beatsPerMeasure', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1, isRest: false },
+      ];
+      const result = fitToMeasure(durations, 0);
+      expect(result).toHaveLength(1);
+    });
+
+    it('should handle notes that fit exactly in measure', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1, isRest: false },
+        { syllableIndex: 1, beats: 1, isRest: false },
+        { syllableIndex: 2, beats: 1, isRest: false },
+        { syllableIndex: 3, beats: 1, isRest: false },
+      ];
+      const result = fitToMeasure(durations, 4);
+      expect(result).toHaveLength(4);
+    });
+  });
+
+  describe('padding with rests', () => {
+    it('should pad incomplete measure with rest by default', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1, isRest: false },
+        { syllableIndex: 1, beats: 1, isRest: false },
+      ];
+      const result = fitToMeasure(durations, 4);
+      const totalBeats = calculateTotalDuration(result);
+      expect(totalBeats).toBe(4); // Should be padded to complete measure
+    });
+
+    it('should not pad when padWithRests is false', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1, isRest: false },
+        { syllableIndex: 1, beats: 1, isRest: false },
+      ];
+      const result = fitToMeasure(durations, 4, { padWithRests: false });
+      const totalBeats = calculateTotalDuration(result);
+      expect(totalBeats).toBe(2);
+    });
+
+    it('should add rest with correct beats to complete measure', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1.5, isRest: false },
+      ];
+      const result = fitToMeasure(durations, 4);
+      const rest = result.find((d) => d.isRest);
+      expect(rest).toBeDefined();
+      expect(rest?.beats).toBe(2.5);
+    });
+  });
+
+  describe('splitting notes across bar lines', () => {
+    it('should split notes that cross bar lines by default', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1, isRest: false },
+        { syllableIndex: 1, beats: 1, isRest: false },
+        { syllableIndex: 2, beats: 1, isRest: false },
+        { syllableIndex: 3, beats: 2, isRest: false }, // This crosses the bar line
+      ];
+      const result = fitToMeasure(durations, 4);
+      // The long note should be split
+      expect(result.length).toBeGreaterThan(4);
+    });
+
+    it('should not split notes when allowSplitNotes is false', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1, isRest: false },
+        { syllableIndex: 1, beats: 1, isRest: false },
+        { syllableIndex: 2, beats: 1, isRest: false },
+        { syllableIndex: 3, beats: 2, isRest: false },
+      ];
+      const result = fitToMeasure(durations, 4, { allowSplitNotes: false });
+      // Note count should not increase due to splitting
+      const nonRestNotes = result.filter((d) => !d.isRest);
+      expect(nonRestNotes.length).toBeLessThanOrEqual(4);
+    });
+  });
+
+  describe('different time signatures', () => {
+    it('should work with 3/4 time (3 beats per measure)', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1, isRest: false },
+        { syllableIndex: 1, beats: 1, isRest: false },
+      ];
+      const result = fitToMeasure(durations, 3);
+      const totalBeats = calculateTotalDuration(result);
+      expect(totalBeats).toBe(3);
+    });
+
+    it('should work with 6/8 time (6 beats per measure)', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 0.5, isRest: false },
+        { syllableIndex: 1, beats: 0.5, isRest: false },
+        { syllableIndex: 2, beats: 0.5, isRest: false },
+      ];
+      const result = fitToMeasure(durations, 6);
+      const totalBeats = calculateTotalDuration(result);
+      expect(totalBeats).toBe(6);
+    });
+  });
+
+  describe('multiple measures', () => {
+    it('should handle content spanning multiple measures', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1, isRest: false },
+        { syllableIndex: 1, beats: 1, isRest: false },
+        { syllableIndex: 2, beats: 1, isRest: false },
+        { syllableIndex: 3, beats: 1, isRest: false },
+        { syllableIndex: 4, beats: 1, isRest: false },
+        { syllableIndex: 5, beats: 1, isRest: false },
+        { syllableIndex: 6, beats: 1, isRest: false },
+        { syllableIndex: 7, beats: 1, isRest: false },
+      ];
+      const result = fitToMeasure(durations, 4);
+      const totalBeats = calculateTotalDuration(result);
+      expect(totalBeats).toBe(8); // Exactly 2 measures
+    });
+  });
+
+  describe('options', () => {
+    it('should respect all options', () => {
+      const durations: NoteDuration[] = [
+        { syllableIndex: 0, beats: 1, isRest: false },
+      ];
+      const options: FitToMeasureOptions = {
+        padWithRests: false,
+        allowSplitNotes: false,
+        preserveStressAlignment: true,
+      };
+      const result = fitToMeasure(durations, 4, options);
+      expect(result).toHaveLength(1);
+    });
+  });
+});
+
+// =============================================================================
+// Utility Function Tests
+// =============================================================================
+
+describe('calculateTotalDuration', () => {
+  it('should return 0 for empty array', () => {
+    expect(calculateTotalDuration([])).toBe(0);
+  });
+
+  it('should sum all durations', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 1, isRest: false },
+      { syllableIndex: 1, beats: 0.5, isRest: false },
+      { syllableIndex: 2, beats: 1.5, isRest: false },
+    ];
+    expect(calculateTotalDuration(durations)).toBe(3);
+  });
+
+  it('should include rests in total', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 1, isRest: false },
+      { syllableIndex: -1, beats: 0.5, isRest: true },
+      { syllableIndex: 1, beats: 1, isRest: false },
+    ];
+    expect(calculateTotalDuration(durations)).toBe(2.5);
+  });
+});
+
+describe('countMeasures', () => {
+  it('should count measures correctly', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 1, isRest: false },
+      { syllableIndex: 1, beats: 1, isRest: false },
+      { syllableIndex: 2, beats: 1, isRest: false },
+      { syllableIndex: 3, beats: 1, isRest: false },
+    ];
+    expect(countMeasures(durations, 4)).toBe(1);
+  });
+
+  it('should return fractional measures', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 1, isRest: false },
+      { syllableIndex: 1, beats: 1, isRest: false },
+    ];
+    expect(countMeasures(durations, 4)).toBe(0.5);
+  });
+
+  it('should handle multiple complete measures', () => {
+    const durations: NoteDuration[] = Array(8).fill(null).map((_, i) => ({
+      syllableIndex: i,
+      beats: 1,
+      isRest: false,
+    }));
+    expect(countMeasures(durations, 4)).toBe(2);
+  });
+});
+
+describe('validateRhythm', () => {
+  it('should validate correct rhythm', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 1, isRest: false },
+      { syllableIndex: 1, beats: 0.5, isRest: false },
+    ];
+    const result = validateRhythm(durations);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('should detect invalid beats value', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 0, isRest: false },
+    ];
+    const result = validateRhythm(durations);
+    expect(result.valid).toBe(false);
+    expect(result.issues.length).toBeGreaterThan(0);
+  });
+
+  it('should detect invalid syllable index for non-rest', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: -1, beats: 1, isRest: false },
+    ];
+    const result = validateRhythm(durations);
+    expect(result.valid).toBe(false);
+  });
+
+  it('should validate rests have syllableIndex -1', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 1, isRest: true },
+    ];
+    const result = validateRhythm(durations);
+    expect(result.valid).toBe(false);
+  });
+
+  it('should return valid for empty array', () => {
+    const result = validateRhythm([]);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('createRhythmContext', () => {
+  it('should create context with all properties', () => {
+    const context = createRhythmContext('4/4', 120, 2);
+    expect(context.timeSignature).toBe('4/4');
+    expect(context.tempo).toBe(120);
+    expect(context.position).toBe(2);
+  });
+
+  it('should default position to 0', () => {
+    const context = createRhythmContext('3/4', 100);
+    expect(context.position).toBe(0);
+  });
+});
+
+describe('getStrongBeats', () => {
+  it('should return [0, 2] for 4/4', () => {
+    expect(getStrongBeats('4/4')).toEqual([0, 2]);
+  });
+
+  it('should return [0] for 3/4', () => {
+    expect(getStrongBeats('3/4')).toEqual([0]);
+  });
+
+  it('should return [0, 3] for 6/8', () => {
+    expect(getStrongBeats('6/8')).toEqual([0, 3]);
+  });
+
+  it('should return [0] for 2/4', () => {
+    expect(getStrongBeats('2/4')).toEqual([0]);
+  });
+});
+
+describe('isStrongBeat', () => {
+  it('should identify strong beats in 4/4', () => {
+    expect(isStrongBeat(0, '4/4')).toBe(true);
+    expect(isStrongBeat(1, '4/4')).toBe(false);
+    expect(isStrongBeat(2, '4/4')).toBe(true);
+    expect(isStrongBeat(3, '4/4')).toBe(false);
+  });
+
+  it('should identify strong beats in 3/4', () => {
+    expect(isStrongBeat(0, '3/4')).toBe(true);
+    expect(isStrongBeat(1, '3/4')).toBe(false);
+    expect(isStrongBeat(2, '3/4')).toBe(false);
+  });
+
+  it('should wrap around for positions beyond measure', () => {
+    expect(isStrongBeat(4, '4/4')).toBe(true); // Position 4 mod 4 = 0
+    expect(isStrongBeat(6, '4/4')).toBe(true); // Position 6 mod 4 = 2
+  });
+});
+
+describe('durationsToBeats', () => {
+  it('should extract beat values', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 1, isRest: false },
+      { syllableIndex: 1, beats: 0.5, isRest: false },
+      { syllableIndex: -1, beats: 0.5, isRest: true },
+    ];
+    expect(durationsToBeats(durations)).toEqual([1, 0.5, 0.5]);
+  });
+
+  it('should return empty array for empty input', () => {
+    expect(durationsToBeats([])).toEqual([]);
+  });
+});
+
+describe('createIambicRhythm', () => {
+  it('should create iambic pattern (short-long)', () => {
+    const result = createIambicRhythm(4);
+    expect(result).toHaveLength(4);
+    // First and third should be shorter (unstressed)
+    expect(result[0].beats).toBeLessThan(result[1].beats);
+    expect(result[2].beats).toBeLessThan(result[3].beats);
+  });
+
+  it('should handle odd syllable counts', () => {
+    const result = createIambicRhythm(5);
+    expect(result).toHaveLength(5);
+  });
+
+  it('should accept custom time signature', () => {
+    const result = createIambicRhythm(4, '3/4');
+    expect(result).toHaveLength(4);
+  });
+});
+
+describe('createTrochaicRhythm', () => {
+  it('should create trochaic pattern (long-short)', () => {
+    const result = createTrochaicRhythm(4);
+    expect(result).toHaveLength(4);
+    // First and third should be longer (stressed)
+    expect(result[0].beats).toBeGreaterThan(result[1].beats);
+    expect(result[2].beats).toBeGreaterThan(result[3].beats);
+  });
+});
+
+describe('alignStressToBeats', () => {
+  it('should return copy for empty input', () => {
+    const result = alignStressToBeats([], '', '4/4');
+    expect(result).toEqual([]);
+  });
+
+  it('should attempt to align stressed syllables to strong beats', () => {
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 0.5, isRest: false },
+      { syllableIndex: 1, beats: 1, isRest: false },
+      { syllableIndex: 2, beats: 0.5, isRest: false },
+      { syllableIndex: 3, beats: 1, isRest: false },
+    ];
+    const result = alignStressToBeats(durations, '0101', '4/4');
+    expect(result.length).toBeGreaterThanOrEqual(durations.length);
+  });
+
+  it('should preserve original durations if already aligned', () => {
+    // Stress pattern already aligned with strong beats
+    const durations: NoteDuration[] = [
+      { syllableIndex: 0, beats: 0.5, isRest: false }, // beat 0, unstressed
+      { syllableIndex: 1, beats: 0.5, isRest: false }, // beat 0.5, stressed
+      { syllableIndex: 2, beats: 1, isRest: false }, // beat 1, unstressed
+      { syllableIndex: 3, beats: 1, isRest: false }, // beat 2, stressed (strong beat)
+    ];
+    const result = alignStressToBeats(durations, '0101', '4/4');
+    expect(result).toBeDefined();
+  });
+});
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+describe('Integration Tests', () => {
+  describe('complete rhythm generation workflow', () => {
+    it('should generate rhythm for "The woods are lovely, dark and deep"', () => {
+      // Stress pattern for iambic tetrameter: 01010101
+      const stressPattern = '01010101';
+      const timeSignature: TimeSignature = '4/4';
+
+      // Step 1: Map stress to rhythm
+      const durations = mapLineToRhythm(stressPattern, timeSignature, 80);
+      expect(durations).toHaveLength(8);
+
+      // Step 2: Insert breath rest after "lovely" (position 3)
+      const withBreath = insertBreathRests(durations, [3], 0.5);
+      expect(withBreath).toHaveLength(9);
+
+      // Step 3: Fit to measures
+      const fitted = fitToMeasure(withBreath, 4);
+
+      // Validate result
+      const validation = validateRhythm(fitted);
+      expect(validation.valid).toBe(true);
+    });
+
+    it('should handle complex poem line with punctuation pauses', () => {
+      // "Once upon a midnight dreary, while I pondered, weak and weary"
+      // Simplified stress pattern
+      const stressPattern = '1010101010101010';
+
+      const durations = mapLineToRhythm(stressPattern, '4/4');
+
+      // Breath points after "dreary" (7) and "pondered" (11)
+      const withBreaths = insertBreathRests(durations, [7, 11]);
+
+      const fitted = fitToMeasure(withBreaths, 4);
+
+      expect(calculateTotalDuration(fitted)).toBeGreaterThan(0);
+      expect(validateRhythm(fitted).valid).toBe(true);
+    });
+
+    it('should work with waltz time (3/4)', () => {
+      const stressPattern = '100100';
+      const durations = mapLineToRhythm(stressPattern, '3/4');
+      const fitted = fitToMeasure(durations, 3);
+
+      const measures = countMeasures(fitted, 3);
+      expect(measures).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should work with compound meter (6/8)', () => {
+      const stressPattern = '100100';
+      const durations = mapLineToRhythm(stressPattern, '6/8');
+      const fitted = fitToMeasure(durations, 6);
+
+      expect(validateRhythm(fitted).valid).toBe(true);
+    });
+  });
+
+  describe('rhythm quality checks', () => {
+    it('should produce singable rhythms (no extremely short notes)', () => {
+      const stressPattern = '01010101';
+      const durations = mapLineToRhythm(stressPattern, '4/4', 120);
+
+      // All notes should be at least a sixteenth note (0.25 beats)
+      durations.forEach((d) => {
+        expect(d.beats).toBeGreaterThanOrEqual(0.25);
+      });
+    });
+
+    it('should produce rhythms that can be fitted to measures', () => {
+      const patterns = ['01010101', '10101010', '001001001', '100100100'];
+
+      patterns.forEach((pattern) => {
+        const durations = mapLineToRhythm(pattern, '4/4');
+        const fitted = fitToMeasure(durations, 4);
+        const validation = validateRhythm(fitted);
+        expect(validation.valid).toBe(true);
+      });
+    });
+  });
+});

--- a/web/src/lib/melody/rhythm.ts
+++ b/web/src/lib/melody/rhythm.ts
@@ -1,0 +1,656 @@
+/**
+ * Stress-to-Rhythm Mapping Module
+ *
+ * This module creates the algorithm that maps syllable stress patterns to musical rhythm.
+ * It transforms linguistic stress (from poem analysis) into note durations that can be
+ * used for melody generation.
+ *
+ * Key principles from MELODY_GENERATION.md:
+ * - Stressed syllables (1) → longer notes (quarter, half)
+ * - Unstressed syllables (0) → shorter notes (eighth)
+ * - Secondary stress (2) → medium notes (quarter)
+ * - Breath points → rests
+ *
+ * @module lib/melody/rhythm
+ */
+
+import type { TimeSignature } from './types';
+import { getBeatsPerMeasure } from './abcGenerator';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Stress level from poem analysis
+ * '0' = unstressed, '1' = primary stress, '2' = secondary stress
+ */
+export type StressLevel = '0' | '1' | '2';
+
+/**
+ * Context for rhythm generation
+ */
+export interface RhythmContext {
+  /** Time signature (e.g., '4/4', '3/4', '6/8') */
+  timeSignature: TimeSignature;
+  /** Tempo in BPM */
+  tempo: number;
+  /** Current beat position in the measure (0-indexed) */
+  position: number;
+}
+
+/**
+ * A note duration with its syllable mapping
+ */
+export interface NoteDuration {
+  /** Index of the syllable this duration corresponds to (-1 for rests) */
+  syllableIndex: number;
+  /** Duration in beats (e.g., 0.5 for eighth note, 1 for quarter, 2 for half) */
+  beats: number;
+  /** Whether this is a rest (no pitch, breath pause) */
+  isRest: boolean;
+}
+
+// =============================================================================
+// Logging
+// =============================================================================
+
+const DEBUG = process.env.NODE_ENV === 'development';
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[rhythm] ${message}`, ...args);
+  }
+};
+
+// =============================================================================
+// Duration Constants
+// =============================================================================
+
+/**
+ * Default beat durations for each stress level (in beats, assuming quarter note = 1 beat)
+ * These values follow the documentation guidelines:
+ * - Primary stress (1): longer notes
+ * - Secondary stress (2): medium notes
+ * - Unstressed (0): shorter notes
+ */
+const DEFAULT_STRESS_DURATIONS: Record<StressLevel, number> = {
+  '0': 0.5, // Eighth note for unstressed syllables
+  '1': 1.0, // Quarter note for primary stress
+  '2': 0.75, // Dotted eighth or short quarter for secondary stress
+};
+
+/**
+ * Time signature specific adjustments
+ * Different time signatures have different "feels" and require duration adjustments
+ */
+const TIME_SIGNATURE_MULTIPLIERS: Record<TimeSignature, number> = {
+  '4/4': 1.0, // Standard timing
+  '3/4': 1.0, // Waltz timing, same base durations
+  '6/8': 0.5, // Compound meter, eighth note is the pulse
+  '2/4': 1.0, // March timing
+};
+
+/**
+ * Strong beat positions for each time signature (0-indexed)
+ * Used to determine if a syllable falls on a strong beat
+ */
+const STRONG_BEATS: Record<TimeSignature, number[]> = {
+  '4/4': [0, 2], // Beats 1 and 3 are strong
+  '3/4': [0], // Beat 1 is strong
+  '6/8': [0, 3], // Beats 1 and 4 are strong (compound duple)
+  '2/4': [0], // Beat 1 is strong
+};
+
+// =============================================================================
+// Core Functions
+// =============================================================================
+
+/**
+ * Maps a single syllable's stress level to a note duration.
+ *
+ * Takes into account:
+ * - The stress level of the syllable
+ * - The time signature and tempo context
+ * - The current position in the measure
+ *
+ * @param stress - The stress level ('0', '1', or '2')
+ * @param context - The rhythm context with time signature, tempo, and position
+ * @returns Duration in beats
+ *
+ * @example
+ * stressToNoteDuration('1', { timeSignature: '4/4', tempo: 100, position: 0 }) // 1.0
+ * stressToNoteDuration('0', { timeSignature: '4/4', tempo: 100, position: 1 }) // 0.5
+ */
+export function stressToNoteDuration(stress: StressLevel, context: RhythmContext): number {
+  log('stressToNoteDuration', { stress, context });
+
+  // Validate input
+  if (!['0', '1', '2'].includes(stress)) {
+    log('Invalid stress level, defaulting to unstressed');
+    stress = '0';
+  }
+
+  // Get base duration for this stress level
+  const baseDuration = DEFAULT_STRESS_DURATIONS[stress];
+
+  // Apply time signature multiplier
+  const multiplier = TIME_SIGNATURE_MULTIPLIERS[context.timeSignature] ?? 1.0;
+  let duration = baseDuration * multiplier;
+
+  // Check if we're on a strong beat - strong beats can have slightly longer notes
+  const strongBeats = STRONG_BEATS[context.timeSignature] ?? [0];
+  const isOnStrongBeat = strongBeats.includes(Math.floor(context.position));
+
+  // If stressed syllable is on a strong beat, it can be emphasized more
+  if (stress === '1' && isOnStrongBeat) {
+    // Allow for longer notes on strong beats for stressed syllables
+    duration = Math.min(duration * 1.25, 2.0); // Cap at half note
+  }
+
+  // Adjust for tempo - faster tempos might benefit from shorter durations
+  if (context.tempo > 140) {
+    // Fast tempo - shorten notes slightly for better articulation
+    duration *= 0.9;
+  } else if (context.tempo < 60) {
+    // Slow tempo - can afford slightly longer notes
+    duration *= 1.1;
+  }
+
+  // Round to common note values (eighth, quarter, dotted quarter, half)
+  duration = roundToMusicalDuration(duration);
+
+  log('stressToNoteDuration result:', duration);
+  return duration;
+}
+
+/**
+ * Rounds a duration value to the nearest common musical duration.
+ *
+ * Common durations (in beats, quarter note = 1):
+ * - 0.25 (sixteenth note)
+ * - 0.5 (eighth note)
+ * - 0.75 (dotted eighth)
+ * - 1.0 (quarter note)
+ * - 1.5 (dotted quarter)
+ * - 2.0 (half note)
+ *
+ * @param duration - Raw duration value
+ * @returns Rounded duration
+ */
+function roundToMusicalDuration(duration: number): number {
+  const musicalDurations = [0.25, 0.5, 0.75, 1.0, 1.5, 2.0];
+
+  // Find the closest musical duration
+  let closest = musicalDurations[0];
+  let minDiff = Math.abs(duration - closest);
+
+  for (const md of musicalDurations) {
+    const diff = Math.abs(duration - md);
+    if (diff < minDiff) {
+      minDiff = diff;
+      closest = md;
+    }
+  }
+
+  return closest;
+}
+
+/**
+ * Maps a complete line's stress pattern to rhythm (note durations).
+ *
+ * Takes a stress pattern string (e.g., "01010101") and converts it to
+ * an array of NoteDuration objects representing the rhythm for each syllable.
+ *
+ * @param stressPattern - String of stress levels (e.g., "01010101" for iambic tetrameter)
+ * @param timeSignature - Time signature for the line
+ * @param tempo - Tempo in BPM (optional, defaults to 100)
+ * @returns Array of NoteDuration objects
+ *
+ * @example
+ * mapLineToRhythm('01010101', '4/4')
+ * // Returns array of NoteDuration objects with alternating short/long durations
+ */
+export function mapLineToRhythm(
+  stressPattern: string,
+  timeSignature: TimeSignature,
+  tempo: number = 100
+): NoteDuration[] {
+  log('mapLineToRhythm', { stressPattern, timeSignature, tempo });
+
+  if (!stressPattern || stressPattern.length === 0) {
+    return [];
+  }
+
+  const durations: NoteDuration[] = [];
+  let currentPosition = 0;
+
+  for (let i = 0; i < stressPattern.length; i++) {
+    const stress = stressPattern[i] as StressLevel;
+
+    // Create context for this syllable
+    const context: RhythmContext = {
+      timeSignature,
+      tempo,
+      position: currentPosition % getBeatsPerMeasure(timeSignature),
+    };
+
+    // Get duration for this stress level
+    const beats = stressToNoteDuration(stress, context);
+
+    durations.push({
+      syllableIndex: i,
+      beats,
+      isRest: false,
+    });
+
+    // Update position for next syllable
+    currentPosition += beats;
+  }
+
+  log('mapLineToRhythm result:', durations);
+  return durations;
+}
+
+/**
+ * Inserts breath rests at specified positions in a rhythm sequence.
+ *
+ * Breath points are typically at:
+ * - End of phrases
+ * - After punctuation (commas, periods)
+ * - Natural pause points in the text
+ *
+ * @param durations - Original array of NoteDurations
+ * @param breathPoints - Array of syllable indices after which to insert rests
+ * @param restDuration - Duration of breath rests in beats (default: 0.5)
+ * @returns New array with rests inserted at breath points
+ *
+ * @example
+ * insertBreathRests(durations, [3, 7], 0.5)
+ * // Inserts 0.5 beat rests after syllables 3 and 7
+ */
+export function insertBreathRests(
+  durations: NoteDuration[],
+  breathPoints: number[],
+  restDuration: number = 0.5
+): NoteDuration[] {
+  log('insertBreathRests', { durationsCount: durations.length, breathPoints, restDuration });
+
+  if (!durations || durations.length === 0) {
+    return [];
+  }
+
+  if (!breathPoints || breathPoints.length === 0) {
+    return [...durations];
+  }
+
+  // Sort breath points in descending order so we can insert from end to beginning
+  // This prevents index shifting issues
+  const sortedBreathPoints = [...breathPoints].sort((a, b) => b - a);
+
+  // Create a copy to avoid mutating the original
+  const result: NoteDuration[] = [...durations];
+
+  for (const breathPoint of sortedBreathPoints) {
+    // Validate breath point is within range
+    if (breathPoint < 0 || breathPoint >= durations.length) {
+      log(`Skipping invalid breath point: ${breathPoint}`);
+      continue;
+    }
+
+    // Create rest to insert after the breath point
+    const rest: NoteDuration = {
+      syllableIndex: -1, // -1 indicates this is a rest, not a syllable
+      beats: restDuration,
+      isRest: true,
+    };
+
+    // Insert rest after the breath point
+    result.splice(breathPoint + 1, 0, rest);
+  }
+
+  log('insertBreathRests result:', result);
+  return result;
+}
+
+/**
+ * Fits a sequence of note durations into complete measures.
+ *
+ * This function adjusts durations to ensure they fit properly within measures:
+ * - Adds rests at end if measure is incomplete
+ * - Optionally adjusts note lengths to fill measures
+ * - Handles tied notes across bar lines
+ *
+ * @param durations - Array of NoteDuration objects to fit
+ * @param beatsPerMeasure - Number of beats per measure (e.g., 4 for 4/4)
+ * @param options - Configuration options
+ * @returns New array of NoteDurations fitted to measures
+ *
+ * @example
+ * fitToMeasure(durations, 4) // Fits to 4/4 time
+ * fitToMeasure(durations, 3) // Fits to 3/4 time
+ */
+export function fitToMeasure(
+  durations: NoteDuration[],
+  beatsPerMeasure: number,
+  options: FitToMeasureOptions = {}
+): NoteDuration[] {
+  log('fitToMeasure', { durationsCount: durations.length, beatsPerMeasure, options });
+
+  const {
+    padWithRests = true,
+    allowSplitNotes = true,
+    preserveStressAlignment = true,
+  } = options;
+
+  if (!durations || durations.length === 0) {
+    return [];
+  }
+
+  if (beatsPerMeasure <= 0) {
+    log('Invalid beatsPerMeasure, returning original durations');
+    return [...durations];
+  }
+
+  const result: NoteDuration[] = [];
+  let currentBeat = 0;
+
+  for (let i = 0; i < durations.length; i++) {
+    const duration = durations[i];
+    const remainingInMeasure = beatsPerMeasure - (currentBeat % beatsPerMeasure);
+
+    // Check if this note fits in the current measure
+    if (duration.beats <= remainingInMeasure) {
+      // Note fits completely
+      result.push({ ...duration });
+      currentBeat += duration.beats;
+    } else if (allowSplitNotes && duration.beats > remainingInMeasure) {
+      // Note needs to be split across bar line
+      // First part fills the current measure
+      const firstPart: NoteDuration = {
+        syllableIndex: duration.syllableIndex,
+        beats: remainingInMeasure,
+        isRest: duration.isRest,
+      };
+      result.push(firstPart);
+      currentBeat += remainingInMeasure;
+
+      // Second part goes into next measure
+      const secondPartBeats = duration.beats - remainingInMeasure;
+      const secondPart: NoteDuration = {
+        syllableIndex: duration.syllableIndex, // Same syllable (tied note)
+        beats: secondPartBeats,
+        isRest: duration.isRest,
+      };
+      result.push(secondPart);
+      currentBeat += secondPartBeats;
+    } else {
+      // Don't split - adjust the note to fit
+      if (preserveStressAlignment && !duration.isRest) {
+        // Shorten the note to fit the measure
+        const adjustedDuration: NoteDuration = {
+          syllableIndex: duration.syllableIndex,
+          beats: Math.min(duration.beats, remainingInMeasure),
+          isRest: duration.isRest,
+        };
+        result.push(adjustedDuration);
+        currentBeat += adjustedDuration.beats;
+      } else {
+        // Just add the note and let it overflow
+        result.push({ ...duration });
+        currentBeat += duration.beats;
+      }
+    }
+  }
+
+  // Pad the final measure with rests if needed
+  if (padWithRests) {
+    const remainingBeats = beatsPerMeasure - (currentBeat % beatsPerMeasure);
+    if (remainingBeats > 0 && remainingBeats < beatsPerMeasure) {
+      result.push({
+        syllableIndex: -1,
+        beats: remainingBeats,
+        isRest: true,
+      });
+    }
+  }
+
+  log('fitToMeasure result:', result);
+  return result;
+}
+
+/**
+ * Options for fitToMeasure function
+ */
+export interface FitToMeasureOptions {
+  /** Whether to add rests at the end to complete the final measure (default: true) */
+  padWithRests?: boolean;
+  /** Whether to split notes that cross bar lines (default: true) */
+  allowSplitNotes?: boolean;
+  /** Whether to preserve stressed syllables on strong beats (default: true) */
+  preserveStressAlignment?: boolean;
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Calculates the total duration of a rhythm sequence in beats.
+ *
+ * @param durations - Array of NoteDuration objects
+ * @returns Total duration in beats
+ */
+export function calculateTotalDuration(durations: NoteDuration[]): number {
+  if (!durations || durations.length === 0) {
+    return 0;
+  }
+  return durations.reduce((total, d) => total + d.beats, 0);
+}
+
+/**
+ * Counts the number of measures a rhythm sequence spans.
+ *
+ * @param durations - Array of NoteDuration objects
+ * @param beatsPerMeasure - Number of beats per measure
+ * @returns Number of measures (may be fractional)
+ */
+export function countMeasures(durations: NoteDuration[], beatsPerMeasure: number): number {
+  const totalBeats = calculateTotalDuration(durations);
+  return totalBeats / beatsPerMeasure;
+}
+
+/**
+ * Validates that a rhythm sequence has consistent timing.
+ *
+ * @param durations - Array of NoteDuration objects
+ * @returns Object with valid flag and any issues found
+ */
+export function validateRhythm(durations: NoteDuration[]): { valid: boolean; issues: string[] } {
+  const issues: string[] = [];
+
+  if (!durations || durations.length === 0) {
+    return { valid: true, issues: [] };
+  }
+
+  for (let i = 0; i < durations.length; i++) {
+    const d = durations[i];
+
+    // Check for valid beats value
+    if (d.beats <= 0) {
+      issues.push(`Invalid duration at index ${i}: beats must be positive`);
+    }
+
+    // Check for valid syllable index
+    if (!d.isRest && d.syllableIndex < 0) {
+      issues.push(`Invalid syllable index at index ${i}: non-rest notes must have syllableIndex >= 0`);
+    }
+
+    // Check for rests having correct syllable index
+    if (d.isRest && d.syllableIndex !== -1) {
+      issues.push(`Rest at index ${i} should have syllableIndex of -1`);
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+/**
+ * Creates a rhythm context from common parameters.
+ *
+ * @param timeSignature - Time signature
+ * @param tempo - Tempo in BPM
+ * @param position - Beat position in measure (optional, defaults to 0)
+ * @returns RhythmContext object
+ */
+export function createRhythmContext(
+  timeSignature: TimeSignature,
+  tempo: number,
+  position: number = 0
+): RhythmContext {
+  return {
+    timeSignature,
+    tempo,
+    position,
+  };
+}
+
+/**
+ * Gets the beat positions that are considered "strong" for a time signature.
+ *
+ * @param timeSignature - The time signature
+ * @returns Array of strong beat positions (0-indexed)
+ */
+export function getStrongBeats(timeSignature: TimeSignature): number[] {
+  return STRONG_BEATS[timeSignature] ?? [0];
+}
+
+/**
+ * Determines if a beat position is strong for the given time signature.
+ *
+ * @param position - Beat position (0-indexed)
+ * @param timeSignature - The time signature
+ * @returns True if the position is a strong beat
+ */
+export function isStrongBeat(position: number, timeSignature: TimeSignature): boolean {
+  const strongBeats = getStrongBeats(timeSignature);
+  return strongBeats.includes(Math.floor(position % getBeatsPerMeasure(timeSignature)));
+}
+
+/**
+ * Converts durations to a simplified array of beat values for debugging.
+ *
+ * @param durations - Array of NoteDuration objects
+ * @returns Array of beat values
+ */
+export function durationsToBeats(durations: NoteDuration[]): number[] {
+  return durations.map((d) => d.beats);
+}
+
+/**
+ * Creates a basic iambic rhythm pattern (unstressed-stressed alternation).
+ *
+ * @param syllableCount - Number of syllables
+ * @param timeSignature - Time signature (default: '4/4')
+ * @returns Array of NoteDurations in iambic pattern
+ */
+export function createIambicRhythm(
+  syllableCount: number,
+  timeSignature: TimeSignature = '4/4'
+): NoteDuration[] {
+  // Generate iambic stress pattern (01 repeated)
+  let pattern = '';
+  for (let i = 0; i < syllableCount; i++) {
+    pattern += i % 2 === 0 ? '0' : '1';
+  }
+  return mapLineToRhythm(pattern, timeSignature);
+}
+
+/**
+ * Creates a basic trochaic rhythm pattern (stressed-unstressed alternation).
+ *
+ * @param syllableCount - Number of syllables
+ * @param timeSignature - Time signature (default: '4/4')
+ * @returns Array of NoteDurations in trochaic pattern
+ */
+export function createTrochaicRhythm(
+  syllableCount: number,
+  timeSignature: TimeSignature = '4/4'
+): NoteDuration[] {
+  // Generate trochaic stress pattern (10 repeated)
+  let pattern = '';
+  for (let i = 0; i < syllableCount; i++) {
+    pattern += i % 2 === 0 ? '1' : '0';
+  }
+  return mapLineToRhythm(pattern, timeSignature);
+}
+
+/**
+ * Adjusts rhythm to better align stressed syllables with strong beats.
+ *
+ * This is useful when the natural stress pattern doesn't align well
+ * with the time signature's strong beats.
+ *
+ * @param durations - Original rhythm
+ * @param stressPattern - Original stress pattern
+ * @param timeSignature - Time signature
+ * @returns Adjusted rhythm with better stress alignment
+ */
+export function alignStressToBeats(
+  durations: NoteDuration[],
+  stressPattern: string,
+  timeSignature: TimeSignature
+): NoteDuration[] {
+  log('alignStressToBeats', { durationsCount: durations.length, stressPattern, timeSignature });
+
+  if (durations.length === 0 || !stressPattern) {
+    return [...durations];
+  }
+
+  const beatsPerMeasure = getBeatsPerMeasure(timeSignature);
+  const strongBeats = getStrongBeats(timeSignature);
+  const result: NoteDuration[] = [];
+  let currentBeat = 0;
+
+  for (let i = 0; i < durations.length; i++) {
+    const duration = { ...durations[i] };
+    const stress = stressPattern[i] ?? '0';
+    const beatInMeasure = currentBeat % beatsPerMeasure;
+
+    // If this is a stressed syllable not on a strong beat,
+    // and we're close to a strong beat, adjust timing
+    if (stress === '1' && !strongBeats.includes(Math.floor(beatInMeasure))) {
+      // Find nearest strong beat
+      let nearestStrongBeat = strongBeats[0];
+      let minDistance = Math.abs(beatInMeasure - strongBeats[0]);
+
+      for (const sb of strongBeats) {
+        const dist = Math.abs(beatInMeasure - sb);
+        if (dist < minDistance) {
+          minDistance = dist;
+          nearestStrongBeat = sb;
+        }
+      }
+
+      // If we're within 0.5 beats of a strong beat, adjust
+      if (minDistance <= 0.5 && minDistance > 0) {
+        // Add a small rest or adjust previous note to shift this syllable
+        const adjustment = nearestStrongBeat - beatInMeasure;
+        if (adjustment > 0 && result.length > 0) {
+          // Extend the previous note/rest slightly
+          const prev = result[result.length - 1];
+          prev.beats += adjustment;
+          currentBeat += adjustment;
+        }
+      }
+    }
+
+    result.push(duration);
+    currentBeat += duration.beats;
+  }
+
+  log('alignStressToBeats result:', result);
+  return result;
+}


### PR DESCRIPTION
## Summary
- Implements the stress-to-rhythm mapping algorithm that converts syllable stress patterns to musical rhythm
- Maps linguistic stress (from poem analysis) into note durations for melody generation
- Core module for connecting the poem analysis pipeline to the melody generation system

## Changes
- `web/src/lib/melody/rhythm.ts` - New rhythm mapping module with:
  - `stressToNoteDuration()` - Maps individual stress level to beat duration
  - `mapLineToRhythm()` - Converts full stress pattern to NoteDuration array
  - `insertBreathRests()` - Inserts rests at breath/phrase points
  - `fitToMeasure()` - Fits rhythm sequence to measure boundaries
  - Utility functions for rhythm analysis and manipulation
- `web/src/lib/melody/rhythm.test.ts` - 89 comprehensive unit tests
- `web/src/lib/melody/index.ts` - Added rhythm module export

## Implementation Details

### Stress-to-Duration Mapping
| Stress Level | Note Duration | Beats |
|-------------|---------------|-------|
| Primary (1) | Quarter note | 1.0 |
| Secondary (2) | Dotted eighth | 0.75 |
| Unstressed (0) | Eighth note | 0.5 |

### Time Signature Support
- 4/4 (Common time) - Strong beats at 1 and 3
- 3/4 (Waltz time) - Strong beat at 1
- 6/8 (Compound duple) - Strong beats at 1 and 4
- 2/4 (March time) - Strong beat at 1

### Key Features
- Tempo-aware duration adjustments
- Strong beat emphasis for stressed syllables
- Musical duration rounding (to standard note values)
- Breath rest insertion at phrase boundaries
- Measure padding and note splitting across bar lines

## Testing
- [x] Unit tests pass (`npm test` - 89 new tests, 1964 total)
- [x] Linter passes (`npm run lint`)
- [x] Integration tests for complete workflow

## Notes
This module bridges the gap between poem analysis (stress patterns) and melody generation (note durations). It follows the design principles outlined in `docs/MELODY_GENERATION.md`:
- Stressed syllables get longer notes
- Unstressed syllables get shorter notes
- Rhythm fits within measures
- Breath points become rests

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)