### PR TITLE
feat(GH-112): Wire melody store playback to AbcSynth audio engine

### DIFF
--- a/web/src/stores/types.ts
+++ b/web/src/stores/types.ts
@@ -230,7 +230,7 @@ export interface MelodyActions {
   /** Set ABC notation */
   setAbcNotation: (abc: string) => void;
   /** Play/resume playback */
-  play: () => void;
+  play: () => Promise<void> | void;
   /** Pause playback */
   pause: () => void;
   /** Stop playback */


### PR DESCRIPTION
## Summary

Wire the melody store's playback actions (play, pause, stop) to the actual AbcSynth audio engine so that clicking play/pause/stop buttons produces audio instead of just toggling icon states.

## Changes

- `web/src/stores/useMelodyStore.ts` - Major update to playback actions:
  - `play()`: Now async, initializes synth via `initSynth()`, starts playback via `playMelody()`, handles resume from paused state
  - `pause()`: Calls `pausePlayback()` to pause actual audio
  - `stop()`: Calls `stopPlayback()` to stop audio and reset position
  - `clear()` and `reset()`: Now stop synth playback before clearing state
  - Added progress callbacks that update `currentTime` and `duration` during playback
  - Added loading state during synth initialization
  - Added loop support via synth state change callback

- `web/src/stores/types.ts` - Updated `play` action type to support async return

- `web/src/stores/useMelodyStore.test.ts` - Comprehensive test updates:
  - Mocked abcRenderer module for synth functions
  - Updated existing playback tests to work with async play() and require ABC notation
  - Added new test suite for synth integration verifying initSynth, playMelody, pausePlayback, stopPlayback, and resumePlayback are called correctly

## Testing

- [x] Unit tests pass (`npm test` - 3325 tests pass)
- [x] Check passes (`npm run check` - lint and typecheck pass)
- [x] Manual testing: Verified the play/pause/stop buttons now call actual synth functions

## Notes

The implementation uses the existing `AbcSynth` class and helper functions from `@/lib/music/abcRenderer.ts`. The notation element ID is hardcoded to `'notation-display-1'` which matches the auto-generated ID pattern from `NotationDisplay` component for visual sync during playback.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)