### PR TITLE
feat(GH-51): Configure automated deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,108 @@
+# Deploy Workflow - Deploys to GitHub Pages after CI passes
+# Triggers on push to main branch only
+# Depends on CI workflow completing successfully
+
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  # Allow manual deployment
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Wait for CI to pass first
+  wait-for-ci:
+    name: Wait for CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for CI workflow
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: 'Build'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
+  # Check if web directory exists (same as CI)
+  check-web:
+    name: Check if web/ exists
+    runs-on: ubuntu-latest
+    needs: wait-for-ci
+    outputs:
+      exists: ${{ steps.check.outputs.exists }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for web directory
+        id: check
+        run: |
+          if [ -d "web" ] && [ -f "web/package.json" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "⚠️ web/ directory not found - deployment will skip"
+          fi
+
+  # Build the application for production
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: check-web
+    if: needs.check-web.outputs.exists == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Build for production
+        working-directory: web
+        run: npm run build
+        env:
+          # Set base path for GitHub Pages (repository name)
+          # This is automatically detected by Vite when GITHUB_REPOSITORY is set
+          VITE_BASE_URL: /${{ github.event.repository.name }}/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  # Deploy to GitHub Pages
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Ghost Note
 
+[![CI](https://github.com/audio-forge-rs/ghost-note/actions/workflows/ci.yml/badge.svg)](https://github.com/audio-forge-rs/ghost-note/actions/workflows/ci.yml)
+[![Deploy](https://github.com/audio-forge-rs/ghost-note/actions/workflows/deploy.yml/badge.svg)](https://github.com/audio-forge-rs/ghost-note/actions/workflows/deploy.yml)
+
 Transform poems into songs. Adjust lyrics for singability, generate vocal melodies, record your performance.
+
+**Live Demo**: [https://audio-forge-rs.github.io/ghost-note/](https://audio-forge-rs.github.io/ghost-note/)
 
 ## Overview
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,9 @@ import path from 'path'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  // Set base path for GitHub Pages deployment
+  // VITE_BASE_URL is set during CI/CD, defaults to '/' for local development
+  base: process.env.VITE_BASE_URL || '/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
Set up automated deployment of the web app to GitHub Pages with the following features:
- Deploys automatically on push to main branch
- Waits for CI workflow to pass before deploying
- Properly configures base path for GitHub Pages subdirectory hosting
- Uses GitHub's official Pages deployment actions

## Changes
- `.github/workflows/deploy.yml` - New workflow for automated GitHub Pages deployment
  - Uses `wait-on-check-action` to wait for CI workflow completion
  - Checks for web/ directory existence (same as CI)
  - Builds with correct base path via VITE_BASE_URL
  - Deploys using `actions/deploy-pages@v4`
- `web/vite.config.ts` - Added dynamic base path configuration for GitHub Pages
- `README.md` - Added CI and Deploy status badges, plus live demo link

## Testing
- [x] Unit tests pass (`npm test`)
- [x] Check passes (`npm run check`)
- [ ] Manual testing performed (deployment will be tested after merge)

## Configuration Notes
After merging, the repository needs:
1. **Enable GitHub Pages** in Settings > Pages > Source: "GitHub Actions"
2. The site will be accessible at https://audio-forge-rs.github.io/ghost-note/

## Acceptance Criteria
- [x] Automatic deployment on main push
- [x] Only deploys if CI passes
- [x] Status badge in README
- [ ] Site accessible at github.io URL (after merge and Pages enabled)

Closes #51