### PR TITLE
feat(GH-110): Wire LyricEditor to generate suggestions from analysis

### DIFF
--- a/web/src/lib/suggestions/generator.test.ts
+++ b/web/src/lib/suggestions/generator.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Ghost Note - Suggestion Generator Tests
+ *
+ * Tests for the suggestion generation module.
+ *
+ * @module lib/suggestions/generator.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generateSuggestionsFromAnalysis,
+  hasGeneratableProblems,
+  countGeneratableProblems,
+} from './generator';
+import type { PoemAnalysis, ProblemReport } from '../../types/analysis';
+import { createDefaultPoemAnalysis } from '../../types/analysis';
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+/**
+ * Creates a mock problem report
+ */
+function createMockProblem(overrides: Partial<ProblemReport> = {}): ProblemReport {
+  return {
+    line: 1,
+    position: 0,
+    type: 'singability',
+    severity: 'medium',
+    description: 'Test problem description',
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a mock analysis with problems
+ */
+function createMockAnalysis(problemCount: number = 0): PoemAnalysis {
+  const analysis = createDefaultPoemAnalysis();
+
+  // Add some basic structure
+  analysis.meta.lineCount = 4;
+  analysis.meta.stanzaCount = 1;
+  analysis.structure.stanzas = [
+    {
+      lines: [
+        {
+          text: 'The strength of through the night',
+          words: [
+            { text: 'The', syllables: [{ phonemes: ['DH', 'AH'], stress: 0, vowelPhoneme: 'AH', isOpen: true }] },
+            { text: 'strength', syllables: [{ phonemes: ['S', 'T', 'R', 'EH1', 'NG', 'K', 'TH'], stress: 1, vowelPhoneme: 'EH1', isOpen: false }] },
+            { text: 'of', syllables: [{ phonemes: ['AH', 'V'], stress: 0, vowelPhoneme: 'AH', isOpen: false }] },
+            { text: 'through', syllables: [{ phonemes: ['TH', 'R', 'UW1'], stress: 1, vowelPhoneme: 'UW1', isOpen: true }] },
+            { text: 'the', syllables: [{ phonemes: ['DH', 'AH'], stress: 0, vowelPhoneme: 'AH', isOpen: true }] },
+            { text: 'night', syllables: [{ phonemes: ['N', 'AY1', 'T'], stress: 1, vowelPhoneme: 'AY1', isOpen: false }] },
+          ],
+          stressPattern: '010101',
+          syllableCount: 6,
+          singability: { syllableScores: [0.8, 0.5, 0.9, 0.6, 0.9, 0.8], lineScore: 0.75, problemSpots: [] },
+        },
+        {
+          text: 'I remember the day',
+          words: [
+            { text: 'I', syllables: [{ phonemes: ['AY1'], stress: 1, vowelPhoneme: 'AY1', isOpen: true }] },
+            { text: 'remember', syllables: [
+              { phonemes: ['R', 'IH0'], stress: 0, vowelPhoneme: 'IH0', isOpen: true },
+              { phonemes: ['M', 'EH1', 'M'], stress: 1, vowelPhoneme: 'EH1', isOpen: false },
+              { phonemes: ['B', 'ER0'], stress: 0, vowelPhoneme: 'ER0', isOpen: true },
+            ] },
+            { text: 'the', syllables: [{ phonemes: ['DH', 'AH'], stress: 0, vowelPhoneme: 'AH', isOpen: true }] },
+            { text: 'day', syllables: [{ phonemes: ['D', 'EY1'], stress: 1, vowelPhoneme: 'EY1', isOpen: true }] },
+          ],
+          stressPattern: '10101',
+          syllableCount: 5,
+          singability: { syllableScores: [0.9, 0.7, 0.6, 0.9, 0.9], lineScore: 0.8, problemSpots: [] },
+        },
+        {
+          text: 'Against all odds we stand',
+          words: [
+            { text: 'Against', syllables: [
+              { phonemes: ['AH0'], stress: 0, vowelPhoneme: 'AH0', isOpen: true },
+              { phonemes: ['G', 'EH1', 'N', 'S', 'T'], stress: 1, vowelPhoneme: 'EH1', isOpen: false },
+            ] },
+            { text: 'all', syllables: [{ phonemes: ['AO1', 'L'], stress: 1, vowelPhoneme: 'AO1', isOpen: false }] },
+            { text: 'odds', syllables: [{ phonemes: ['AA1', 'D', 'Z'], stress: 1, vowelPhoneme: 'AA1', isOpen: false }] },
+            { text: 'we', syllables: [{ phonemes: ['W', 'IY1'], stress: 1, vowelPhoneme: 'IY1', isOpen: true }] },
+            { text: 'stand', syllables: [{ phonemes: ['S', 'T', 'AE1', 'N', 'D'], stress: 1, vowelPhoneme: 'AE1', isOpen: false }] },
+          ],
+          stressPattern: '011111',
+          syllableCount: 6,
+          singability: { syllableScores: [0.5, 0.7, 0.8, 0.9, 0.7], lineScore: 0.72, problemSpots: [] },
+        },
+        {
+          text: 'Throughout the night and day',
+          words: [
+            { text: 'Throughout', syllables: [
+              { phonemes: ['TH', 'R', 'UW0'], stress: 0, vowelPhoneme: 'UW0', isOpen: true },
+              { phonemes: ['AW1', 'T'], stress: 1, vowelPhoneme: 'AW1', isOpen: false },
+            ] },
+            { text: 'the', syllables: [{ phonemes: ['DH', 'AH'], stress: 0, vowelPhoneme: 'AH', isOpen: true }] },
+            { text: 'night', syllables: [{ phonemes: ['N', 'AY1', 'T'], stress: 1, vowelPhoneme: 'AY1', isOpen: false }] },
+            { text: 'and', syllables: [{ phonemes: ['AE1', 'N', 'D'], stress: 1, vowelPhoneme: 'AE1', isOpen: false }] },
+            { text: 'day', syllables: [{ phonemes: ['D', 'EY1'], stress: 1, vowelPhoneme: 'EY1', isOpen: true }] },
+          ],
+          stressPattern: '010111',
+          syllableCount: 6,
+          singability: { syllableScores: [0.4, 0.7, 0.9, 0.8, 0.7, 0.9], lineScore: 0.73, problemSpots: [] },
+        },
+      ],
+    },
+  ];
+
+  // Add problems
+  const problems: ProblemReport[] = [];
+  for (let i = 0; i < problemCount; i++) {
+    problems.push(createMockProblem({
+      line: (i % 4) + 1,
+      position: i % 6,
+      type: ['singability', 'stress_mismatch', 'rhyme_break', 'syllable_variance'][i % 4] as ProblemReport['type'],
+      severity: ['low', 'medium', 'high'][i % 3] as ProblemReport['severity'],
+    }));
+  }
+  analysis.problems = problems;
+
+  return analysis;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('generateSuggestionsFromAnalysis', () => {
+  it('should return empty suggestions when analysis has no problems', () => {
+    const analysis = createMockAnalysis(0);
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    expect(result.suggestions).toHaveLength(0);
+    expect(result.problemsProcessed).toBe(0);
+    expect(result.problemsSkipped).toBe(0);
+  });
+
+  it('should generate suggestions from analysis problems', () => {
+    const analysis = createMockAnalysis(0);
+    // Add a problem with a word we have a substitution for
+    analysis.problems = [
+      createMockProblem({
+        line: 1,
+        position: 1, // "strength"
+        type: 'singability',
+        severity: 'high',
+        description: 'Contains difficult consonant clusters',
+      }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    expect(result.problemsProcessed).toBe(1);
+    // May or may not generate a suggestion depending on if word is in substitution list
+  });
+
+  it('should respect maxSuggestions option', () => {
+    const analysis = createMockAnalysis(20);
+    // Make sure all problems can generate suggestions by using known words
+    analysis.problems = analysis.problems.map((p) => ({
+      ...p,
+      line: 1,
+      position: 1, // All point to "strength" which has substitutions
+    }));
+
+    const result = generateSuggestionsFromAnalysis(analysis, { maxSuggestions: 3 });
+
+    expect(result.suggestions.length).toBeLessThanOrEqual(3);
+  });
+
+  it('should filter by minSeverity', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.problems = [
+      createMockProblem({ line: 1, position: 1, severity: 'low' }),
+      createMockProblem({ line: 2, position: 1, severity: 'medium' }),
+      createMockProblem({ line: 3, position: 0, severity: 'high' }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis, { minSeverity: 'medium' });
+
+    // Should skip the low severity problem
+    expect(result.problemsSkipped).toBeGreaterThan(0);
+    expect(result.skipReasons.some((r) => r.includes('below threshold'))).toBe(true);
+  });
+
+  it('should filter by focusTypes', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.problems = [
+      createMockProblem({ line: 1, position: 1, type: 'singability' }),
+      createMockProblem({ line: 2, position: 1, type: 'rhyme_break' }),
+      createMockProblem({ line: 3, position: 0, type: 'stress_mismatch' }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis, {
+      focusTypes: ['singability'],
+    });
+
+    // Should only process singability problems
+    expect(result.problemsSkipped).toBeGreaterThanOrEqual(2);
+    expect(result.skipReasons.some((r) => r.includes('not in focus'))).toBe(true);
+  });
+
+  it('should skip duplicate positions', () => {
+    const analysis = createMockAnalysis(0);
+    // Add two problems at the same position
+    analysis.problems = [
+      createMockProblem({ line: 1, position: 1, type: 'singability' }),
+      createMockProblem({ line: 1, position: 1, type: 'stress_mismatch' }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    // Should process first, skip second
+    expect(result.skipReasons.some((r) => r.includes('duplicate position'))).toBe(true);
+  });
+
+  it('should sort problems by severity (high first)', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.problems = [
+      createMockProblem({ line: 1, position: 1, severity: 'low', description: 'Low severity issue' }),
+      createMockProblem({ line: 2, position: 1, severity: 'high', description: 'High severity issue' }),
+      createMockProblem({ line: 3, position: 0, severity: 'medium', description: 'Medium severity issue' }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis, { maxSuggestions: 1 });
+
+    // The first processed should be the high severity one
+    expect(result.problemsProcessed).toBeGreaterThan(0);
+  });
+
+  it('should generate suggestion with correct structure', () => {
+    const analysis = createMockAnalysis(0);
+    // Add a problem for "through" which has substitutions
+    analysis.problems = [
+      createMockProblem({
+        line: 1,
+        position: 3, // "through" in the first line
+        type: 'singability',
+        severity: 'high',
+        description: 'Hard to sustain this sound',
+      }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    if (result.suggestions.length > 0) {
+      const suggestion = result.suggestions[0];
+      expect(suggestion).toHaveProperty('originalWord');
+      expect(suggestion).toHaveProperty('suggestedWord');
+      expect(suggestion).toHaveProperty('lineNumber');
+      expect(suggestion).toHaveProperty('position');
+      expect(suggestion).toHaveProperty('reason');
+      expect(suggestion).toHaveProperty('preservesMeaning');
+      expect(['yes', 'partial', 'no']).toContain(suggestion.preservesMeaning);
+    }
+  });
+
+  it('should handle empty analysis structure gracefully', () => {
+    const analysis = createDefaultPoemAnalysis();
+    analysis.problems = [createMockProblem({ line: 1, position: 0 })];
+
+    // Should not throw
+    const result = generateSuggestionsFromAnalysis(analysis);
+    expect(result).toBeDefined();
+  });
+});
+
+describe('hasGeneratableProblems', () => {
+  it('should return false when no problems exist', () => {
+    const analysis = createMockAnalysis(0);
+    expect(hasGeneratableProblems(analysis)).toBe(false);
+  });
+
+  it('should return true when matching problems exist', () => {
+    const analysis = createMockAnalysis(1);
+    expect(hasGeneratableProblems(analysis)).toBe(true);
+  });
+
+  it('should respect minSeverity option', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.problems = [createMockProblem({ severity: 'low' })];
+
+    expect(hasGeneratableProblems(analysis, { minSeverity: 'high' })).toBe(false);
+    expect(hasGeneratableProblems(analysis, { minSeverity: 'low' })).toBe(true);
+  });
+
+  it('should respect focusTypes option', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.problems = [createMockProblem({ type: 'singability' })];
+
+    expect(hasGeneratableProblems(analysis, { focusTypes: ['rhyme_break'] })).toBe(false);
+    expect(hasGeneratableProblems(analysis, { focusTypes: ['singability'] })).toBe(true);
+  });
+});
+
+describe('countGeneratableProblems', () => {
+  it('should return 0 when no problems exist', () => {
+    const analysis = createMockAnalysis(0);
+    expect(countGeneratableProblems(analysis)).toBe(0);
+  });
+
+  it('should count matching problems', () => {
+    const analysis = createMockAnalysis(5);
+    const count = countGeneratableProblems(analysis);
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThanOrEqual(5);
+  });
+
+  it('should filter by severity', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.problems = [
+      createMockProblem({ severity: 'low' }),
+      createMockProblem({ severity: 'medium' }),
+      createMockProblem({ severity: 'high' }),
+    ];
+
+    expect(countGeneratableProblems(analysis, { minSeverity: 'low' })).toBe(3);
+    expect(countGeneratableProblems(analysis, { minSeverity: 'medium' })).toBe(2);
+    expect(countGeneratableProblems(analysis, { minSeverity: 'high' })).toBe(1);
+  });
+
+  it('should filter by type', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.problems = [
+      createMockProblem({ type: 'singability' }),
+      createMockProblem({ type: 'singability' }),
+      createMockProblem({ type: 'rhyme_break' }),
+    ];
+
+    expect(countGeneratableProblems(analysis, { focusTypes: ['singability'] })).toBe(2);
+    expect(countGeneratableProblems(analysis, { focusTypes: ['rhyme_break'] })).toBe(1);
+    expect(countGeneratableProblems(analysis, { focusTypes: ['stress_mismatch'] })).toBe(0);
+  });
+});
+
+describe('suggestion content', () => {
+  it('should generate reason from problem description when available', () => {
+    const analysis = createMockAnalysis(0);
+    const customDescription = 'This word has difficult consonant clusters';
+    analysis.problems = [
+      createMockProblem({
+        line: 1,
+        position: 1, // "strength"
+        type: 'singability',
+        description: customDescription,
+      }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    if (result.suggestions.length > 0) {
+      expect(result.suggestions[0].reason).toBe(customDescription);
+    }
+  });
+
+  it('should determine meaning preservation based on problem type', () => {
+    const analysis = createMockAnalysis(0);
+
+    // Rhyme break problems should have partial meaning preservation
+    analysis.problems = [
+      createMockProblem({
+        line: 1,
+        position: 5, // "night" - which has rhyme alternatives
+        type: 'rhyme_break',
+      }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    if (result.suggestions.length > 0) {
+      // Rhyme changes often alter meaning
+      expect(['partial', 'no']).toContain(result.suggestions[0].preservesMeaning);
+    }
+  });
+});
+
+describe('edge cases', () => {
+  it('should handle analysis with no structure gracefully', () => {
+    const analysis = createDefaultPoemAnalysis();
+    analysis.problems = [createMockProblem({ line: 10, position: 0 })];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    // Should not crash, but may not generate suggestions
+    expect(result.problemsProcessed).toBeGreaterThan(0);
+    expect(result.skipReasons.some((r) => r.includes('Could not generate'))).toBe(true);
+  });
+
+  it('should handle out-of-bounds line numbers', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.problems = [createMockProblem({ line: 100, position: 0 })];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    // Should process but skip due to inability to find word
+    expect(result.problemsProcessed).toBe(1);
+  });
+
+  it('should handle out-of-bounds positions', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.problems = [createMockProblem({ line: 1, position: 100 })];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    // Should process but may skip due to inability to find word
+    expect(result.problemsProcessed).toBe(1);
+  });
+
+  it('should handle empty strings in analysis', () => {
+    const analysis = createMockAnalysis(0);
+    analysis.structure.stanzas = [
+      {
+        lines: [
+          {
+            text: '',
+            words: [],
+            stressPattern: '',
+            syllableCount: 0,
+            singability: { syllableScores: [], lineScore: 0, problemSpots: [] },
+          },
+        ],
+      },
+    ];
+    analysis.problems = [createMockProblem({ line: 1, position: 0 })];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    // Should not crash
+    expect(result).toBeDefined();
+  });
+
+  it('should not generate duplicate suggestions for same original word', () => {
+    const analysis = createMockAnalysis(0);
+    // Add problems at same position - should dedupe
+    analysis.problems = [
+      createMockProblem({ line: 1, position: 1, type: 'singability' }),
+      createMockProblem({ line: 1, position: 1, type: 'stress_mismatch' }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    // Should only have at most 1 suggestion for this position
+    const uniquePositions = new Set(
+      result.suggestions.map((s) => `${s.lineNumber}:${s.position}`)
+    );
+    expect(uniquePositions.size).toBe(result.suggestions.length);
+  });
+});
+
+describe('substitution lookup', () => {
+  it('should find singability substitutions', () => {
+    const analysis = createMockAnalysis(0);
+    // "strength" has substitutions: ['power', 'force', 'might']
+    analysis.problems = [
+      createMockProblem({
+        line: 1,
+        position: 1,
+        type: 'singability',
+      }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    if (result.suggestions.length > 0) {
+      expect(['power', 'force', 'might']).toContain(result.suggestions[0].suggestedWord);
+    }
+  });
+
+  it('should find stress substitutions', () => {
+    const analysis = createMockAnalysis(0);
+    // "remember" has substitutions: ['recall', 'think of']
+    analysis.problems = [
+      createMockProblem({
+        line: 2,
+        position: 1,
+        type: 'stress_mismatch',
+      }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    if (result.suggestions.length > 0) {
+      expect(['recall', 'think of']).toContain(result.suggestions[0].suggestedWord);
+    }
+  });
+
+  it('should find rhyme alternatives', () => {
+    const analysis = createMockAnalysis(0);
+    // "night" has rhyme alternatives: ['light', 'sight', 'bright', 'flight', 'right']
+    analysis.problems = [
+      createMockProblem({
+        line: 1,
+        position: 5,
+        type: 'rhyme_break',
+      }),
+    ];
+
+    const result = generateSuggestionsFromAnalysis(analysis);
+
+    if (result.suggestions.length > 0) {
+      expect(['light', 'sight', 'bright', 'flight', 'right']).toContain(
+        result.suggestions[0].suggestedWord
+      );
+    }
+  });
+});

--- a/web/src/lib/suggestions/generator.ts
+++ b/web/src/lib/suggestions/generator.ts
@@ -1,0 +1,494 @@
+/**
+ * Ghost Note - Suggestion Generator
+ *
+ * Generates lyric improvement suggestions from poem analysis results.
+ * Maps analysis problems to actionable suggestions with heuristic-based
+ * word substitutions.
+ *
+ * @module lib/suggestions/generator
+ */
+
+import type { PoemAnalysis, ProblemReport, ProblemType, Severity } from '../../types/analysis';
+import type { Suggestion, MeaningPreservation } from '../claude/types';
+
+// =============================================================================
+// Logging
+// =============================================================================
+
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[SuggestionGenerator] ${message}`, ...args);
+  }
+};
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Options for suggestion generation
+ */
+export interface GeneratorOptions {
+  /** Maximum number of suggestions to generate */
+  maxSuggestions?: number;
+  /** Minimum severity to include */
+  minSeverity?: Severity;
+  /** Problem types to focus on */
+  focusTypes?: ProblemType[];
+}
+
+/**
+ * Result of suggestion generation
+ */
+export interface GeneratorResult {
+  /** Generated suggestions */
+  suggestions: Suggestion[];
+  /** Number of problems processed */
+  problemsProcessed: number;
+  /** Number of problems skipped */
+  problemsSkipped: number;
+  /** Reasons for skipping problems */
+  skipReasons: string[];
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Default options for generation
+ */
+const DEFAULT_OPTIONS: Required<GeneratorOptions> = {
+  maxSuggestions: 10,
+  minSeverity: 'low',
+  focusTypes: ['stress_mismatch', 'syllable_variance', 'singability', 'rhyme_break'],
+};
+
+/**
+ * Severity ordering for filtering
+ */
+const SEVERITY_ORDER: Record<Severity, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+/**
+ * Word substitutions for common singability issues
+ * Maps problematic patterns to more singable alternatives
+ */
+const SINGABILITY_SUBSTITUTIONS: Record<string, string[]> = {
+  // Words with consonant clusters that are hard to sing
+  'strength': ['power', 'force', 'might'],
+  'through': ['past', 'by', 'via'],
+  'against': ['facing', 'toward', 'upon'],
+  'underneath': ['below', 'under', 'beneath'],
+  'throughout': ['across', 'over', 'within'],
+  'stretch': ['reach', 'spread', 'span'],
+  'scratched': ['marked', 'scraped', 'torn'],
+  'struggled': ['fought', 'strove', 'tried'],
+  'strangled': ['choked', 'gripped', 'held'],
+  'splashed': ['sprayed', 'spilled', 'soaked'],
+  // Short unstressed words that can cause issues
+  'the': ['this', 'that', 'a'],
+  'a': ['one', 'some'],
+};
+
+/**
+ * Word substitutions for stress mismatch issues
+ * Maps words where stress often falls incorrectly
+ */
+const STRESS_SUBSTITUTIONS: Record<string, string[]> = {
+  // Multi-syllable words with tricky stress
+  'remember': ['recall', 'think of'],
+  'however': ['but yet', 'although'],
+  'because': ['since', 'for', 'as'],
+  'before': ['ere', 'prior'],
+  'about': ['around', 'near'],
+  'upon': ['on', 'atop'],
+  'between': ['amid', 'among'],
+  'without': ['lacking', 'minus'],
+};
+
+/**
+ * Common rhyme alternatives
+ * Maps end words to possible rhyme alternatives
+ */
+const RHYME_ALTERNATIVES: Record<string, string[]> = {
+  'night': ['light', 'sight', 'bright', 'flight', 'right'],
+  'day': ['way', 'say', 'stay', 'play', 'ray'],
+  'love': ['above', 'dove', 'of'],
+  'heart': ['part', 'start', 'art', 'dart'],
+  'time': ['rhyme', 'climb', 'chime', 'prime'],
+  'away': ['today', 'betray', 'display', 'decay'],
+  'mind': ['find', 'kind', 'blind', 'behind'],
+  'eyes': ['skies', 'lies', 'rise', 'wise', 'cries'],
+  'soul': ['whole', 'goal', 'role', 'toll'],
+  'dream': ['stream', 'beam', 'seem', 'gleam'],
+};
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Checks if severity meets minimum threshold
+ */
+function meetsMinSeverity(severity: Severity, minSeverity: Severity): boolean {
+  return SEVERITY_ORDER[severity] >= SEVERITY_ORDER[minSeverity];
+}
+
+/**
+ * Extracts a word from the poem text at the given position
+ */
+function extractWordAtPosition(
+  analysis: PoemAnalysis,
+  lineNumber: number,
+  position: number
+): string | null {
+  const lineIndex = lineNumber - 1; // Convert to 0-indexed
+
+  // Navigate to find the line in the stanza structure
+  let currentLine = 0;
+  for (const stanza of analysis.structure.stanzas) {
+    for (const line of stanza.lines) {
+      if (currentLine === lineIndex) {
+        // Find the word at position
+        const words = line.words;
+        if (position >= 0 && position < words.length) {
+          return words[position].text.toLowerCase();
+        }
+        // If position is beyond words, try to extract from text
+        const lineWords = line.text.split(/\s+/);
+        if (position >= 0 && position < lineWords.length) {
+          return lineWords[position].toLowerCase().replace(/[^\w]/g, '');
+        }
+        return null;
+      }
+      currentLine++;
+    }
+  }
+  return null;
+}
+
+/**
+ * Gets line text from analysis
+ */
+function getLineText(analysis: PoemAnalysis, lineNumber: number): string | null {
+  const lineIndex = lineNumber - 1;
+  let currentLine = 0;
+
+  for (const stanza of analysis.structure.stanzas) {
+    for (const line of stanza.lines) {
+      if (currentLine === lineIndex) {
+        return line.text;
+      }
+      currentLine++;
+    }
+  }
+  return null;
+}
+
+/**
+ * Determines meaning preservation based on substitution
+ */
+function determineMeaningPreservation(
+  original: string,
+  suggested: string,
+  problemType: ProblemType
+): MeaningPreservation {
+  // Rhyme changes often alter meaning more
+  if (problemType === 'rhyme_break') {
+    return 'partial';
+  }
+
+  // If the words are synonyms (from our curated lists), meaning is preserved
+  const lowerOriginal = original.toLowerCase();
+  const lowerSuggested = suggested.toLowerCase();
+
+  // Check if they're in our synonym-like substitution lists
+  const allSubstitutions = { ...SINGABILITY_SUBSTITUTIONS, ...STRESS_SUBSTITUTIONS };
+  for (const [key, values] of Object.entries(allSubstitutions)) {
+    if (key === lowerOriginal && values.includes(lowerSuggested)) {
+      return 'yes';
+    }
+    if (values.includes(lowerOriginal) && (key === lowerSuggested || values.includes(lowerSuggested))) {
+      return 'yes';
+    }
+  }
+
+  // Default to partial for other substitutions
+  return 'partial';
+}
+
+/**
+ * Generates reason text based on problem type and severity
+ */
+function generateReason(problem: ProblemReport): string {
+  // Use the problem description if available
+  if (problem.description) {
+    return problem.description;
+  }
+
+  // Generate based on type
+  switch (problem.type) {
+    case 'stress_mismatch':
+      return 'The stress pattern of this word may not align with the musical beat.';
+    case 'syllable_variance':
+      return 'This line has a different syllable count than others, which may affect rhythm.';
+    case 'singability':
+      return 'This word contains sounds that are difficult to sing clearly.';
+    case 'rhyme_break':
+      return 'This word breaks the rhyme scheme, consider an alternative.';
+    default:
+      return 'Consider revising this word for better singability.';
+  }
+}
+
+/**
+ * Finds a substitution for a word based on problem type
+ */
+function findSubstitution(
+  word: string,
+  problemType: ProblemType,
+  lineText: string | null
+): string | null {
+  const lowerWord = word.toLowerCase();
+
+  // Try problem-type-specific substitutions first
+  switch (problemType) {
+    case 'singability': {
+      const singabilitySubs = SINGABILITY_SUBSTITUTIONS[lowerWord];
+      if (singabilitySubs && singabilitySubs.length > 0) {
+        return singabilitySubs[0];
+      }
+      break;
+    }
+
+    case 'stress_mismatch': {
+      const stressSubs = STRESS_SUBSTITUTIONS[lowerWord];
+      if (stressSubs && stressSubs.length > 0) {
+        return stressSubs[0];
+      }
+      break;
+    }
+
+    case 'rhyme_break': {
+      const rhymeSubs = RHYME_ALTERNATIVES[lowerWord];
+      if (rhymeSubs && rhymeSubs.length > 0) {
+        // Pick the first alternative that isn't already in the line
+        for (const alt of rhymeSubs) {
+          if (!lineText || !lineText.toLowerCase().includes(alt)) {
+            return alt;
+          }
+        }
+        return rhymeSubs[0];
+      }
+      break;
+    }
+  }
+
+  // Try any substitution as fallback
+  const allSubs = [
+    ...Object.entries(SINGABILITY_SUBSTITUTIONS),
+    ...Object.entries(STRESS_SUBSTITUTIONS),
+  ];
+
+  for (const [key, values] of allSubs) {
+    if (key === lowerWord && values.length > 0) {
+      return values[0];
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Generates a suggestion from a problem report
+ */
+function problemToSuggestion(
+  problem: ProblemReport,
+  analysis: PoemAnalysis
+): Suggestion | null {
+  // Extract the word at the problem position
+  const originalWord = extractWordAtPosition(analysis, problem.line, problem.position);
+
+  if (!originalWord) {
+    log('Could not extract word for problem:', problem);
+    return null;
+  }
+
+  // Get line text for context
+  const lineText = getLineText(analysis, problem.line);
+
+  // Find a substitution
+  const suggestedWord = findSubstitution(originalWord, problem.type, lineText);
+
+  if (!suggestedWord) {
+    log('No substitution found for word:', originalWord);
+    return null;
+  }
+
+  // Skip if suggestion is the same as original
+  if (suggestedWord.toLowerCase() === originalWord.toLowerCase()) {
+    log('Suggestion same as original, skipping:', originalWord);
+    return null;
+  }
+
+  const suggestion: Suggestion = {
+    originalWord,
+    suggestedWord,
+    lineNumber: problem.line,
+    position: problem.position,
+    reason: generateReason(problem),
+    preservesMeaning: determineMeaningPreservation(originalWord, suggestedWord, problem.type),
+  };
+
+  log('Generated suggestion:', suggestion);
+  return suggestion;
+}
+
+// =============================================================================
+// Main Generator Function
+// =============================================================================
+
+/**
+ * Generates suggestions from poem analysis problems.
+ *
+ * This function maps analysis problems to actionable suggestions using
+ * heuristic-based word substitutions. It prioritizes high-severity issues
+ * and limits output to avoid overwhelming the user.
+ *
+ * @param analysis - The complete poem analysis
+ * @param options - Generation options
+ * @returns Generator result with suggestions
+ *
+ * @example
+ * ```typescript
+ * const analysis = await analyzePoem(poemText);
+ * const result = generateSuggestionsFromAnalysis(analysis, {
+ *   maxSuggestions: 5,
+ *   minSeverity: 'medium',
+ * });
+ * console.log(`Generated ${result.suggestions.length} suggestions`);
+ * ```
+ */
+export function generateSuggestionsFromAnalysis(
+  analysis: PoemAnalysis,
+  options: GeneratorOptions = {}
+): GeneratorResult {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  log('Generating suggestions from analysis', {
+    problemCount: analysis.problems.length,
+    options: opts,
+  });
+
+  const result: GeneratorResult = {
+    suggestions: [],
+    problemsProcessed: 0,
+    problemsSkipped: 0,
+    skipReasons: [],
+  };
+
+  // Filter and sort problems
+  const filteredProblems = analysis.problems
+    .filter((problem) => {
+      // Check severity
+      if (!meetsMinSeverity(problem.severity, opts.minSeverity)) {
+        result.problemsSkipped++;
+        result.skipReasons.push(`Skipped line ${problem.line}: severity ${problem.severity} below threshold`);
+        return false;
+      }
+
+      // Check focus types
+      if (!opts.focusTypes.includes(problem.type)) {
+        result.problemsSkipped++;
+        result.skipReasons.push(`Skipped line ${problem.line}: type ${problem.type} not in focus`);
+        return false;
+      }
+
+      return true;
+    })
+    // Sort by severity (high first) then by line number
+    .sort((a, b) => {
+      const severityDiff = SEVERITY_ORDER[b.severity] - SEVERITY_ORDER[a.severity];
+      if (severityDiff !== 0) return severityDiff;
+      return a.line - b.line;
+    });
+
+  log(`Filtered to ${filteredProblems.length} problems for processing`);
+
+  // Generate suggestions from problems
+  const seenPositions = new Set<string>();
+
+  for (const problem of filteredProblems) {
+    // Check if we've hit the max
+    if (result.suggestions.length >= opts.maxSuggestions) {
+      log(`Reached max suggestions (${opts.maxSuggestions}), stopping`);
+      break;
+    }
+
+    // Skip duplicate positions (same line + position)
+    const posKey = `${problem.line}:${problem.position}`;
+    if (seenPositions.has(posKey)) {
+      result.problemsSkipped++;
+      result.skipReasons.push(`Skipped duplicate position: ${posKey}`);
+      continue;
+    }
+
+    result.problemsProcessed++;
+    seenPositions.add(posKey);
+
+    // Try to generate a suggestion
+    const suggestion = problemToSuggestion(problem, analysis);
+
+    if (suggestion) {
+      result.suggestions.push(suggestion);
+    } else {
+      result.problemsSkipped++;
+      result.skipReasons.push(`Could not generate suggestion for line ${problem.line}`);
+    }
+  }
+
+  log('Generation complete', {
+    suggestionsGenerated: result.suggestions.length,
+    problemsProcessed: result.problemsProcessed,
+    problemsSkipped: result.problemsSkipped,
+  });
+
+  return result;
+}
+
+/**
+ * Checks if an analysis has problems that can generate suggestions
+ */
+export function hasGeneratableProblems(
+  analysis: PoemAnalysis,
+  options: GeneratorOptions = {}
+): boolean {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  return analysis.problems.some(
+    (problem) =>
+      meetsMinSeverity(problem.severity, opts.minSeverity) &&
+      opts.focusTypes.includes(problem.type)
+  );
+}
+
+/**
+ * Gets the count of problems that can potentially generate suggestions
+ */
+export function countGeneratableProblems(
+  analysis: PoemAnalysis,
+  options: GeneratorOptions = {}
+): number {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  return analysis.problems.filter(
+    (problem) =>
+      meetsMinSeverity(problem.severity, opts.minSeverity) &&
+      opts.focusTypes.includes(problem.type)
+  ).length;
+}

--- a/web/src/lib/suggestions/index.ts
+++ b/web/src/lib/suggestions/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Ghost Note - Suggestions Library
+ *
+ * Exports for the suggestion generation module.
+ *
+ * @module lib/suggestions
+ */
+
+export {
+  generateSuggestionsFromAnalysis,
+  hasGeneratableProblems,
+  countGeneratableProblems,
+  type GeneratorOptions,
+  type GeneratorResult,
+} from './generator';


### PR DESCRIPTION
## Summary
This PR wires the LyricEditor component to generate and display suggestions from poem analysis results, completing the connection between the analysis pipeline and the suggestion UI.

## Changes
- `web/src/lib/suggestions/generator.ts` - New suggestion generator that maps analysis problems to actionable word suggestions using heuristic-based substitutions
- `web/src/lib/suggestions/generator.test.ts` - Comprehensive test suite (27 tests)
- `web/src/lib/suggestions/index.ts` - Module exports
- `web/src/components/LyricEditor/LyricEditor.tsx` - Updated to use useSuggestionStore instead of local state, with proper store action wiring
- `web/src/App.tsx` - Added LyricEditorWithSuggestions wrapper to trigger suggestion generation when entering the view

## Key Implementation Details
- **Suggestion Generator**: Converts analysis problems to word suggestions with:
  - Heuristic-based substitutions for singability, stress, and rhyme issues
  - Configurable options (maxSuggestions, minSeverity, focusTypes)
  - Severity-based sorting and position deduplication

- **Store Integration**: LyricEditor now uses useSuggestionStore for:
  - Reading suggestions (mapped to LyricSuggestion format for UI)
  - Accept/reject actions that update store state
  - Loading state display

- **React Best Practices**: Used useEffect in wrapper component to trigger generation (avoiding render-time side effects)

## Testing
- [x] Unit tests pass (`npm test`) - 3314 tests passing
- [x] Check passes (`npm run check`) - lint and typecheck passing
- [x] 27 new tests for suggestion generator

## Notes
The generator uses simple word substitution lists for common singability issues. Future enhancements could integrate Claude-powered suggestions for more sophisticated recommendations.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)