### PR TITLE
feat(GH-102): Wire PoemInput component into App.tsx

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -51,6 +51,24 @@ vi.mock('@/components/Common', () => ({
   ),
 }));
 
+// Mock PoemInput component
+vi.mock('@/components/PoemInput', () => ({
+  PoemInput: ({ onAnalyze, showStats }: { onAnalyze?: () => void; showStats?: boolean }) => (
+    <div data-testid="poem-input-component" data-show-stats={showStats}>
+      <h2>Enter Your Poem</h2>
+      <textarea data-testid="poem-textarea" placeholder="Enter your poem..." />
+      <button data-testid="analyze-button" onClick={onAnalyze}>Analyze</button>
+      {showStats && (
+        <div data-testid="poem-stats">
+          <span>Lines: 0</span>
+          <span>Words: 0</span>
+          <span>Characters: 0</span>
+        </div>
+      )}
+    </div>
+  ),
+}));
+
 interface MockUIState {
   theme: 'light' | 'dark' | 'system';
   setTheme: ReturnType<typeof vi.fn>;
@@ -86,10 +104,17 @@ describe('App', () => {
       expect(screen.getByTestId('app-shell')).toHaveAttribute('data-active-view', 'poem-input');
     });
 
-    it('renders the default view placeholder', () => {
+    it('renders the PoemInput component in the default view', () => {
       render(<App />);
-      expect(screen.getByTestId('view-poem-input')).toBeInTheDocument();
-      expect(screen.getByText('No Poem Entered')).toBeInTheDocument();
+      expect(screen.getByTestId('poem-input-component')).toBeInTheDocument();
+      expect(screen.getByText('Enter Your Poem')).toBeInTheDocument();
+      expect(screen.getByTestId('poem-textarea')).toBeInTheDocument();
+      expect(screen.getByTestId('analyze-button')).toBeInTheDocument();
+    });
+
+    it('renders poem stats when showStats is true', () => {
+      render(<App />);
+      expect(screen.getByTestId('poem-stats')).toBeInTheDocument();
     });
   });
 
@@ -144,14 +169,25 @@ describe('App', () => {
       // Navigate back
       fireEvent.click(screen.getByTestId('nav-poem-input'));
       expect(screen.getByTestId('app-shell')).toHaveAttribute('data-active-view', 'poem-input');
+      expect(screen.getByTestId('poem-input-component')).toBeInTheDocument();
+    });
+
+    it('navigates to analysis view when analyze button is clicked', () => {
+      render(<App />);
+
+      // Click analyze button in PoemInput
+      fireEvent.click(screen.getByTestId('analyze-button'));
+
+      expect(screen.getByTestId('app-shell')).toHaveAttribute('data-active-view', 'analysis');
+      expect(screen.getByTestId('view-analysis')).toBeInTheDocument();
     });
   });
 
   describe('view placeholders', () => {
-    it('displays correct title and description for poem-input view', () => {
+    it('renders PoemInput component for poem-input view', () => {
       render(<App />);
-      expect(screen.getByText('No Poem Entered')).toBeInTheDocument();
-      expect(screen.getByText('Paste or type your poem to get started.')).toBeInTheDocument();
+      expect(screen.getByTestId('poem-input-component')).toBeInTheDocument();
+      expect(screen.getByText('Enter Your Poem')).toBeInTheDocument();
     });
 
     it('displays correct title and description for analysis view', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect } from 'react';
 import { useThemeStore } from '@/stores/useThemeStore';
 import { AppShell, type NavigationView } from '@/components/Layout';
 import { EmptyState } from '@/components/Common';
+import { PoemInput } from '@/components/PoemInput';
 import './App.css';
 
 // Logging helper for debugging
@@ -58,20 +59,46 @@ const VIEW_CONFIGS: Record<NavigationView, ViewConfig> = {
 };
 
 /**
- * Placeholder view component for each navigation section.
- * These will be replaced with actual view implementations.
+ * Renders the appropriate component for each navigation view.
+ * Falls back to EmptyState placeholder for views not yet implemented.
  */
-function ViewPlaceholder({ view }: { view: NavigationView }): React.ReactElement {
+function ViewContent({
+  view,
+  onNavigate,
+}: {
+  view: NavigationView;
+  onNavigate: (view: NavigationView) => void;
+}): React.ReactElement {
   const config = VIEW_CONFIGS[view];
 
-  return (
-    <EmptyState
-      title={config.title}
-      description={config.description}
-      variant="centered"
-      testId={`view-${view}`}
-    />
-  );
+  log('Rendering view content for:', view);
+
+  switch (view) {
+    case 'poem-input':
+      return (
+        <PoemInput
+          onAnalyze={() => {
+            log('Analyze triggered, navigating to analysis view');
+            onNavigate('analysis');
+          }}
+          showStats
+        />
+      );
+
+    case 'analysis':
+    case 'lyrics-editor':
+    case 'melody':
+    case 'recording':
+    default:
+      return (
+        <EmptyState
+          title={config.title}
+          description={config.description}
+          variant="centered"
+          testId={`view-${view}`}
+        />
+      );
+  }
 }
 
 /**
@@ -101,7 +128,7 @@ function App(): React.ReactElement {
 
   return (
     <AppShell activeView={activeView} onNavigate={handleNavigate}>
-      <ViewPlaceholder view={activeView} />
+      <ViewContent view={activeView} onNavigate={handleNavigate} />
     </AppShell>
   );
 }


### PR DESCRIPTION
## Summary
- Wire the existing PoemInput component into the poem-input view in App.tsx
- Users can now type/paste poems in the main application
- Analyze button navigates to analysis view

## Changes
- `web/src/App.tsx` - Import PoemInput, replace ViewPlaceholder with ViewContent that renders PoemInput for poem-input view
- `web/src/App.test.tsx` - Add PoemInput mock and update tests for new behavior

## Testing
- [x] Unit tests pass (`npm test`)
- [x] Linter passes (`npm run lint`)
- [x] Manual testing performed

## Notes
This fix addresses the bug where poem input view showed an "No Poem Entered" empty state instead of the actual PoemInput component that was built in PR #97.

The ViewContent component uses a switch statement to render the appropriate component for each view, with EmptyState as fallback for views not yet implemented.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)