### PR TITLE
feat(GH-20): Implement cadence and phrase ending generator

### DIFF
--- a/web/src/lib/melody/cadence.test.ts
+++ b/web/src/lib/melody/cadence.test.ts
@@ -1,0 +1,892 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateCadence,
+  determineLineEndingCadence,
+  applyPhraseClosure,
+  getShortCadence,
+  validateCadence,
+  getCadenceToTarget,
+  suggestCadenceForEmotion,
+  type CadenceType,
+  type LinePosition,
+} from './cadence';
+import type { Note, KeySignature } from './types';
+
+describe('generateCadence', () => {
+  describe('perfect cadence (V→I)', () => {
+    it('generates perfect cadence in C major', () => {
+      const cadence = generateCadence('perfect', 'C');
+
+      // Should have 3 notes: approach, V, I
+      expect(cadence).toHaveLength(3);
+
+      // Last note should be tonic (C)
+      expect(cadence[2].pitch).toBe('C');
+
+      // Second-to-last should be dominant (G)
+      expect(cadence[1].pitch).toBe('G');
+
+      // Final note should be longer (4)
+      expect(cadence[2].duration).toBe(4);
+    });
+
+    it('generates perfect cadence in G major', () => {
+      const cadence = generateCadence('perfect', 'G');
+
+      // Last note should be tonic (G)
+      expect(cadence[2].pitch).toBe('G');
+
+      // Second-to-last should be dominant (D)
+      expect(cadence[1].pitch).toBe('D');
+    });
+
+    it('generates perfect cadence in Am (minor key)', () => {
+      const cadence = generateCadence('perfect', 'Am');
+
+      // Last note should be tonic (A)
+      expect(cadence[2].pitch).toBe('A');
+
+      // Dominant should be E
+      expect(cadence[1].pitch).toBe('E');
+    });
+
+    it('generates perfect cadence in all major keys', () => {
+      const majorKeys: KeySignature[] = ['C', 'G', 'D', 'F'];
+      const expectedTonics: Record<string, string> = {
+        C: 'C',
+        G: 'G',
+        D: 'D',
+        F: 'F',
+      };
+
+      for (const key of majorKeys) {
+        const cadence = generateCadence('perfect', key);
+        expect(cadence[cadence.length - 1].pitch).toBe(expectedTonics[key]);
+      }
+    });
+
+    it('generates perfect cadence in all minor keys', () => {
+      const minorKeys: KeySignature[] = ['Am', 'Em', 'Dm'];
+      const expectedTonics: Record<string, string> = {
+        Am: 'A',
+        Em: 'E',
+        Dm: 'D',
+      };
+
+      for (const key of minorKeys) {
+        const cadence = generateCadence('perfect', key);
+        expect(cadence[cadence.length - 1].pitch).toBe(expectedTonics[key]);
+      }
+    });
+  });
+
+  describe('half cadence (?→V)', () => {
+    it('generates half cadence in C major', () => {
+      const cadence = generateCadence('half', 'C');
+
+      // Should have 3 notes
+      expect(cadence).toHaveLength(3);
+
+      // Last note should be dominant (G)
+      expect(cadence[2].pitch).toBe('G');
+
+      // Final note should have longer duration
+      expect(cadence[2].duration).toBe(4);
+    });
+
+    it('generates half cadence in Am (minor)', () => {
+      const cadence = generateCadence('half', 'Am');
+
+      // Last note should be dominant (E)
+      expect(cadence[2].pitch).toBe('E');
+    });
+
+    it('ends on dominant for all keys', () => {
+      const expectedDominants: Record<KeySignature, string> = {
+        C: 'G',
+        G: 'D',
+        D: 'A',
+        F: 'C',
+        Am: 'E',
+        Em: 'B',
+        Dm: 'A',
+      };
+
+      for (const [key, expectedDominant] of Object.entries(expectedDominants)) {
+        const cadence = generateCadence('half', key as KeySignature);
+        expect(cadence[cadence.length - 1].pitch).toBe(expectedDominant);
+      }
+    });
+  });
+
+  describe('deceptive cadence (V→vi)', () => {
+    it('generates deceptive cadence in C major', () => {
+      const cadence = generateCadence('deceptive', 'C');
+
+      expect(cadence).toHaveLength(3);
+
+      // Last note should be submediant (A)
+      expect(cadence[2].pitch).toBe('A');
+
+      // Second-to-last should be dominant (G)
+      expect(cadence[1].pitch).toBe('G');
+    });
+
+    it('generates deceptive cadence in G major', () => {
+      const cadence = generateCadence('deceptive', 'G');
+
+      // Last note should be submediant (E)
+      expect(cadence[2].pitch).toBe('E');
+    });
+
+    it('creates surprise ending', () => {
+      const perfect = generateCadence('perfect', 'C');
+      const deceptive = generateCadence('deceptive', 'C');
+
+      // Both should have dominant (G) before final note
+      expect(perfect[1].pitch).toBe('G');
+      expect(deceptive[1].pitch).toBe('G');
+
+      // But endings differ: C vs A
+      expect(perfect[2].pitch).toBe('C');
+      expect(deceptive[2].pitch).toBe('A');
+    });
+  });
+
+  describe('plagal cadence (IV→I)', () => {
+    it('generates plagal cadence in C major', () => {
+      const cadence = generateCadence('plagal', 'C');
+
+      expect(cadence).toHaveLength(3);
+
+      // Last note should be tonic (C)
+      expect(cadence[2].pitch).toBe('C');
+
+      // Second-to-last should be subdominant (F)
+      expect(cadence[1].pitch).toBe('F');
+    });
+
+    it('generates plagal cadence in G major', () => {
+      const cadence = generateCadence('plagal', 'G');
+
+      // Last note should be tonic (G)
+      expect(cadence[2].pitch).toBe('G');
+
+      // Subdominant is C
+      expect(cadence[1].pitch).toBe('C');
+    });
+
+    it('ends on tonic like perfect cadence', () => {
+      const perfect = generateCadence('perfect', 'C');
+      const plagal = generateCadence('plagal', 'C');
+
+      // Both end on tonic
+      expect(perfect[2].pitch).toBe(plagal[2].pitch);
+      expect(plagal[2].pitch).toBe('C');
+    });
+  });
+
+  describe('octave handling', () => {
+    it('respects base octave parameter', () => {
+      const cadence0 = generateCadence('perfect', 'C', 0);
+      const cadence1 = generateCadence('perfect', 'C', 1);
+
+      // Octave should be offset
+      expect(cadence1[2].octave).toBe(cadence0[2].octave + 1);
+    });
+
+    it('supports negative base octave', () => {
+      const cadence = generateCadence('perfect', 'C', -1);
+
+      expect(cadence[2].octave).toBe(-1);
+    });
+  });
+
+  describe('unknown cadence type', () => {
+    it('falls back to perfect cadence', () => {
+      // Force unknown type via type assertion
+      const cadence = generateCadence('unknown' as CadenceType, 'C');
+      const perfect = generateCadence('perfect', 'C');
+
+      // Should behave like perfect cadence
+      expect(cadence[cadence.length - 1].pitch).toBe(perfect[perfect.length - 1].pitch);
+    });
+  });
+});
+
+describe('determineLineEndingCadence', () => {
+  describe('final line of poem', () => {
+    it('returns perfect cadence for last line of last stanza', () => {
+      const position: LinePosition = {
+        lineIndex: 3,
+        totalLines: 4,
+        isStanzaEnd: true,
+        isLastStanza: true,
+      };
+
+      expect(determineLineEndingCadence(position)).toBe('perfect');
+    });
+
+    it('returns perfect for final couplet', () => {
+      const position: LinePosition = {
+        lineIndex: 1,
+        totalLines: 2,
+        isStanzaEnd: true,
+        isLastStanza: true,
+      };
+
+      expect(determineLineEndingCadence(position)).toBe('perfect');
+    });
+  });
+
+  describe('stanza endings', () => {
+    it('returns perfect cadence for end of non-final stanza', () => {
+      const position: LinePosition = {
+        lineIndex: 3,
+        totalLines: 4,
+        isStanzaEnd: true,
+        isLastStanza: false,
+      };
+
+      expect(determineLineEndingCadence(position)).toBe('perfect');
+    });
+
+    it('returns perfect for stanza end in 6-line stanza', () => {
+      const position: LinePosition = {
+        lineIndex: 5,
+        totalLines: 6,
+        isStanzaEnd: true,
+        isLastStanza: false,
+      };
+
+      expect(determineLineEndingCadence(position)).toBe('perfect');
+    });
+  });
+
+  describe('mid-stanza lines', () => {
+    it('returns half cadence for first line of stanza', () => {
+      const position: LinePosition = {
+        lineIndex: 0,
+        totalLines: 4,
+        isStanzaEnd: false,
+        isLastStanza: false,
+      };
+
+      expect(determineLineEndingCadence(position)).toBe('half');
+    });
+
+    it('returns half cadence for second line of quartet', () => {
+      const position: LinePosition = {
+        lineIndex: 1,
+        totalLines: 4,
+        isStanzaEnd: false,
+        isLastStanza: false,
+      };
+
+      // Line 1 is ~50%, may get plagal
+      const result = determineLineEndingCadence(position);
+      expect(['half', 'plagal']).toContain(result);
+    });
+  });
+
+  describe('second-to-last line (tension building)', () => {
+    it('returns deceptive cadence for penultimate line in 4-line stanza', () => {
+      const position: LinePosition = {
+        lineIndex: 2, // 0-indexed, so this is 3rd line of 4
+        totalLines: 4,
+        isStanzaEnd: false,
+        isLastStanza: false,
+      };
+
+      expect(determineLineEndingCadence(position)).toBe('deceptive');
+    });
+
+    it('returns deceptive for line 4 of 6-line stanza', () => {
+      const position: LinePosition = {
+        lineIndex: 4, // 5th line of 6
+        totalLines: 6,
+        isStanzaEnd: false,
+        isLastStanza: false,
+      };
+
+      expect(determineLineEndingCadence(position)).toBe('deceptive');
+    });
+  });
+
+  describe('couplet handling', () => {
+    it('returns half for first line of couplet', () => {
+      const position: LinePosition = {
+        lineIndex: 0,
+        totalLines: 2,
+        isStanzaEnd: false,
+        isLastStanza: false,
+      };
+
+      // First line of a 2-line stanza should continue
+      expect(determineLineEndingCadence(position)).toBe('half');
+    });
+  });
+
+  describe('three-line stanza (tercet)', () => {
+    it('returns half for first line', () => {
+      const position: LinePosition = {
+        lineIndex: 0,
+        totalLines: 3,
+        isStanzaEnd: false,
+        isLastStanza: false,
+      };
+
+      expect(determineLineEndingCadence(position)).toBe('half');
+    });
+
+    it('returns half or deceptive for second line', () => {
+      const position: LinePosition = {
+        lineIndex: 1,
+        totalLines: 3,
+        isStanzaEnd: false,
+        isLastStanza: false,
+      };
+
+      const result = determineLineEndingCadence(position);
+      // Second line of 3 is penultimate, but stanza too short for deceptive
+      expect(['half', 'plagal']).toContain(result);
+    });
+  });
+
+  describe('varied stanza lengths', () => {
+    it('handles 8-line stanza correctly', () => {
+      // Test various positions in an 8-line stanza
+      const results: CadenceType[] = [];
+      for (let i = 0; i < 8; i++) {
+        const position: LinePosition = {
+          lineIndex: i,
+          totalLines: 8,
+          isStanzaEnd: i === 7,
+          isLastStanza: false,
+        };
+        results.push(determineLineEndingCadence(position));
+      }
+
+      // Last line should be perfect
+      expect(results[7]).toBe('perfect');
+
+      // Penultimate should be deceptive
+      expect(results[6]).toBe('deceptive');
+
+      // Early lines should be half or plagal
+      expect(['half', 'plagal']).toContain(results[0]);
+    });
+  });
+});
+
+describe('applyPhraseClosure', () => {
+  describe('basic functionality', () => {
+    it('adds cadence notes to existing melody', () => {
+      const melody: Note[] = [
+        { pitch: 'C', octave: 0, duration: 2 },
+        { pitch: 'E', octave: 0, duration: 2 },
+        { pitch: 'G', octave: 0, duration: 2 },
+      ];
+
+      const result = applyPhraseClosure(melody, 'perfect', 'C');
+
+      // Should have original notes plus cadence
+      expect(result.length).toBeGreaterThan(melody.length);
+
+      // Original notes should be preserved
+      expect(result[0]).toEqual(melody[0]);
+      expect(result[1]).toEqual(melody[1]);
+      expect(result[2]).toEqual(melody[2]);
+    });
+
+    it('handles empty melody', () => {
+      const result = applyPhraseClosure([], 'perfect', 'C');
+
+      // Should just return the cadence
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[result.length - 1].pitch).toBe('C');
+    });
+  });
+
+  describe('octave matching', () => {
+    it('matches octave of last melody note', () => {
+      const melody: Note[] = [
+        { pitch: 'E', octave: 1, duration: 2 },
+      ];
+
+      const result = applyPhraseClosure(melody, 'perfect', 'C');
+
+      // Cadence notes should be in octave 1
+      const cadenceNotes = result.slice(1);
+      expect(cadenceNotes.some(n => n.octave >= 1)).toBe(true);
+    });
+
+    it('works with low octave melody', () => {
+      const melody: Note[] = [
+        { pitch: 'A', octave: -1, duration: 2 },
+      ];
+
+      const result = applyPhraseClosure(melody, 'perfect', 'Am');
+
+      // Final note should be low octave tonic
+      expect(result[result.length - 1].pitch).toBe('A');
+    });
+  });
+
+  describe('cadence type application', () => {
+    const melody: Note[] = [
+      { pitch: 'D', octave: 0, duration: 2 },
+    ];
+
+    it('applies perfect cadence correctly', () => {
+      const result = applyPhraseClosure(melody, 'perfect', 'C');
+      expect(result[result.length - 1].pitch).toBe('C');
+    });
+
+    it('applies half cadence correctly', () => {
+      const result = applyPhraseClosure(melody, 'half', 'C');
+      expect(result[result.length - 1].pitch).toBe('G');
+    });
+
+    it('applies deceptive cadence correctly', () => {
+      const result = applyPhraseClosure(melody, 'deceptive', 'C');
+      expect(result[result.length - 1].pitch).toBe('A');
+    });
+
+    it('applies plagal cadence correctly', () => {
+      const result = applyPhraseClosure(melody, 'plagal', 'C');
+      expect(result[result.length - 1].pitch).toBe('C');
+    });
+  });
+
+  describe('different keys', () => {
+    it('works with G major', () => {
+      const melody: Note[] = [
+        { pitch: 'B', octave: 0, duration: 2 },
+      ];
+
+      const result = applyPhraseClosure(melody, 'perfect', 'G');
+
+      // Should end on G
+      expect(result[result.length - 1].pitch).toBe('G');
+    });
+
+    it('works with minor keys', () => {
+      const melody: Note[] = [
+        { pitch: 'C', octave: 0, duration: 2 },
+      ];
+
+      const result = applyPhraseClosure(melody, 'perfect', 'Am');
+
+      // Should end on A
+      expect(result[result.length - 1].pitch).toBe('A');
+    });
+  });
+
+  describe('default key', () => {
+    it('defaults to C major when key not specified', () => {
+      const melody: Note[] = [
+        { pitch: 'E', octave: 0, duration: 2 },
+      ];
+
+      const result = applyPhraseClosure(melody, 'perfect');
+
+      // Should end on C
+      expect(result[result.length - 1].pitch).toBe('C');
+    });
+  });
+});
+
+describe('getShortCadence', () => {
+  it('returns 2-note perfect cadence', () => {
+    const cadence = getShortCadence('perfect', 'C');
+
+    expect(cadence).toHaveLength(2);
+    expect(cadence[0].pitch).toBe('G'); // V
+    expect(cadence[1].pitch).toBe('C'); // I
+  });
+
+  it('returns 2-note half cadence', () => {
+    const cadence = getShortCadence('half', 'C');
+
+    expect(cadence).toHaveLength(2);
+    expect(cadence[0].pitch).toBe('F'); // IV
+    expect(cadence[1].pitch).toBe('G'); // V
+  });
+
+  it('returns 2-note deceptive cadence', () => {
+    const cadence = getShortCadence('deceptive', 'C');
+
+    expect(cadence).toHaveLength(2);
+    expect(cadence[0].pitch).toBe('G'); // V
+    expect(cadence[1].pitch).toBe('A'); // vi
+  });
+
+  it('returns 2-note plagal cadence', () => {
+    const cadence = getShortCadence('plagal', 'C');
+
+    expect(cadence).toHaveLength(2);
+    expect(cadence[0].pitch).toBe('F'); // IV
+    expect(cadence[1].pitch).toBe('C'); // I
+  });
+
+  it('respects base octave', () => {
+    const cadence = getShortCadence('perfect', 'C', 1);
+
+    expect(cadence[0].octave).toBe(1);
+    expect(cadence[1].octave).toBe(1);
+  });
+
+  it('has appropriate durations', () => {
+    const cadence = getShortCadence('perfect', 'C');
+
+    // First note shorter, second longer
+    expect(cadence[0].duration).toBe(2);
+    expect(cadence[1].duration).toBe(4);
+  });
+});
+
+describe('validateCadence', () => {
+  describe('perfect cadence validation', () => {
+    it('validates correct perfect cadence', () => {
+      const cadence = generateCadence('perfect', 'C');
+      const result = validateCadence(cadence, 'perfect', 'C');
+
+      expect(result.valid).toBe(true);
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it('fails if perfect cadence ends on wrong note', () => {
+      const badCadence: Note[] = [
+        { pitch: 'B', octave: 0, duration: 2 },
+        { pitch: 'G', octave: 0, duration: 4 }, // Should be C
+      ];
+
+      const result = validateCadence(badCadence, 'perfect', 'C');
+
+      expect(result.valid).toBe(false);
+      expect(result.issues[0]).toContain('should end on tonic');
+    });
+  });
+
+  describe('half cadence validation', () => {
+    it('validates correct half cadence', () => {
+      const cadence = generateCadence('half', 'C');
+      const result = validateCadence(cadence, 'half', 'C');
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('fails if half cadence ends on wrong note', () => {
+      const badCadence: Note[] = [
+        { pitch: 'F', octave: 0, duration: 2 },
+        { pitch: 'C', octave: 0, duration: 4 }, // Should be G
+      ];
+
+      const result = validateCadence(badCadence, 'half', 'C');
+
+      expect(result.valid).toBe(false);
+      expect(result.issues[0]).toContain('should end on dominant');
+    });
+  });
+
+  describe('deceptive cadence validation', () => {
+    it('validates correct deceptive cadence', () => {
+      const cadence = generateCadence('deceptive', 'C');
+      const result = validateCadence(cadence, 'deceptive', 'C');
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('fails if deceptive cadence ends on tonic', () => {
+      const badCadence: Note[] = [
+        { pitch: 'G', octave: 0, duration: 2 },
+        { pitch: 'C', octave: 0, duration: 4 }, // Should be A
+      ];
+
+      const result = validateCadence(badCadence, 'deceptive', 'C');
+
+      expect(result.valid).toBe(false);
+      expect(result.issues[0]).toContain('should end on submediant');
+    });
+  });
+
+  describe('plagal cadence validation', () => {
+    it('validates correct plagal cadence', () => {
+      const cadence = generateCadence('plagal', 'C');
+      const result = validateCadence(cadence, 'plagal', 'C');
+
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('duration validation', () => {
+    it('warns if final note is too short', () => {
+      const shortCadence: Note[] = [
+        { pitch: 'G', octave: 0, duration: 2 },
+        { pitch: 'C', octave: 0, duration: 1 }, // Duration too short
+      ];
+
+      const result = validateCadence(shortCadence, 'perfect', 'C');
+
+      expect(result.issues.some(i => i.includes('duration'))).toBe(true);
+    });
+  });
+
+  describe('empty cadence', () => {
+    it('returns invalid for empty cadence', () => {
+      const result = validateCadence([], 'perfect', 'C');
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toContain('Cadence is empty');
+    });
+  });
+});
+
+describe('getCadenceToTarget', () => {
+  describe('targeting tonic', () => {
+    it('approaches tonic via dominant', () => {
+      const cadence = getCadenceToTarget('C', 'C');
+
+      expect(cadence[cadence.length - 1].pitch).toBe('C');
+      expect(cadence[0].pitch).toBe('G'); // Dominant approach
+    });
+  });
+
+  describe('targeting dominant', () => {
+    it('approaches dominant via subdominant', () => {
+      const cadence = getCadenceToTarget('G', 'C');
+
+      expect(cadence[cadence.length - 1].pitch).toBe('G');
+      expect(cadence[0].pitch).toBe('F'); // Subdominant approach
+    });
+  });
+
+  describe('targeting other scale degrees', () => {
+    it('uses step-wise approach for other targets', () => {
+      const cadence = getCadenceToTarget('E', 'C');
+
+      expect(cadence[cadence.length - 1].pitch).toBe('E');
+      // Should approach from scale degree below
+      expect(cadence).toHaveLength(2);
+    });
+  });
+
+  describe('non-scale tones', () => {
+    it('handles target not in scale', () => {
+      // F# is not in C major
+      const cadence = getCadenceToTarget('X', 'C');
+
+      // Should still return the target
+      expect(cadence.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('base octave', () => {
+    it('respects base octave parameter', () => {
+      const cadence = getCadenceToTarget('C', 'C', 1);
+
+      expect(cadence[cadence.length - 1].octave).toBe(1);
+    });
+  });
+});
+
+describe('suggestCadenceForEmotion', () => {
+  it('suggests perfect for conclusive emotion', () => {
+    expect(suggestCadenceForEmotion('conclusive')).toBe('perfect');
+  });
+
+  it('suggests half for suspenseful emotion', () => {
+    expect(suggestCadenceForEmotion('suspenseful')).toBe('half');
+  });
+
+  it('suggests deceptive for surprising emotion', () => {
+    expect(suggestCadenceForEmotion('surprising')).toBe('deceptive');
+  });
+
+  it('suggests plagal for peaceful emotion', () => {
+    expect(suggestCadenceForEmotion('peaceful')).toBe('plagal');
+  });
+
+  it('defaults to perfect for unknown emotion', () => {
+    // Force unknown via type assertion
+    expect(suggestCadenceForEmotion('unknown' as Parameters<typeof suggestCadenceForEmotion>[0])).toBe('perfect');
+  });
+});
+
+describe('integration tests', () => {
+  describe('complete phrase with cadence', () => {
+    it('builds a complete 4-line stanza with appropriate cadences', () => {
+      // Simulate processing a 4-line stanza
+      const stanzaResults: { line: number; cadence: CadenceType }[] = [];
+
+      for (let i = 0; i < 4; i++) {
+        const position: LinePosition = {
+          lineIndex: i,
+          totalLines: 4,
+          isStanzaEnd: i === 3,
+          isLastStanza: true,
+        };
+
+        stanzaResults.push({
+          line: i + 1,
+          cadence: determineLineEndingCadence(position),
+        });
+      }
+
+      // Lines 1-2 should be half or plagal (continuing)
+      expect(['half', 'plagal']).toContain(stanzaResults[0].cadence);
+      expect(['half', 'plagal']).toContain(stanzaResults[1].cadence);
+
+      // Line 3 should be deceptive (tension)
+      expect(stanzaResults[2].cadence).toBe('deceptive');
+
+      // Line 4 should be perfect (final resolution)
+      expect(stanzaResults[3].cadence).toBe('perfect');
+    });
+  });
+
+  describe('melody with cadence application', () => {
+    it('creates properly resolved phrase in Am', () => {
+      const melody: Note[] = [
+        { pitch: 'A', octave: 0, duration: 2 },
+        { pitch: 'B', octave: 0, duration: 1 },
+        { pitch: 'C', octave: 1, duration: 2 },
+        { pitch: 'B', octave: 0, duration: 1 },
+        { pitch: 'A', octave: 0, duration: 2 },
+      ];
+
+      const phrase = applyPhraseClosure(melody, 'perfect', 'Am');
+
+      // Should end on A (tonic of Am)
+      expect(phrase[phrase.length - 1].pitch).toBe('A');
+
+      // Should include E (dominant) before final A
+      const hasE = phrase.slice(-4).some(n => n.pitch === 'E');
+      expect(hasE).toBe(true);
+    });
+  });
+
+  describe('all cadence types valid in all keys', () => {
+    const allKeys: KeySignature[] = ['C', 'G', 'D', 'F', 'Am', 'Em', 'Dm'];
+    const allTypes: CadenceType[] = ['perfect', 'half', 'deceptive', 'plagal'];
+
+    for (const key of allKeys) {
+      for (const type of allTypes) {
+        it(`generates valid ${type} cadence in ${key}`, () => {
+          const cadence = generateCadence(type, key);
+          const validation = validateCadence(cadence, type, key);
+
+          expect(validation.valid).toBe(true);
+          expect(cadence.length).toBeGreaterThan(0);
+        });
+      }
+    }
+  });
+
+  describe('real-world poem scenarios', () => {
+    it('handles Shakespearean sonnet structure (14 lines, 3 quatrains + couplet)', () => {
+      // Simulate quatrain 1 (lines 1-4)
+      const quatrain1: CadenceType[] = [];
+      for (let i = 0; i < 4; i++) {
+        const position: LinePosition = {
+          lineIndex: i,
+          totalLines: 4,
+          isStanzaEnd: i === 3,
+          isLastStanza: false,
+        };
+        quatrain1.push(determineLineEndingCadence(position));
+      }
+
+      // Final quatrain line should have strong ending
+      expect(quatrain1[3]).toBe('perfect');
+
+      // Simulate final couplet (lines 13-14)
+      const couplet: CadenceType[] = [];
+      for (let i = 0; i < 2; i++) {
+        const position: LinePosition = {
+          lineIndex: i,
+          totalLines: 2,
+          isStanzaEnd: i === 1,
+          isLastStanza: true,
+        };
+        couplet.push(determineLineEndingCadence(position));
+      }
+
+      // Final line of poem should be perfect
+      expect(couplet[1]).toBe('perfect');
+    });
+
+    it('handles haiku structure (3 lines)', () => {
+      const haiku: CadenceType[] = [];
+      for (let i = 0; i < 3; i++) {
+        const position: LinePosition = {
+          lineIndex: i,
+          totalLines: 3,
+          isStanzaEnd: i === 2,
+          isLastStanza: true,
+        };
+        haiku.push(determineLineEndingCadence(position));
+      }
+
+      // First two lines continue, last resolves
+      expect(['half', 'plagal']).toContain(haiku[0]);
+      expect(['half', 'plagal']).toContain(haiku[1]);
+      expect(haiku[2]).toBe('perfect');
+    });
+  });
+});
+
+describe('edge cases', () => {
+  describe('single line poem', () => {
+    it('uses perfect cadence for single line', () => {
+      const position: LinePosition = {
+        lineIndex: 0,
+        totalLines: 1,
+        isStanzaEnd: true,
+        isLastStanza: true,
+      };
+
+      expect(determineLineEndingCadence(position)).toBe('perfect');
+    });
+  });
+
+  describe('very long stanza', () => {
+    it('handles 20-line stanza', () => {
+      const position: LinePosition = {
+        lineIndex: 18, // Penultimate
+        totalLines: 20,
+        isStanzaEnd: false,
+        isLastStanza: false,
+      };
+
+      // Should still get deceptive for tension
+      expect(determineLineEndingCadence(position)).toBe('deceptive');
+    });
+  });
+
+  describe('octave extremes', () => {
+    it('handles very high octave', () => {
+      const cadence = generateCadence('perfect', 'C', 3);
+
+      expect(cadence[0].octave).toBe(3);
+    });
+
+    it('handles very low octave', () => {
+      const cadence = generateCadence('perfect', 'C', -2);
+
+      expect(cadence[0].octave).toBe(-2);
+    });
+  });
+
+  describe('note durations in cadence', () => {
+    it('ensures final note is longer for proper resolution', () => {
+      for (const type of ['perfect', 'half', 'deceptive', 'plagal'] as CadenceType[]) {
+        const cadence = generateCadence(type, 'C');
+        const lastNote = cadence[cadence.length - 1];
+
+        expect(lastNote.duration).toBeGreaterThanOrEqual(2);
+      }
+    });
+  });
+});

--- a/web/src/lib/melody/cadence.ts
+++ b/web/src/lib/melody/cadence.ts
@@ -1,0 +1,686 @@
+/**
+ * Cadence and Phrase Ending Generator
+ *
+ * Generates musically appropriate phrase endings (cadences) for melodies.
+ * Cadences provide closure and structure to musical phrases, creating
+ * natural breathing points and resolution in the melody.
+ *
+ * Reference: docs/MELODY_GENERATION.md - Phrase Endings section
+ */
+
+import type { Note, KeySignature } from './types';
+
+// Logging helper for debugging
+const DEBUG = process.env.NODE_ENV === 'development';
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[cadence] ${message}`, ...args);
+  }
+};
+
+/**
+ * Types of musical cadences
+ *
+ * - perfect: V→I - Strong, conclusive ending (dominant to tonic)
+ * - half: ?→V - Incomplete feel, keeps the music moving (ends on dominant)
+ * - deceptive: V→vi - Surprise ending (dominant to submediant)
+ * - plagal: IV→I - "Amen" cadence (subdominant to tonic)
+ */
+export type CadenceType = 'perfect' | 'half' | 'deceptive' | 'plagal';
+
+/**
+ * Position information for a line within a poem
+ */
+export interface LinePosition {
+  /** Zero-based index of the line within the stanza */
+  lineIndex: number;
+  /** Total number of lines in the stanza */
+  totalLines: number;
+  /** Whether this line ends a stanza */
+  isStanzaEnd: boolean;
+  /** Whether this is the last stanza of the poem */
+  isLastStanza: boolean;
+}
+
+/**
+ * Scale degree information for cadence construction
+ */
+interface ScaleDegree {
+  /** Pitch name */
+  pitch: string;
+  /** Octave relative to tonic (0 = same octave as tonic) */
+  octave: number;
+}
+
+/**
+ * Scale degrees for major keys
+ * Index 0 = tonic (I), 1 = supertonic (ii), etc.
+ */
+const MAJOR_SCALE_DEGREES: Record<string, ScaleDegree[]> = {
+  C: [
+    { pitch: 'C', octave: 0 }, // I - Tonic
+    { pitch: 'D', octave: 0 }, // ii - Supertonic
+    { pitch: 'E', octave: 0 }, // iii - Mediant
+    { pitch: 'F', octave: 0 }, // IV - Subdominant
+    { pitch: 'G', octave: 0 }, // V - Dominant
+    { pitch: 'A', octave: 0 }, // vi - Submediant
+    { pitch: 'B', octave: 0 }, // vii° - Leading tone
+  ],
+  G: [
+    { pitch: 'G', octave: 0 },
+    { pitch: 'A', octave: 0 },
+    { pitch: 'B', octave: 0 },
+    { pitch: 'C', octave: 1 },
+    { pitch: 'D', octave: 1 },
+    { pitch: 'E', octave: 1 },
+    { pitch: 'F', octave: 1 }, // F# in G major, but we use natural for simplicity
+  ],
+  D: [
+    { pitch: 'D', octave: 0 },
+    { pitch: 'E', octave: 0 },
+    { pitch: 'F', octave: 0 }, // F# in D major
+    { pitch: 'G', octave: 0 },
+    { pitch: 'A', octave: 0 },
+    { pitch: 'B', octave: 0 },
+    { pitch: 'C', octave: 1 }, // C# in D major
+  ],
+  F: [
+    { pitch: 'F', octave: 0 },
+    { pitch: 'G', octave: 0 },
+    { pitch: 'A', octave: 0 },
+    { pitch: 'B', octave: 0 }, // Bb in F major
+    { pitch: 'C', octave: 1 },
+    { pitch: 'D', octave: 1 },
+    { pitch: 'E', octave: 1 },
+  ],
+};
+
+/**
+ * Scale degrees for minor keys
+ * Uses natural minor scale
+ */
+const MINOR_SCALE_DEGREES: Record<string, ScaleDegree[]> = {
+  Am: [
+    { pitch: 'A', octave: 0 }, // i - Tonic
+    { pitch: 'B', octave: 0 }, // ii° - Supertonic
+    { pitch: 'C', octave: 1 }, // III - Mediant
+    { pitch: 'D', octave: 1 }, // iv - Subdominant
+    { pitch: 'E', octave: 1 }, // v - Dominant (or V with G#)
+    { pitch: 'F', octave: 1 }, // VI - Submediant
+    { pitch: 'G', octave: 1 }, // VII - Subtonic
+  ],
+  Em: [
+    { pitch: 'E', octave: 0 },
+    { pitch: 'F', octave: 0 }, // F# in E minor
+    { pitch: 'G', octave: 0 },
+    { pitch: 'A', octave: 0 },
+    { pitch: 'B', octave: 0 },
+    { pitch: 'C', octave: 1 },
+    { pitch: 'D', octave: 1 },
+  ],
+  Dm: [
+    { pitch: 'D', octave: 0 },
+    { pitch: 'E', octave: 0 },
+    { pitch: 'F', octave: 0 },
+    { pitch: 'G', octave: 0 },
+    { pitch: 'A', octave: 0 },
+    { pitch: 'B', octave: 0 }, // Bb in D minor
+    { pitch: 'C', octave: 1 },
+  ],
+};
+
+/**
+ * Checks if a key is minor
+ */
+function isMinorKey(key: KeySignature): boolean {
+  return key.endsWith('m');
+}
+
+/**
+ * Gets scale degrees for a given key
+ */
+function getScaleDegrees(key: KeySignature): ScaleDegree[] {
+  if (isMinorKey(key)) {
+    return MINOR_SCALE_DEGREES[key] || MINOR_SCALE_DEGREES['Am'];
+  }
+  return MAJOR_SCALE_DEGREES[key] || MAJOR_SCALE_DEGREES['C'];
+}
+
+/**
+ * Gets the tonic note for a key
+ */
+function getTonic(key: KeySignature): ScaleDegree {
+  const degrees = getScaleDegrees(key);
+  return degrees[0];
+}
+
+/**
+ * Gets the dominant note (V) for a key
+ */
+function getDominant(key: KeySignature): ScaleDegree {
+  const degrees = getScaleDegrees(key);
+  return degrees[4];
+}
+
+/**
+ * Gets the subdominant note (IV) for a key
+ */
+function getSubdominant(key: KeySignature): ScaleDegree {
+  const degrees = getScaleDegrees(key);
+  return degrees[3];
+}
+
+/**
+ * Gets the submediant note (vi) for a key
+ */
+function getSubmediant(key: KeySignature): ScaleDegree {
+  const degrees = getScaleDegrees(key);
+  return degrees[5];
+}
+
+/**
+ * Gets the leading tone (vii) for a key
+ */
+function getLeadingTone(key: KeySignature): ScaleDegree {
+  const degrees = getScaleDegrees(key);
+  return degrees[6];
+}
+
+/**
+ * Gets the supertonic (ii) for a key
+ */
+function getSupertonic(key: KeySignature): ScaleDegree {
+  const degrees = getScaleDegrees(key);
+  return degrees[1];
+}
+
+/**
+ * Creates a Note from a ScaleDegree
+ */
+function createNote(degree: ScaleDegree, duration: number, baseOctave: number = 0): Note {
+  return {
+    pitch: degree.pitch,
+    octave: baseOctave + degree.octave,
+    duration,
+  };
+}
+
+/**
+ * Generates a cadence pattern for the specified type and key.
+ *
+ * Cadence patterns:
+ * - Perfect (V→I): Dominant to tonic - strongest resolution
+ * - Half (?→V): Ends on dominant - creates expectation
+ * - Deceptive (V→vi): Dominant to submediant - surprise
+ * - Plagal (IV→I): Subdominant to tonic - "Amen" cadence
+ *
+ * @param type - The type of cadence to generate
+ * @param key - The musical key for the cadence
+ * @param baseOctave - Base octave for the notes (default 0)
+ * @returns Array of notes forming the cadence
+ *
+ * @example
+ * ```typescript
+ * // Generate a perfect cadence in C major
+ * const cadence = generateCadence('perfect', 'C');
+ * // Returns notes: G (duration 2) -> C (duration 4)
+ * ```
+ */
+export function generateCadence(
+  type: CadenceType,
+  key: KeySignature,
+  baseOctave: number = 0
+): Note[] {
+  log('generateCadence', { type, key, baseOctave });
+
+  const tonic = getTonic(key);
+  const dominant = getDominant(key);
+  const subdominant = getSubdominant(key);
+  const submediant = getSubmediant(key);
+  const leadingTone = getLeadingTone(key);
+  const supertonic = getSupertonic(key);
+
+  switch (type) {
+    case 'perfect': {
+      // V → I: Strong resolution
+      // Include leading tone for stronger resolution
+      log('Generating perfect cadence: V → I');
+      return [
+        createNote(leadingTone, 1, baseOctave),  // Leading tone (approach)
+        createNote(dominant, 2, baseOctave),      // Dominant
+        createNote(tonic, 4, baseOctave),         // Tonic (longer for resolution)
+      ];
+    }
+
+    case 'half': {
+      // ? → V: Ends on dominant, incomplete feel
+      // Approach from supertonic or subdominant
+      log('Generating half cadence: ii → V');
+      return [
+        createNote(supertonic, 1, baseOctave),    // Supertonic (approach)
+        createNote(leadingTone, 1, baseOctave),   // Leading tone
+        createNote(dominant, 4, baseOctave),      // Dominant (end)
+      ];
+    }
+
+    case 'deceptive': {
+      // V → vi: Surprise ending
+      log('Generating deceptive cadence: V → vi');
+      return [
+        createNote(leadingTone, 1, baseOctave),   // Leading tone (approach)
+        createNote(dominant, 2, baseOctave),      // Dominant
+        createNote(submediant, 4, baseOctave),    // Submediant (surprise)
+      ];
+    }
+
+    case 'plagal': {
+      // IV → I: "Amen" cadence
+      log('Generating plagal cadence: IV → I');
+      return [
+        createNote(submediant, 1, baseOctave),    // vi (approach)
+        createNote(subdominant, 2, baseOctave),   // Subdominant
+        createNote(tonic, 4, baseOctave),         // Tonic
+      ];
+    }
+
+    default: {
+      // Fallback to perfect cadence
+      log('Unknown cadence type, defaulting to perfect');
+      return generateCadence('perfect', key, baseOctave);
+    }
+  }
+}
+
+/**
+ * Determines the appropriate cadence type based on line position within the poem.
+ *
+ * Cadence selection rules:
+ * - Final line of poem (last line of last stanza) → Perfect cadence
+ * - Stanza end (but not final) → Perfect cadence
+ * - Mid-stanza line → Half cadence
+ * - Second-to-last line of stanza → May use deceptive for tension
+ *
+ * @param position - The position of the line in the poem
+ * @returns The recommended cadence type for this position
+ *
+ * @example
+ * ```typescript
+ * // Last line of a 4-line stanza in the final stanza
+ * const cadence = determineLineEndingCadence({
+ *   lineIndex: 3,
+ *   totalLines: 4,
+ *   isStanzaEnd: true,
+ *   isLastStanza: true
+ * });
+ * // Returns 'perfect'
+ *
+ * // Middle of a stanza
+ * const cadence = determineLineEndingCadence({
+ *   lineIndex: 1,
+ *   totalLines: 4,
+ *   isStanzaEnd: false,
+ *   isLastStanza: false
+ * });
+ * // Returns 'half'
+ * ```
+ */
+export function determineLineEndingCadence(position: LinePosition): CadenceType {
+  log('determineLineEndingCadence', position);
+
+  const { lineIndex, totalLines, isStanzaEnd, isLastStanza } = position;
+
+  // Final line of the entire poem - strongest resolution
+  if (isStanzaEnd && isLastStanza) {
+    log('Final line of poem - using perfect cadence');
+    return 'perfect';
+  }
+
+  // End of a stanza (but not the last stanza)
+  if (isStanzaEnd && !isLastStanza) {
+    log('End of stanza (not final) - using perfect cadence');
+    return 'perfect';
+  }
+
+  // Second-to-last line of a stanza - sometimes use deceptive for tension
+  if (lineIndex === totalLines - 2 && totalLines >= 4) {
+    // Use deceptive cadence for longer stanzas to create anticipation
+    // This creates a "surprise" before the final resolution
+    log('Second-to-last line - using deceptive cadence for tension');
+    return 'deceptive';
+  }
+
+  // Check if this is a "turning point" in the stanza (around 60-70% through)
+  const positionRatio = (lineIndex + 1) / totalLines;
+  if (positionRatio >= 0.5 && positionRatio < 0.75 && totalLines >= 4) {
+    // Mid-to-late stanza - could use plagal for variety
+    // Only use occasionally to add musical interest
+    if (lineIndex % 2 === 1) {
+      log('Mid-stanza turning point - using plagal cadence');
+      return 'plagal';
+    }
+  }
+
+  // Default: mid-stanza lines use half cadence to keep music moving
+  log('Mid-stanza line - using half cadence');
+  return 'half';
+}
+
+/**
+ * Calculates the interval between two pitches
+ * Returns the number of scale steps
+ */
+function calculateInterval(from: string, to: string): number {
+  const pitchOrder = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+  const fromIndex = pitchOrder.indexOf(from.toUpperCase());
+  const toIndex = pitchOrder.indexOf(to.toUpperCase());
+
+  if (fromIndex === -1 || toIndex === -1) {
+    return 0;
+  }
+
+  // Simple interval calculation (not accounting for octave)
+  let interval = toIndex - fromIndex;
+  if (interval < 0) {
+    interval += 7;
+  }
+  return interval;
+}
+
+/**
+ * Creates a smooth transition note between two pitches
+ */
+function createTransitionNote(from: Note, to: Note, key: KeySignature): Note | null {
+  const interval = calculateInterval(from.pitch, to.pitch);
+
+  // If interval is large (4th or more), add a passing tone
+  if (interval >= 3) {
+    const degrees = getScaleDegrees(key);
+    const pitchOrder = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+    const fromIndex = pitchOrder.indexOf(from.pitch.toUpperCase());
+    const toIndex = pitchOrder.indexOf(to.pitch.toUpperCase());
+
+    // Find a midpoint pitch
+    let midIndex: number;
+    if (toIndex > fromIndex) {
+      midIndex = Math.floor((fromIndex + toIndex) / 2);
+    } else {
+      // Wrap around
+      midIndex = Math.floor((fromIndex + toIndex + 7) / 2) % 7;
+    }
+
+    const midPitch = pitchOrder[midIndex];
+
+    // Check if this pitch is in the scale
+    const inScale = degrees.some((d) => d.pitch === midPitch);
+    if (inScale) {
+      return {
+        pitch: midPitch,
+        octave: from.octave,
+        duration: 1, // Short passing tone
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Applies phrase closure by appending cadence notes to an existing note sequence.
+ * This function smoothly transitions from the melody into the cadence pattern,
+ * ensuring musical continuity.
+ *
+ * The function:
+ * 1. Analyzes the last note of the input sequence
+ * 2. Generates the appropriate cadence pattern
+ * 3. Adds transition notes if needed for smooth voice leading
+ * 4. Adjusts octaves to maintain comfortable range
+ *
+ * @param notes - The existing melody notes
+ * @param cadenceType - The type of cadence to apply
+ * @param key - The musical key (defaults to 'C')
+ * @returns New array with original notes plus cadence notes
+ *
+ * @example
+ * ```typescript
+ * const melody = [
+ *   { pitch: 'E', octave: 0, duration: 2 },
+ *   { pitch: 'D', octave: 0, duration: 2 },
+ * ];
+ *
+ * const withCadence = applyPhraseClosure(melody, 'perfect', 'C');
+ * // Returns melody + smooth transition to G -> C cadence
+ * ```
+ */
+export function applyPhraseClosure(
+  notes: Note[],
+  cadenceType: CadenceType,
+  key: KeySignature = 'C'
+): Note[] {
+  log('applyPhraseClosure', { noteCount: notes.length, cadenceType, key });
+
+  // Handle empty input
+  if (notes.length === 0) {
+    log('Empty notes array, returning cadence only');
+    return generateCadence(cadenceType, key);
+  }
+
+  // Get the last note to determine transition
+  const lastNote = notes[notes.length - 1];
+  log('Last melody note:', lastNote);
+
+  // Determine base octave from the last note
+  const baseOctave = lastNote.octave;
+
+  // Generate the cadence pattern
+  const cadenceNotes = generateCadence(cadenceType, key, baseOctave);
+  log('Generated cadence notes:', cadenceNotes);
+
+  // Check if we need a transition note for smooth voice leading
+  const firstCadenceNote = cadenceNotes[0];
+  const transitionNote = createTransitionNote(lastNote, firstCadenceNote, key);
+
+  // Build the result
+  const result = [...notes];
+
+  if (transitionNote) {
+    log('Adding transition note:', transitionNote);
+    result.push(transitionNote);
+  }
+
+  // Add cadence notes
+  result.push(...cadenceNotes);
+
+  log('Final phrase length:', result.length);
+  return result;
+}
+
+/**
+ * Gets a short cadence pattern (2 notes) for tighter phrase endings.
+ * Useful when there's limited space for a full cadence.
+ *
+ * @param type - The type of cadence
+ * @param key - The musical key
+ * @param baseOctave - Base octave for the notes
+ * @returns Array of 2 notes forming a shortened cadence
+ */
+export function getShortCadence(
+  type: CadenceType,
+  key: KeySignature,
+  baseOctave: number = 0
+): Note[] {
+  log('getShortCadence', { type, key, baseOctave });
+
+  const tonic = getTonic(key);
+  const dominant = getDominant(key);
+  const subdominant = getSubdominant(key);
+  const submediant = getSubmediant(key);
+
+  switch (type) {
+    case 'perfect':
+      return [
+        createNote(dominant, 2, baseOctave),
+        createNote(tonic, 4, baseOctave),
+      ];
+    case 'half':
+      return [
+        createNote(subdominant, 2, baseOctave),
+        createNote(dominant, 4, baseOctave),
+      ];
+    case 'deceptive':
+      return [
+        createNote(dominant, 2, baseOctave),
+        createNote(submediant, 4, baseOctave),
+      ];
+    case 'plagal':
+      return [
+        createNote(subdominant, 2, baseOctave),
+        createNote(tonic, 4, baseOctave),
+      ];
+    default:
+      return getShortCadence('perfect', key, baseOctave);
+  }
+}
+
+/**
+ * Validates that a cadence resolves correctly in the given key.
+ * Checks that the final note is appropriate for the cadence type.
+ *
+ * @param cadence - The cadence notes to validate
+ * @param type - The expected cadence type
+ * @param key - The musical key
+ * @returns Object with valid flag and any issues found
+ */
+export function validateCadence(
+  cadence: Note[],
+  type: CadenceType,
+  key: KeySignature
+): { valid: boolean; issues: string[] } {
+  const issues: string[] = [];
+
+  if (cadence.length === 0) {
+    issues.push('Cadence is empty');
+    return { valid: false, issues };
+  }
+
+  const lastNote = cadence[cadence.length - 1];
+  const tonic = getTonic(key);
+  const dominant = getDominant(key);
+  const submediant = getSubmediant(key);
+
+  switch (type) {
+    case 'perfect':
+    case 'plagal':
+      // Should end on tonic
+      if (lastNote.pitch !== tonic.pitch) {
+        issues.push(
+          `${type} cadence should end on tonic (${tonic.pitch}), but ends on ${lastNote.pitch}`
+        );
+      }
+      break;
+    case 'half':
+      // Should end on dominant
+      if (lastNote.pitch !== dominant.pitch) {
+        issues.push(
+          `Half cadence should end on dominant (${dominant.pitch}), but ends on ${lastNote.pitch}`
+        );
+      }
+      break;
+    case 'deceptive':
+      // Should end on submediant
+      if (lastNote.pitch !== submediant.pitch) {
+        issues.push(
+          `Deceptive cadence should end on submediant (${submediant.pitch}), but ends on ${lastNote.pitch}`
+        );
+      }
+      break;
+  }
+
+  // Check that last note has appropriate duration (should be longer)
+  if (lastNote.duration < 2) {
+    issues.push('Final cadence note should have longer duration for proper resolution');
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+/**
+ * Gets the cadence notes needed to resolve to a target pitch.
+ * Useful for creating custom phrase endings.
+ *
+ * @param targetPitch - The pitch to resolve to
+ * @param key - The musical key
+ * @param baseOctave - Base octave for notes
+ * @returns Notes that lead to the target pitch
+ */
+export function getCadenceToTarget(
+  targetPitch: string,
+  key: KeySignature,
+  baseOctave: number = 0
+): Note[] {
+  log('getCadenceToTarget', { targetPitch, key, baseOctave });
+
+  const degrees = getScaleDegrees(key);
+  const dominant = getDominant(key);
+  const subdominant = getSubdominant(key);
+
+  // Find what degree the target is
+  const targetDegree = degrees.findIndex(
+    (d) => d.pitch.toUpperCase() === targetPitch.toUpperCase()
+  );
+
+  if (targetDegree === -1) {
+    // Target not in scale - approach from step above
+    log('Target not in scale, using generic approach');
+    return [
+      { pitch: targetPitch, octave: baseOctave, duration: 4 },
+    ];
+  }
+
+  // Build approach based on target
+  switch (targetDegree) {
+    case 0: // Tonic - use V-I
+      return [
+        createNote(dominant, 2, baseOctave),
+        { pitch: targetPitch, octave: baseOctave, duration: 4 },
+      ];
+    case 4: // Dominant - use IV-V or ii-V
+      return [
+        createNote(subdominant, 2, baseOctave),
+        { pitch: targetPitch, octave: baseOctave, duration: 4 },
+      ];
+    default: {
+      // Generic step-wise approach
+      const prevDegree = (targetDegree - 1 + 7) % 7;
+      return [
+        createNote(degrees[prevDegree], 2, baseOctave),
+        { pitch: targetPitch, octave: baseOctave, duration: 4 },
+      ];
+    }
+  }
+}
+
+/**
+ * Suggests the best cadence type based on the emotional content.
+ *
+ * @param emotion - The emotional quality desired
+ * @returns Recommended cadence type
+ */
+export function suggestCadenceForEmotion(
+  emotion: 'conclusive' | 'suspenseful' | 'surprising' | 'peaceful'
+): CadenceType {
+  switch (emotion) {
+    case 'conclusive':
+      return 'perfect';
+    case 'suspenseful':
+      return 'half';
+    case 'surprising':
+      return 'deceptive';
+    case 'peaceful':
+      return 'plagal';
+    default:
+      return 'perfect';
+  }
+}

--- a/web/src/lib/melody/index.ts
+++ b/web/src/lib/melody/index.ts
@@ -7,3 +7,4 @@
 export * from './types';
 export * from './abcGenerator';
 export * from './rhythm';
+export * from './cadence';


### PR DESCRIPTION
## Summary
Implements a complete cadence and phrase ending generator for Ghost Note melodies, providing musically appropriate phrase resolutions based on line position and emotional context.

## Changes
- `web/src/lib/melody/cadence.ts` - Core cadence generation module with:
  - `generateCadence()` - Creates perfect (V→I), half (?→V), deceptive (V→vi), and plagal (IV→I) cadences
  - `determineLineEndingCadence()` - Selects cadence type based on line position in poem
  - `applyPhraseClosure()` - Smoothly appends cadence to existing melody with transition notes
  - `getShortCadence()` - Compact 2-note cadence for tight phrase endings
  - `validateCadence()` - Validates cadence correctness for given type and key
  - `getCadenceToTarget()` - Custom resolution to specific target pitch
  - `suggestCadenceForEmotion()` - Maps emotional qualities to cadence types
  
- `web/src/lib/melody/cadence.test.ts` - Comprehensive tests (102 tests)
  
- `web/src/lib/melody/index.ts` - Added cadence module export

## Key Features
- Supports all key signatures: C, G, D, F, Am, Em, Dm
- Proper scale degree calculation for major and minor keys
- Smooth voice leading with transition notes between melody and cadence
- Contextual cadence selection based on poem structure:
  - Final line → Perfect cadence (strongest resolution)
  - Stanza end → Perfect cadence
  - Penultimate line → Deceptive cadence (builds tension)
  - Mid-stanza → Half cadence (keeps music moving)

## Testing
- [x] Unit tests pass (`npm test` - 102 new tests, all passing)
- [x] Linter passes (`npm run lint`)
- [x] Manual testing of cadence generation in different keys

## Notes
- Follows existing code patterns from abcGenerator.ts
- Uses same Note type from types.ts
- Added debug logging for development mode
- Cadence durations follow musical convention (longer final notes)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)