### PR TITLE
feat(GH-29): Implement audio export and download

### DIFF
--- a/web/src/components/Recording/ExportButton.test.tsx
+++ b/web/src/components/Recording/ExportButton.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * ExportButton Component Tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExportButton } from './ExportButton';
+import type { ExportFormat } from '@/lib/audio/export';
+
+// Mock the export module
+vi.mock('@/lib/audio/export', () => ({
+  getSupportedFormats: vi.fn(() => ['webm', 'wav'] as ExportFormat[]),
+  getFormatInfo: vi.fn((format: ExportFormat) => ({
+    webm: {
+      name: 'WebM',
+      mimeType: 'audio/webm',
+      extension: '.webm',
+      description: 'Web-optimized audio format',
+      isSupported: true,
+    },
+    wav: {
+      name: 'WAV',
+      mimeType: 'audio/wav',
+      extension: '.wav',
+      description: 'Uncompressed audio format',
+      isSupported: true,
+    },
+  }[format])),
+}));
+
+describe('ExportButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render the button', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} />);
+
+      expect(screen.getByTestId('export-button')).toBeInTheDocument();
+    });
+
+    it('should display default label', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} />);
+
+      expect(screen.getByText('Export')).toBeInTheDocument();
+    });
+
+    it('should display custom label', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} label="Download" />);
+
+      expect(screen.getByText('Download')).toBeInTheDocument();
+    });
+
+    it('should display "Exporting..." when isExporting is true', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} isExporting />);
+
+      expect(screen.getByText('Exporting...')).toBeInTheDocument();
+    });
+
+    it('should apply custom className', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} className="custom-class" />);
+
+      expect(screen.getByTestId('export-button').parentElement).toHaveClass('custom-class');
+    });
+  });
+
+  describe('Button sizes', () => {
+    it('should render small size', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} size="small" />);
+
+      const button = screen.getByTestId('export-button');
+      expect(button).toHaveStyle({ height: '32px' });
+    });
+
+    it('should render medium size by default', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} />);
+
+      const button = screen.getByTestId('export-button');
+      expect(button).toHaveStyle({ height: '40px' });
+    });
+
+    it('should render large size', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} size="large" />);
+
+      const button = screen.getByTestId('export-button');
+      expect(button).toHaveStyle({ height: '48px' });
+    });
+  });
+
+  describe('Disabled state', () => {
+    it('should be disabled when disabled prop is true', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} disabled />);
+
+      expect(screen.getByTestId('export-button')).toBeDisabled();
+    });
+
+    it('should be disabled when isExporting is true', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} isExporting />);
+
+      expect(screen.getByTestId('export-button')).toBeDisabled();
+    });
+
+    it('should not trigger export when disabled', () => {
+      const handleExport = vi.fn();
+      render(
+        <ExportButton onExport={handleExport} disabled showFormatSelector={false} />
+      );
+
+      fireEvent.click(screen.getByTestId('export-button'));
+
+      expect(handleExport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Format selector', () => {
+    it('should show dropdown when showFormatSelector is true', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector />);
+
+      fireEvent.click(screen.getByTestId('export-button'));
+
+      expect(screen.getByTestId('export-format-dropdown')).toBeInTheDocument();
+    });
+
+    it('should not show dropdown when showFormatSelector is false', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector={false} />);
+
+      fireEvent.click(screen.getByTestId('export-button'));
+
+      expect(screen.queryByTestId('export-format-dropdown')).not.toBeInTheDocument();
+    });
+
+    it('should export directly when showFormatSelector is false', () => {
+      const handleExport = vi.fn();
+      render(
+        <ExportButton
+          onExport={handleExport}
+          showFormatSelector={false}
+          defaultFormat="wav"
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('export-button'));
+
+      expect(handleExport).toHaveBeenCalledWith('wav');
+    });
+
+    it('should show format options in dropdown', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector />);
+
+      fireEvent.click(screen.getByTestId('export-button'));
+
+      expect(screen.getByTestId('export-format-webm')).toBeInTheDocument();
+      expect(screen.getByTestId('export-format-wav')).toBeInTheDocument();
+    });
+
+    it('should call onExport with selected format', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector />);
+
+      fireEvent.click(screen.getByTestId('export-button'));
+      fireEvent.click(screen.getByTestId('export-format-wav'));
+
+      expect(handleExport).toHaveBeenCalledWith('wav');
+    });
+
+    it('should close dropdown after selection', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector />);
+
+      fireEvent.click(screen.getByTestId('export-button'));
+      expect(screen.getByTestId('export-format-dropdown')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('export-format-webm'));
+
+      expect(screen.queryByTestId('export-format-dropdown')).not.toBeInTheDocument();
+    });
+
+    it('should toggle dropdown on button click', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector />);
+
+      // Open
+      fireEvent.click(screen.getByTestId('export-button'));
+      expect(screen.getByTestId('export-format-dropdown')).toBeInTheDocument();
+
+      // Close
+      fireEvent.click(screen.getByTestId('export-button'));
+      expect(screen.queryByTestId('export-format-dropdown')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Default format', () => {
+    it('should use default format when exporting directly', () => {
+      const handleExport = vi.fn();
+      render(
+        <ExportButton
+          onExport={handleExport}
+          showFormatSelector={false}
+          defaultFormat="wav"
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('export-button'));
+
+      expect(handleExport).toHaveBeenCalledWith('wav');
+    });
+
+    it('should use webm as default when no defaultFormat specified', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector={false} />);
+
+      fireEvent.click(screen.getByTestId('export-button'));
+
+      expect(handleExport).toHaveBeenCalledWith('webm');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have correct aria-label', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} />);
+
+      expect(screen.getByTestId('export-button')).toHaveAttribute('aria-label', 'Export');
+    });
+
+    it('should update aria-label when exporting', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} isExporting />);
+
+      expect(screen.getByTestId('export-button')).toHaveAttribute(
+        'aria-label',
+        'Exporting...'
+      );
+    });
+
+    it('should have aria-expanded when dropdown is open', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector />);
+
+      const button = screen.getByTestId('export-button');
+
+      expect(button).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.click(button);
+
+      expect(button).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should have aria-haspopup when format selector is enabled', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector />);
+
+      expect(screen.getByTestId('export-button')).toHaveAttribute('aria-haspopup', 'listbox');
+    });
+
+    it('should have role listbox on dropdown', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector />);
+
+      fireEvent.click(screen.getByTestId('export-button'));
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('Keyboard navigation', () => {
+    it('should close dropdown on Escape key', () => {
+      const handleExport = vi.fn();
+      render(<ExportButton onExport={handleExport} showFormatSelector />);
+
+      fireEvent.click(screen.getByTestId('export-button'));
+      expect(screen.getByTestId('export-format-dropdown')).toBeInTheDocument();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(screen.queryByTestId('export-format-dropdown')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Outside click', () => {
+    it('should close dropdown when clicking outside', () => {
+      const handleExport = vi.fn();
+      render(
+        <div>
+          <ExportButton onExport={handleExport} showFormatSelector />
+          <div data-testid="outside">Outside</div>
+        </div>
+      );
+
+      fireEvent.click(screen.getByTestId('export-button'));
+      expect(screen.getByTestId('export-format-dropdown')).toBeInTheDocument();
+
+      fireEvent.mouseDown(screen.getByTestId('outside'));
+
+      expect(screen.queryByTestId('export-format-dropdown')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/Recording/ExportButton.tsx
+++ b/web/src/components/Recording/ExportButton.tsx
@@ -1,0 +1,357 @@
+/**
+ * ExportButton Component
+ *
+ * A button that triggers audio export with format options.
+ * Shows a dropdown menu for format selection.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { ExportFormat } from '@/lib/audio/export';
+import { getSupportedFormats, getFormatInfo } from '@/lib/audio/export';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[ExportButton] ${message}`, ...args);
+  }
+};
+
+/**
+ * Size options for the button
+ */
+export type ExportButtonSize = 'small' | 'medium' | 'large';
+
+/**
+ * Props for ExportButton component
+ */
+export interface ExportButtonProps {
+  /** Callback when export is triggered */
+  onExport: (format: ExportFormat) => void;
+  /** Whether export is currently in progress */
+  isExporting?: boolean;
+  /** Whether the button is disabled */
+  disabled?: boolean;
+  /** Button size */
+  size?: ExportButtonSize;
+  /** Show format selector dropdown */
+  showFormatSelector?: boolean;
+  /** Default format to use */
+  defaultFormat?: ExportFormat;
+  /** Custom label */
+  label?: string;
+  /** Custom class name */
+  className?: string;
+}
+
+/**
+ * Get button dimensions based on size
+ */
+function getButtonDimensions(size: ExportButtonSize): {
+  height: number;
+  fontSize: string;
+  padding: string;
+  iconSize: number;
+} {
+  switch (size) {
+    case 'small':
+      return { height: 32, fontSize: '0.8125rem', padding: '0.375rem 0.75rem', iconSize: 14 };
+    case 'large':
+      return { height: 48, fontSize: '1rem', padding: '0.75rem 1.5rem', iconSize: 20 };
+    case 'medium':
+    default:
+      return { height: 40, fontSize: '0.875rem', padding: '0.5rem 1rem', iconSize: 16 };
+  }
+}
+
+/**
+ * ExportButton provides a button for exporting audio files.
+ *
+ * Features:
+ * - Format selection dropdown
+ * - Loading state during export
+ * - Disabled state
+ * - Multiple sizes
+ *
+ * @example
+ * ```tsx
+ * <ExportButton
+ *   onExport={(format) => handleExport(format)}
+ *   isExporting={isExporting}
+ *   showFormatSelector
+ * />
+ * ```
+ */
+export function ExportButton({
+  onExport,
+  isExporting = false,
+  disabled = false,
+  size = 'medium',
+  showFormatSelector = true,
+  defaultFormat = 'webm',
+  label = 'Export',
+  className = '',
+}: ExportButtonProps): React.ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedFormat, setSelectedFormat] = useState<ExportFormat>(defaultFormat);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const supportedFormats = getSupportedFormats();
+  const dimensions = getButtonDimensions(size);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  // Close dropdown on escape key
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen) {
+        setIsOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
+
+  // Handle main button click
+  const handleClick = useCallback(() => {
+    if (showFormatSelector && supportedFormats.length > 1) {
+      log('Toggle format selector');
+      setIsOpen((prev) => !prev);
+    } else {
+      log('Export with format:', selectedFormat);
+      onExport(selectedFormat);
+    }
+  }, [showFormatSelector, supportedFormats.length, selectedFormat, onExport]);
+
+  // Handle format selection
+  const handleFormatSelect = useCallback(
+    (format: ExportFormat) => {
+      log('Format selected:', format);
+      setSelectedFormat(format);
+      setIsOpen(false);
+      onExport(format);
+    },
+    [onExport]
+  );
+
+  const isDisabled = disabled || isExporting;
+
+  // Main button styles
+  const buttonStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '0.5rem',
+    height: dimensions.height,
+    padding: dimensions.padding,
+    fontSize: dimensions.fontSize,
+    fontWeight: 500,
+    backgroundColor: isDisabled ? '#9ca3af' : '#3b82f6',
+    color: 'white',
+    border: 'none',
+    borderRadius: '8px',
+    cursor: isDisabled ? 'not-allowed' : 'pointer',
+    opacity: isDisabled ? 0.7 : 1,
+    transition: 'all 0.2s',
+    position: 'relative',
+  };
+
+  // Dropdown styles
+  const dropdownStyle: React.CSSProperties = {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    right: 0,
+    marginTop: '4px',
+    backgroundColor: 'white',
+    border: '1px solid #e5e7eb',
+    borderRadius: '8px',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+    zIndex: 50,
+    overflow: 'hidden',
+  };
+
+  // Dropdown item styles
+  const itemStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    width: '100%',
+    padding: '0.625rem 0.75rem',
+    fontSize: '0.875rem',
+    textAlign: 'left',
+    backgroundColor: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    transition: 'background-color 0.15s',
+  };
+
+  return (
+    <div
+      style={{ position: 'relative', display: 'inline-block' }}
+      className={`export-button-container ${className}`.trim()}
+    >
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={handleClick}
+        disabled={isDisabled}
+        style={buttonStyle}
+        className="export-button"
+        aria-label={isExporting ? 'Exporting...' : label}
+        aria-expanded={isOpen}
+        aria-haspopup={showFormatSelector && supportedFormats.length > 1 ? 'listbox' : undefined}
+        data-testid="export-button"
+      >
+        {isExporting ? (
+          // Loading spinner
+          <svg
+            width={dimensions.iconSize}
+            height={dimensions.iconSize}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="export-button__spinner"
+            style={{ animation: 'spin 1s linear infinite' }}
+          >
+            <circle cx="12" cy="12" r="10" opacity="0.25" />
+            <path d="M12 2a10 10 0 0 1 10 10" />
+          </svg>
+        ) : (
+          // Download icon
+          <svg
+            width={dimensions.iconSize}
+            height={dimensions.iconSize}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+        )}
+
+        <span>{isExporting ? 'Exporting...' : label}</span>
+
+        {showFormatSelector && supportedFormats.length > 1 && !isExporting && (
+          // Dropdown arrow
+          <svg
+            width={12}
+            height={12}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{
+              transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+              transition: 'transform 0.2s',
+            }}
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        )}
+      </button>
+
+      {/* Format dropdown */}
+      {isOpen && showFormatSelector && (
+        <div
+          ref={dropdownRef}
+          style={dropdownStyle}
+          className="export-button__dropdown"
+          role="listbox"
+          aria-label="Select export format"
+          data-testid="export-format-dropdown"
+        >
+          {supportedFormats.map((format) => {
+            const info = getFormatInfo(format);
+            return (
+              <button
+                key={format}
+                type="button"
+                onClick={() => handleFormatSelect(format)}
+                style={itemStyle}
+                className="export-button__format-option"
+                role="option"
+                aria-selected={format === selectedFormat}
+                data-testid={`export-format-${format}`}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = '#f3f4f6';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = 'transparent';
+                }}
+              >
+                <span style={{ fontWeight: 500 }}>{info.name}</span>
+                <span style={{ flex: 1, opacity: 0.6, fontSize: '0.75rem' }}>
+                  {info.extension}
+                </span>
+                {format === selectedFormat && (
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="#3b82f6"
+                    strokeWidth="3"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* CSS for animations */}
+      <style>{`
+        @keyframes spin {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+
+        .export-button:hover:not(:disabled) {
+          background-color: #2563eb;
+          transform: translateY(-1px);
+        }
+
+        .export-button:active:not(:disabled) {
+          transform: translateY(0);
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default ExportButton;

--- a/web/src/components/Recording/ExportDialog.test.tsx
+++ b/web/src/components/Recording/ExportDialog.test.tsx
@@ -1,0 +1,441 @@
+/**
+ * ExportDialog Component Tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExportDialog } from './ExportDialog';
+
+// Mock the export module
+vi.mock('@/lib/audio/export', () => ({
+  getSupportedFormats: vi.fn(() => ['webm', 'wav']),
+  getFormatInfo: vi.fn((format: string) => ({
+    webm: {
+      name: 'WebM',
+      mimeType: 'audio/webm',
+      extension: '.webm',
+      description: 'Web-optimized audio format',
+      isSupported: true,
+    },
+    wav: {
+      name: 'WAV',
+      mimeType: 'audio/wav',
+      extension: '.wav',
+      description: 'Uncompressed audio format',
+      isSupported: true,
+    },
+  }[format])),
+  isWavConversionSupported: vi.fn(() => true),
+}));
+
+describe('ExportDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onExport: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render when isOpen is true', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      expect(screen.getByTestId('export-dialog')).toBeInTheDocument();
+    });
+
+    it('should not render when isOpen is false', () => {
+      render(<ExportDialog {...defaultProps} isOpen={false} />);
+
+      expect(screen.queryByTestId('export-dialog')).not.toBeInTheDocument();
+    });
+
+    it('should display dialog title', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      expect(screen.getByText('Export Audio')).toBeInTheDocument();
+    });
+
+    it('should display recording info', () => {
+      render(
+        <ExportDialog
+          {...defaultProps}
+          poemTitle="My Poem"
+          takeName="Take 1"
+          duration={125}
+        />
+      );
+
+      expect(screen.getByText('Take 1')).toBeInTheDocument();
+      expect(screen.getByText('Duration: 2:05')).toBeInTheDocument();
+    });
+
+    it('should display estimated file size', () => {
+      render(<ExportDialog {...defaultProps} duration={60} />);
+
+      expect(screen.getByText(/Est\. size:/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Export mode selection', () => {
+    it('should not show mode selection when hasMelody is false', () => {
+      render(<ExportDialog {...defaultProps} hasMelody={false} />);
+
+      expect(screen.queryByTestId('export-mode-single')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('export-mode-combined')).not.toBeInTheDocument();
+    });
+
+    it('should show mode selection when hasMelody is true', () => {
+      render(<ExportDialog {...defaultProps} hasMelody />);
+
+      expect(screen.getByTestId('export-mode-single')).toBeInTheDocument();
+      expect(screen.getByTestId('export-mode-combined')).toBeInTheDocument();
+    });
+
+    it('should default to single mode', () => {
+      render(<ExportDialog {...defaultProps} hasMelody />);
+
+      const singleRadio = screen.getByTestId('export-mode-single').querySelector('input');
+      expect(singleRadio).toBeChecked();
+    });
+
+    it('should switch to combined mode', () => {
+      render(<ExportDialog {...defaultProps} hasMelody />);
+
+      fireEvent.click(screen.getByTestId('export-mode-combined'));
+
+      const combinedRadio = screen.getByTestId('export-mode-combined').querySelector('input');
+      expect(combinedRadio).toBeChecked();
+    });
+  });
+
+  describe('Volume controls', () => {
+    it('should not show volume controls in single mode', () => {
+      render(<ExportDialog {...defaultProps} hasMelody />);
+
+      expect(screen.queryByTestId('recording-volume-slider')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('melody-volume-slider')).not.toBeInTheDocument();
+    });
+
+    it('should show volume controls in combined mode', () => {
+      render(<ExportDialog {...defaultProps} hasMelody />);
+
+      fireEvent.click(screen.getByTestId('export-mode-combined'));
+
+      expect(screen.getByTestId('recording-volume-slider')).toBeInTheDocument();
+      expect(screen.getByTestId('melody-volume-slider')).toBeInTheDocument();
+    });
+
+    it('should update recording volume', () => {
+      render(<ExportDialog {...defaultProps} hasMelody />);
+
+      fireEvent.click(screen.getByTestId('export-mode-combined'));
+
+      const slider = screen.getByTestId('recording-volume-slider');
+      fireEvent.change(slider, { target: { value: '75' } });
+
+      expect(screen.getByText('75%')).toBeInTheDocument();
+    });
+
+    it('should update melody volume', () => {
+      render(<ExportDialog {...defaultProps} hasMelody />);
+
+      fireEvent.click(screen.getByTestId('export-mode-combined'));
+
+      const slider = screen.getByTestId('melody-volume-slider');
+      fireEvent.change(slider, { target: { value: '30' } });
+
+      expect(screen.getByText('30%')).toBeInTheDocument();
+    });
+  });
+
+  describe('Format selection', () => {
+    it('should show format select', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      expect(screen.getByTestId('export-format-select')).toBeInTheDocument();
+    });
+
+    it('should default to webm', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      const select = screen.getByTestId('export-format-select');
+      expect(select).toHaveValue('webm');
+    });
+
+    it('should allow changing format', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      const select = screen.getByTestId('export-format-select');
+      fireEvent.change(select, { target: { value: 'wav' } });
+
+      expect(select).toHaveValue('wav');
+    });
+  });
+
+  describe('Quality settings', () => {
+    it('should not show quality settings for webm', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      expect(screen.queryByTestId('sample-rate-select')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('bit-depth-select')).not.toBeInTheDocument();
+    });
+
+    it('should show quality settings for wav', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      const formatSelect = screen.getByTestId('export-format-select');
+      fireEvent.change(formatSelect, { target: { value: 'wav' } });
+
+      expect(screen.getByTestId('sample-rate-select')).toBeInTheDocument();
+      expect(screen.getByTestId('bit-depth-select')).toBeInTheDocument();
+      expect(screen.getByTestId('channels-select')).toBeInTheDocument();
+    });
+
+    it('should allow changing sample rate', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      fireEvent.change(screen.getByTestId('export-format-select'), { target: { value: 'wav' } });
+
+      const select = screen.getByTestId('sample-rate-select');
+      fireEvent.change(select, { target: { value: '48000' } });
+
+      expect(select).toHaveValue('48000');
+    });
+
+    it('should allow changing bit depth', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      fireEvent.change(screen.getByTestId('export-format-select'), { target: { value: 'wav' } });
+
+      const select = screen.getByTestId('bit-depth-select');
+      fireEvent.change(select, { target: { value: '24' } });
+
+      expect(select).toHaveValue('24');
+    });
+  });
+
+  describe('Custom filename', () => {
+    it('should show filename input', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      expect(screen.getByTestId('export-filename-input')).toBeInTheDocument();
+    });
+
+    it('should use poem title as placeholder', () => {
+      render(<ExportDialog {...defaultProps} poemTitle="My Song" />);
+
+      expect(screen.getByTestId('export-filename-input')).toHaveAttribute(
+        'placeholder',
+        'My Song'
+      );
+    });
+
+    it('should allow entering custom filename', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      const input = screen.getByTestId('export-filename-input');
+      fireEvent.change(input, { target: { value: 'custom-name' } });
+
+      expect(input).toHaveValue('custom-name');
+    });
+  });
+
+  describe('Export action', () => {
+    it('should call onExport with correct options when Export button clicked', () => {
+      const handleExport = vi.fn();
+      render(<ExportDialog {...defaultProps} onExport={handleExport} />);
+
+      fireEvent.click(screen.getByTestId('export-dialog-confirm'));
+
+      expect(handleExport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'single',
+          format: 'webm',
+          quality: expect.objectContaining({
+            sampleRate: 44100,
+            channels: 2,
+            bitDepth: 16,
+          }),
+        })
+      );
+    });
+
+    it('should include custom filename in export options', () => {
+      const handleExport = vi.fn();
+      render(<ExportDialog {...defaultProps} onExport={handleExport} />);
+
+      const input = screen.getByTestId('export-filename-input');
+      fireEvent.change(input, { target: { value: 'my-export' } });
+
+      fireEvent.click(screen.getByTestId('export-dialog-confirm'));
+
+      expect(handleExport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filename: 'my-export',
+        })
+      );
+    });
+
+    it('should include combine options for combined mode', () => {
+      const handleExport = vi.fn();
+      render(<ExportDialog {...defaultProps} onExport={handleExport} hasMelody />);
+
+      fireEvent.click(screen.getByTestId('export-mode-combined'));
+      fireEvent.click(screen.getByTestId('export-dialog-confirm'));
+
+      expect(handleExport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'combined',
+          combineOptions: expect.objectContaining({
+            recordingVolume: 1.0,
+            melodyVolume: 0.5,
+          }),
+        })
+      );
+    });
+
+    it('should disable Export button when isExporting is true', () => {
+      render(<ExportDialog {...defaultProps} isExporting />);
+
+      expect(screen.getByTestId('export-dialog-confirm')).toBeDisabled();
+    });
+
+    it('should show loading state when exporting', () => {
+      render(<ExportDialog {...defaultProps} isExporting />);
+
+      expect(screen.getByText('Exporting...')).toBeInTheDocument();
+    });
+  });
+
+  describe('Close action', () => {
+    it('should call onClose when Cancel button clicked', () => {
+      const handleClose = vi.fn();
+      render(<ExportDialog {...defaultProps} onClose={handleClose} />);
+
+      fireEvent.click(screen.getByTestId('export-dialog-cancel'));
+
+      expect(handleClose).toHaveBeenCalled();
+    });
+
+    it('should call onClose when close button clicked', () => {
+      const handleClose = vi.fn();
+      render(<ExportDialog {...defaultProps} onClose={handleClose} />);
+
+      fireEvent.click(screen.getByTestId('export-dialog-close'));
+
+      expect(handleClose).toHaveBeenCalled();
+    });
+
+    it('should call onClose when clicking overlay', () => {
+      const handleClose = vi.fn();
+      render(<ExportDialog {...defaultProps} onClose={handleClose} />);
+
+      fireEvent.click(screen.getByTestId('export-dialog'));
+
+      expect(handleClose).toHaveBeenCalled();
+    });
+
+    it('should not call onClose when clicking dialog content', () => {
+      const handleClose = vi.fn();
+      render(<ExportDialog {...defaultProps} onClose={handleClose} />);
+
+      // Click on dialog content (not overlay)
+      fireEvent.click(screen.getByText('Export Audio'));
+
+      expect(handleClose).not.toHaveBeenCalled();
+    });
+
+    it('should not close when exporting', () => {
+      const handleClose = vi.fn();
+      render(<ExportDialog {...defaultProps} onClose={handleClose} isExporting />);
+
+      fireEvent.click(screen.getByTestId('export-dialog-cancel'));
+
+      // Button should be disabled, so onClose should not be called
+      // (This depends on implementation - button might be disabled)
+      expect(screen.getByTestId('export-dialog-cancel')).toBeDisabled();
+    });
+  });
+
+  describe('Keyboard navigation', () => {
+    it('should close on Escape key', () => {
+      const handleClose = vi.fn();
+      render(<ExportDialog {...defaultProps} onClose={handleClose} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(handleClose).toHaveBeenCalled();
+    });
+
+    it('should not close on Escape when exporting', () => {
+      const handleClose = vi.fn();
+      render(<ExportDialog {...defaultProps} onClose={handleClose} isExporting />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(handleClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have role dialog', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('should have aria-modal attribute', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('should have aria-labelledby pointing to title', () => {
+      render(<ExportDialog {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      const titleId = dialog.getAttribute('aria-labelledby');
+      const title = document.getElementById(titleId!);
+
+      expect(title).toHaveTextContent('Export Audio');
+    });
+  });
+
+  describe('State reset', () => {
+    beforeEach(() => {
+      // Mock requestAnimationFrame for state reset tests
+      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        callback(performance.now());
+        return 1;
+      });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('should reset state when dialog reopens', async () => {
+      const { rerender } = render(<ExportDialog {...defaultProps} />);
+
+      // Change format
+      fireEvent.change(screen.getByTestId('export-format-select'), { target: { value: 'wav' } });
+      expect(screen.getByTestId('export-format-select')).toHaveValue('wav');
+
+      // Close dialog
+      rerender(<ExportDialog {...defaultProps} isOpen={false} />);
+
+      // Reopen dialog
+      rerender(<ExportDialog {...defaultProps} isOpen />);
+
+      // Wait for state reset (requestAnimationFrame is mocked to run synchronously)
+      expect(screen.getByTestId('export-format-select')).toHaveValue('webm');
+    });
+  });
+});

--- a/web/src/components/Recording/ExportDialog.tsx
+++ b/web/src/components/Recording/ExportDialog.tsx
@@ -1,0 +1,701 @@
+/**
+ * ExportDialog Component
+ *
+ * A modal dialog for configuring audio export options.
+ * Supports format selection, quality options, and combined export.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { ExportFormat, ExportQuality, CombineOptions } from '@/lib/audio/export';
+import {
+  getSupportedFormats,
+  getFormatInfo,
+  isWavConversionSupported,
+} from '@/lib/audio/export';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[ExportDialog] ${message}`, ...args);
+  }
+};
+
+/**
+ * Export mode - single track or combined
+ */
+export type ExportMode = 'single' | 'combined';
+
+/**
+ * Props for ExportDialog component
+ */
+export interface ExportDialogProps {
+  /** Whether the dialog is open */
+  isOpen: boolean;
+  /** Callback to close the dialog */
+  onClose: () => void;
+  /** Callback when export is confirmed */
+  onExport: (options: ExportDialogResult) => void;
+  /** Whether exporting is in progress */
+  isExporting?: boolean;
+  /** Whether melody is available for combined export */
+  hasMelody?: boolean;
+  /** The poem title for filename generation */
+  poemTitle?: string;
+  /** The take name */
+  takeName?: string;
+  /** Recording duration in seconds */
+  duration?: number;
+}
+
+/**
+ * Result from the export dialog
+ */
+export interface ExportDialogResult {
+  /** Export mode */
+  mode: ExportMode;
+  /** Selected format */
+  format: ExportFormat;
+  /** Quality settings */
+  quality: ExportQuality;
+  /** Combine options (for combined mode) */
+  combineOptions?: CombineOptions;
+  /** Custom filename (without extension) */
+  filename?: string;
+}
+
+/**
+ * Format duration to MM:SS
+ */
+function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Format file size estimate
+ */
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Estimate file size based on format and duration
+ */
+function estimateFileSize(
+  durationSeconds: number,
+  format: ExportFormat,
+  quality: ExportQuality
+): number {
+  const { sampleRate = 44100, channels = 2, bitDepth = 16 } = quality;
+
+  if (format === 'wav') {
+    // WAV: sampleRate * channels * (bitDepth / 8) * seconds
+    return sampleRate * channels * (bitDepth / 8) * durationSeconds;
+  }
+
+  // WebM: roughly 128 kbps
+  return (128000 / 8) * durationSeconds;
+}
+
+/**
+ * ExportDialog provides a modal for configuring export options.
+ *
+ * Features:
+ * - Format selection (WebM, WAV)
+ * - Quality settings for WAV (sample rate, bit depth)
+ * - Combined export option (recording + melody)
+ * - Volume controls for combined export
+ * - File size estimation
+ * - Custom filename input
+ *
+ * @example
+ * ```tsx
+ * <ExportDialog
+ *   isOpen={showExportDialog}
+ *   onClose={() => setShowExportDialog(false)}
+ *   onExport={(options) => handleExport(options)}
+ *   hasMelody={!!melodyBlobUrl}
+ *   poemTitle={poemTitle}
+ * />
+ * ```
+ */
+export function ExportDialog({
+  isOpen,
+  onClose,
+  onExport,
+  isExporting = false,
+  hasMelody = false,
+  poemTitle,
+  takeName,
+  duration = 0,
+}: ExportDialogProps): React.ReactElement | null {
+  // State
+  const [mode, setMode] = useState<ExportMode>('single');
+  const [format, setFormat] = useState<ExportFormat>('webm');
+  const [sampleRate, setSampleRate] = useState(44100);
+  const [bitDepth, setBitDepth] = useState<8 | 16 | 24 | 32>(16);
+  const [channels, setChannels] = useState<1 | 2>(2);
+  const [recordingVolume, setRecordingVolume] = useState(100);
+  const [melodyVolume, setMelodyVolume] = useState(50);
+  const [customFilename, setCustomFilename] = useState('');
+
+  const supportedFormats = getSupportedFormats();
+  const wavSupported = isWavConversionSupported();
+
+  // Track previous open state to detect when dialog opens
+  const wasOpenRef = useRef(false);
+
+  // Reset state when dialog opens (using ref to avoid synchronous setState warning)
+  useEffect(() => {
+    if (isOpen && !wasOpenRef.current) {
+      log('Dialog opened, will reset state');
+      // Use requestAnimationFrame to avoid the synchronous setState warning
+      requestAnimationFrame(() => {
+        setMode('single');
+        setFormat('webm');
+        setSampleRate(44100);
+        setBitDepth(16);
+        setChannels(2);
+        setRecordingVolume(100);
+        setMelodyVolume(50);
+        setCustomFilename('');
+      });
+    }
+    wasOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  // Handle escape key
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen && !isExporting) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, isExporting, onClose]);
+
+  // Calculate estimated file size
+  const quality: ExportQuality = { sampleRate, channels, bitDepth };
+  const estimatedSize = estimateFileSize(duration, format, quality);
+
+  // Handle export
+  const handleExport = useCallback(() => {
+    const exportQuality = { sampleRate, channels, bitDepth };
+    log('Export requested:', { mode, format, quality: exportQuality });
+
+    const result: ExportDialogResult = {
+      mode,
+      format,
+      quality: exportQuality,
+      filename: customFilename.trim() || undefined,
+    };
+
+    if (mode === 'combined') {
+      result.combineOptions = {
+        recordingVolume: recordingVolume / 100,
+        melodyVolume: melodyVolume / 100,
+        format,
+        quality: exportQuality,
+      };
+    }
+
+    onExport(result);
+  }, [
+    mode,
+    format,
+    sampleRate,
+    channels,
+    bitDepth,
+    recordingVolume,
+    melodyVolume,
+    customFilename,
+    onExport,
+  ]);
+
+  // Don't render if not open
+  if (!isOpen) {
+    return null;
+  }
+
+  // Overlay styles
+  const overlayStyle: React.CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 100,
+    padding: '1rem',
+  };
+
+  // Dialog styles
+  const dialogStyle: React.CSSProperties = {
+    backgroundColor: 'white',
+    borderRadius: '12px',
+    boxShadow: '0 8px 32px rgba(0, 0, 0, 0.2)',
+    width: '100%',
+    maxWidth: '480px',
+    maxHeight: '90vh',
+    overflow: 'auto',
+  };
+
+  // Header styles
+  const headerStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '1rem 1.25rem',
+    borderBottom: '1px solid #e5e7eb',
+  };
+
+  // Section styles
+  const sectionStyle: React.CSSProperties = {
+    padding: '1rem 1.25rem',
+    borderBottom: '1px solid #f3f4f6',
+  };
+
+  // Label styles
+  const labelStyle: React.CSSProperties = {
+    display: 'block',
+    fontSize: '0.875rem',
+    fontWeight: 500,
+    marginBottom: '0.5rem',
+    color: '#374151',
+  };
+
+  // Input styles
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '0.5rem 0.75rem',
+    fontSize: '0.875rem',
+    border: '1px solid #d1d5db',
+    borderRadius: '6px',
+    outline: 'none',
+  };
+
+  // Select styles
+  const selectStyle: React.CSSProperties = {
+    ...inputStyle,
+    appearance: 'none',
+    backgroundImage:
+      'url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'16\' height=\'16\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'%236b7280\' stroke-width=\'2\'%3E%3Cpolyline points=\'6 9 12 15 18 9\'/%3E%3C/svg%3E")',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'right 0.5rem center',
+    paddingRight: '2rem',
+  };
+
+  // Button styles
+  const buttonBaseStyle: React.CSSProperties = {
+    padding: '0.625rem 1.25rem',
+    fontSize: '0.875rem',
+    fontWeight: 500,
+    borderRadius: '8px',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+    border: 'none',
+  };
+
+  const primaryButtonStyle: React.CSSProperties = {
+    ...buttonBaseStyle,
+    backgroundColor: '#3b82f6',
+    color: 'white',
+  };
+
+  const secondaryButtonStyle: React.CSSProperties = {
+    ...buttonBaseStyle,
+    backgroundColor: 'transparent',
+    color: '#6b7280',
+    border: '1px solid #d1d5db',
+  };
+
+  // Radio button group styles
+  const radioGroupStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: '0.75rem',
+  };
+
+  const radioLabelStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    padding: '0.625rem 1rem',
+    border: '2px solid #e5e7eb',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+    flex: 1,
+  };
+
+  const radioLabelSelectedStyle: React.CSSProperties = {
+    ...radioLabelStyle,
+    borderColor: '#3b82f6',
+    backgroundColor: 'rgba(59, 130, 246, 0.05)',
+  };
+
+  return (
+    <div
+      style={overlayStyle}
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isExporting) {
+          onClose();
+        }
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="export-dialog-title"
+      data-testid="export-dialog"
+    >
+      <div style={dialogStyle} className="export-dialog">
+        {/* Header */}
+        <div style={headerStyle}>
+          <h2
+            id="export-dialog-title"
+            style={{ margin: 0, fontSize: '1.125rem', fontWeight: 600 }}
+          >
+            Export Audio
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isExporting}
+            style={{
+              padding: '0.375rem',
+              background: 'none',
+              border: 'none',
+              cursor: isExporting ? 'not-allowed' : 'pointer',
+              opacity: isExporting ? 0.5 : 1,
+              borderRadius: '4px',
+            }}
+            aria-label="Close"
+            data-testid="export-dialog-close"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Recording info */}
+        <div style={{ ...sectionStyle, backgroundColor: '#f9fafb' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div>
+              <div style={{ fontWeight: 500 }}>{takeName || poemTitle || 'Recording'}</div>
+              <div style={{ fontSize: '0.8125rem', color: '#6b7280' }}>
+                Duration: {formatDuration(duration)}
+              </div>
+            </div>
+            <div style={{ textAlign: 'right', fontSize: '0.8125rem', color: '#6b7280' }}>
+              Est. size: {formatFileSize(estimatedSize)}
+            </div>
+          </div>
+        </div>
+
+        {/* Export mode (if melody available) */}
+        {hasMelody && (
+          <div style={sectionStyle}>
+            <label style={labelStyle}>Export Mode</label>
+            <div style={radioGroupStyle}>
+              <label
+                style={mode === 'single' ? radioLabelSelectedStyle : radioLabelStyle}
+                data-testid="export-mode-single"
+              >
+                <input
+                  type="radio"
+                  name="exportMode"
+                  value="single"
+                  checked={mode === 'single'}
+                  onChange={() => setMode('single')}
+                  style={{ margin: 0 }}
+                />
+                <div>
+                  <div style={{ fontWeight: 500, fontSize: '0.875rem' }}>Recording Only</div>
+                  <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>Just your vocals</div>
+                </div>
+              </label>
+              <label
+                style={mode === 'combined' ? radioLabelSelectedStyle : radioLabelStyle}
+                data-testid="export-mode-combined"
+              >
+                <input
+                  type="radio"
+                  name="exportMode"
+                  value="combined"
+                  checked={mode === 'combined'}
+                  onChange={() => setMode('combined')}
+                  style={{ margin: 0 }}
+                />
+                <div>
+                  <div style={{ fontWeight: 500, fontSize: '0.875rem' }}>Combined</div>
+                  <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>Vocals + Melody</div>
+                </div>
+              </label>
+            </div>
+          </div>
+        )}
+
+        {/* Volume controls (for combined mode) */}
+        {mode === 'combined' && (
+          <div style={sectionStyle}>
+            <label style={labelStyle}>Mix Levels</label>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+              <div>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    fontSize: '0.8125rem',
+                    marginBottom: '0.25rem',
+                  }}
+                >
+                  <span>Recording</span>
+                  <span>{recordingVolume}%</span>
+                </div>
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={recordingVolume}
+                  onChange={(e) => setRecordingVolume(parseInt(e.target.value))}
+                  style={{ width: '100%' }}
+                  data-testid="recording-volume-slider"
+                />
+              </div>
+              <div>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    fontSize: '0.8125rem',
+                    marginBottom: '0.25rem',
+                  }}
+                >
+                  <span>Melody</span>
+                  <span>{melodyVolume}%</span>
+                </div>
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={melodyVolume}
+                  onChange={(e) => setMelodyVolume(parseInt(e.target.value))}
+                  style={{ width: '100%' }}
+                  data-testid="melody-volume-slider"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Format selection */}
+        <div style={sectionStyle}>
+          <label style={labelStyle} htmlFor="export-format">
+            Format
+          </label>
+          <select
+            id="export-format"
+            value={format}
+            onChange={(e) => setFormat(e.target.value as ExportFormat)}
+            style={selectStyle}
+            data-testid="export-format-select"
+          >
+            {supportedFormats.map((fmt) => {
+              const info = getFormatInfo(fmt);
+              return (
+                <option key={fmt} value={fmt}>
+                  {info.name} ({info.extension}) - {info.description}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+
+        {/* Quality settings (for WAV) */}
+        {format === 'wav' && wavSupported && (
+          <div style={sectionStyle}>
+            <label style={labelStyle}>Quality Settings</label>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+              <div>
+                <label
+                  style={{ ...labelStyle, fontSize: '0.75rem', color: '#6b7280' }}
+                  htmlFor="sample-rate"
+                >
+                  Sample Rate
+                </label>
+                <select
+                  id="sample-rate"
+                  value={sampleRate}
+                  onChange={(e) => setSampleRate(parseInt(e.target.value))}
+                  style={selectStyle}
+                  data-testid="sample-rate-select"
+                >
+                  <option value={22050}>22.05 kHz</option>
+                  <option value={44100}>44.1 kHz (CD)</option>
+                  <option value={48000}>48 kHz</option>
+                  <option value={96000}>96 kHz (High)</option>
+                </select>
+              </div>
+              <div>
+                <label
+                  style={{ ...labelStyle, fontSize: '0.75rem', color: '#6b7280' }}
+                  htmlFor="bit-depth"
+                >
+                  Bit Depth
+                </label>
+                <select
+                  id="bit-depth"
+                  value={bitDepth}
+                  onChange={(e) => setBitDepth(parseInt(e.target.value) as 8 | 16 | 24 | 32)}
+                  style={selectStyle}
+                  data-testid="bit-depth-select"
+                >
+                  <option value={8}>8-bit</option>
+                  <option value={16}>16-bit (CD)</option>
+                  <option value={24}>24-bit (High)</option>
+                  <option value={32}>32-bit</option>
+                </select>
+              </div>
+              <div style={{ gridColumn: '1 / -1' }}>
+                <label
+                  style={{ ...labelStyle, fontSize: '0.75rem', color: '#6b7280' }}
+                  htmlFor="channels"
+                >
+                  Channels
+                </label>
+                <select
+                  id="channels"
+                  value={channels}
+                  onChange={(e) => setChannels(parseInt(e.target.value) as 1 | 2)}
+                  style={selectStyle}
+                  data-testid="channels-select"
+                >
+                  <option value={1}>Mono</option>
+                  <option value={2}>Stereo</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Custom filename */}
+        <div style={sectionStyle}>
+          <label style={labelStyle} htmlFor="export-filename">
+            Filename (optional)
+          </label>
+          <input
+            id="export-filename"
+            type="text"
+            value={customFilename}
+            onChange={(e) => setCustomFilename(e.target.value)}
+            placeholder={poemTitle || takeName || 'recording'}
+            style={inputStyle}
+            data-testid="export-filename-input"
+          />
+          <div style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '0.25rem' }}>
+            Extension will be added automatically
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '0.75rem',
+            padding: '1rem 1.25rem',
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isExporting}
+            style={{
+              ...secondaryButtonStyle,
+              opacity: isExporting ? 0.5 : 1,
+              cursor: isExporting ? 'not-allowed' : 'pointer',
+            }}
+            data-testid="export-dialog-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={isExporting}
+            style={{
+              ...primaryButtonStyle,
+              opacity: isExporting ? 0.7 : 1,
+              cursor: isExporting ? 'not-allowed' : 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+            }}
+            data-testid="export-dialog-confirm"
+          >
+            {isExporting ? (
+              <>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  style={{ animation: 'spin 1s linear infinite' }}
+                >
+                  <circle cx="12" cy="12" r="10" opacity="0.25" />
+                  <path d="M12 2a10 10 0 0 1 10 10" />
+                </svg>
+                Exporting...
+              </>
+            ) : (
+              <>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" y1="15" x2="12" y2="3" />
+                </svg>
+                Export
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* CSS for animations */}
+      <style>{`
+        @keyframes spin {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default ExportDialog;

--- a/web/src/components/Recording/index.ts
+++ b/web/src/components/Recording/index.ts
@@ -48,3 +48,16 @@ export type {
   TakesListProps,
   TakesSortOrder,
 } from './TakesList';
+
+export { ExportButton } from './ExportButton';
+export type {
+  ExportButtonProps,
+  ExportButtonSize,
+} from './ExportButton';
+
+export { ExportDialog } from './ExportDialog';
+export type {
+  ExportDialogProps,
+  ExportDialogResult,
+  ExportMode,
+} from './ExportDialog';

--- a/web/src/lib/audio/export.test.ts
+++ b/web/src/lib/audio/export.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Audio Export Module Tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  downloadAudio,
+  convertToWav,
+  combineAudioTracks,
+  exportRecording,
+  exportAndDownload,
+  fetchBlobFromUrl,
+  generateFilename,
+  sanitizeFilename,
+  getSupportedFormats,
+  isWavConversionSupported,
+  getFormatInfo,
+  getAllFormatsInfo,
+} from './export';
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+// Mock URL.createObjectURL and revokeObjectURL
+const mockObjectUrls = new Map<Blob, string>();
+let urlCounter = 0;
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+// Mock AudioContext
+class MockAudioBuffer {
+  numberOfChannels = 2;
+  sampleRate = 44100;
+  duration = 10;
+  length = 441000;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getChannelData(_channel: number): Float32Array {
+    const data = new Float32Array(this.length);
+    // Fill with sine wave for testing
+    for (let i = 0; i < this.length; i++) {
+      data[i] = Math.sin((i / this.sampleRate) * 440 * 2 * Math.PI) * 0.5;
+    }
+    return data;
+  }
+}
+
+class MockAudioContext {
+  sampleRate = 44100;
+
+  async decodeAudioData(): Promise<AudioBuffer> {
+    return new MockAudioBuffer() as unknown as AudioBuffer;
+  }
+
+  async close(): Promise<void> {}
+}
+
+class MockOfflineAudioContext {
+  destination = {};
+  numberOfChannels: number;
+  length: number;
+  sampleRate: number;
+
+  constructor(numberOfChannels: number, length: number, sampleRate: number) {
+    this.numberOfChannels = numberOfChannels;
+    this.length = length;
+    this.sampleRate = sampleRate;
+  }
+
+  createBufferSource() {
+    return {
+      buffer: null,
+      connect: vi.fn(),
+      start: vi.fn(),
+    };
+  }
+
+  createGain() {
+    return {
+      gain: { value: 1 },
+      connect: vi.fn(),
+    };
+  }
+
+  async startRendering(): Promise<AudioBuffer> {
+    return new MockAudioBuffer() as unknown as AudioBuffer;
+  }
+}
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+describe('export', () => {
+  let originalAudioContext: typeof AudioContext;
+  let originalOfflineAudioContext: typeof OfflineAudioContext;
+  let mockLink: HTMLAnchorElement;
+  let appendChildSpy: ReturnType<typeof vi.spyOn>;
+  let removeChildSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    // Mock URL methods
+    urlCounter = 0;
+    mockObjectUrls.clear();
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      const url = `blob:http://localhost/mock-${urlCounter++}`;
+      mockObjectUrls.set(blob, url);
+      return url;
+    });
+    URL.revokeObjectURL = vi.fn();
+
+    // Mock fetch - return a mock blob with arrayBuffer method
+    const mockArrayBuffer = new ArrayBuffer(100);
+    const mockFetchBlob = {
+      arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+      type: 'audio/webm',
+      size: 100,
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: vi.fn().mockResolvedValue(mockFetchBlob),
+    });
+
+    // Mock AudioContext
+    originalAudioContext = globalThis.AudioContext;
+    originalOfflineAudioContext = globalThis.OfflineAudioContext;
+    globalThis.AudioContext = MockAudioContext as unknown as typeof AudioContext;
+    globalThis.OfflineAudioContext = MockOfflineAudioContext as unknown as typeof OfflineAudioContext;
+
+    // Mock document.createElement for download link
+    mockLink = {
+      href: '',
+      download: '',
+      click: vi.fn(),
+    } as unknown as HTMLAnchorElement;
+
+    vi.spyOn(document, 'createElement').mockReturnValue(mockLink);
+    appendChildSpy = vi.spyOn(document.body, 'appendChild').mockReturnValue(mockLink);
+    removeChildSpy = vi.spyOn(document.body, 'removeChild').mockReturnValue(mockLink);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    globalThis.AudioContext = originalAudioContext;
+    globalThis.OfflineAudioContext = originalOfflineAudioContext;
+  });
+
+  // ===========================================================================
+  // Utility Functions
+  // ===========================================================================
+
+  describe('sanitizeFilename', () => {
+    it('should remove forbidden characters', () => {
+      expect(sanitizeFilename('test<>:"/\\|?*name')).toBe('testname');
+    });
+
+    it('should replace spaces with hyphens', () => {
+      expect(sanitizeFilename('my song title')).toBe('my-song-title');
+    });
+
+    it('should collapse multiple hyphens', () => {
+      expect(sanitizeFilename('test---name')).toBe('test-name');
+    });
+
+    it('should remove leading/trailing hyphens', () => {
+      expect(sanitizeFilename('-test-name-')).toBe('test-name');
+    });
+
+    it('should limit length to 200 characters', () => {
+      const longName = 'a'.repeat(300);
+      expect(sanitizeFilename(longName).length).toBe(200);
+    });
+
+    it('should handle empty string', () => {
+      expect(sanitizeFilename('')).toBe('');
+    });
+  });
+
+  describe('generateFilename', () => {
+    it('should generate filename with poem title', () => {
+      const filename = generateFilename('My Poem', 'webm');
+      expect(filename).toMatch(/^My-Poem-\d{4}-\d{2}-\d{2}\.webm$/);
+    });
+
+    it('should generate filename without poem title', () => {
+      const filename = generateFilename(undefined, 'webm');
+      expect(filename).toMatch(/^recording-\d{4}-\d{2}-\d{2}\.webm$/);
+    });
+
+    it('should include take number when provided', () => {
+      const filename = generateFilename('My Poem', 'wav', 3);
+      expect(filename).toMatch(/^My-Poem-take-3-\d{4}-\d{2}-\d{2}\.wav$/);
+    });
+
+    it('should use correct extension for format', () => {
+      expect(generateFilename('Test', 'webm')).toContain('.webm');
+      expect(generateFilename('Test', 'wav')).toContain('.wav');
+    });
+  });
+
+  describe('getSupportedFormats', () => {
+    it('should always include webm', () => {
+      const formats = getSupportedFormats();
+      expect(formats).toContain('webm');
+    });
+
+    it('should include wav when AudioContext is available', () => {
+      const formats = getSupportedFormats();
+      expect(formats).toContain('wav');
+    });
+
+    it('should not include wav when AudioContext is unavailable', () => {
+      const temp = globalThis.AudioContext;
+      // @ts-expect-error - intentionally setting to undefined
+      globalThis.AudioContext = undefined;
+
+      const formats = getSupportedFormats();
+      expect(formats).not.toContain('wav');
+
+      globalThis.AudioContext = temp;
+    });
+  });
+
+  describe('isWavConversionSupported', () => {
+    it('should return true when AudioContext is available', () => {
+      expect(isWavConversionSupported()).toBe(true);
+    });
+
+    it('should return false when AudioContext is unavailable', () => {
+      const temp = globalThis.AudioContext;
+      // @ts-expect-error - intentionally setting to undefined
+      globalThis.AudioContext = undefined;
+
+      expect(isWavConversionSupported()).toBe(false);
+
+      globalThis.AudioContext = temp;
+    });
+  });
+
+  describe('getFormatInfo', () => {
+    it('should return correct info for webm', () => {
+      const info = getFormatInfo('webm');
+      expect(info.name).toBe('WebM');
+      expect(info.mimeType).toBe('audio/webm');
+      expect(info.extension).toBe('.webm');
+      expect(info.isSupported).toBe(true);
+    });
+
+    it('should return correct info for wav', () => {
+      const info = getFormatInfo('wav');
+      expect(info.name).toBe('WAV');
+      expect(info.mimeType).toBe('audio/wav');
+      expect(info.extension).toBe('.wav');
+    });
+  });
+
+  describe('getAllFormatsInfo', () => {
+    it('should return info for all formats', () => {
+      const allInfo = getAllFormatsInfo();
+      expect(allInfo.length).toBe(2);
+      expect(allInfo.map((i) => i.name)).toContain('WebM');
+      expect(allInfo.map((i) => i.name)).toContain('WAV');
+    });
+  });
+
+  // ===========================================================================
+  // Download Functions
+  // ===========================================================================
+
+  describe('downloadAudio', () => {
+    it('should create a download link with correct properties', () => {
+      const blob = new Blob(['test'], { type: 'audio/webm' });
+      downloadAudio(blob, 'test.webm');
+
+      expect(document.createElement).toHaveBeenCalledWith('a');
+      expect(mockLink.download).toBe('test.webm');
+      expect(mockLink.href).toBeDefined();
+    });
+
+    it('should trigger click on the link', () => {
+      const blob = new Blob(['test'], { type: 'audio/webm' });
+      downloadAudio(blob, 'test.webm');
+
+      expect(mockLink.click).toHaveBeenCalled();
+    });
+
+    it('should append and remove link from document', () => {
+      const blob = new Blob(['test'], { type: 'audio/webm' });
+      downloadAudio(blob, 'test.webm');
+
+      expect(appendChildSpy).toHaveBeenCalledWith(mockLink);
+      expect(removeChildSpy).toHaveBeenCalledWith(mockLink);
+    });
+
+    it('should revoke object URL after delay', () => {
+      const blob = new Blob(['test'], { type: 'audio/webm' });
+      downloadAudio(blob, 'test.webm');
+
+      expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(URL.revokeObjectURL).toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchBlobFromUrl', () => {
+    it('should fetch blob from URL', async () => {
+      const result = await fetchBlobFromUrl('blob:http://localhost/test');
+
+      expect(global.fetch).toHaveBeenCalledWith('blob:http://localhost/test');
+      // Result should have blob-like properties
+      expect(result).toBeDefined();
+      expect(result.type).toBe('audio/webm');
+    });
+
+    it('should throw error on failed fetch', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Not Found',
+      });
+
+      await expect(fetchBlobFromUrl('invalid-url')).rejects.toThrow('Failed to fetch blob');
+    });
+  });
+
+  // ===========================================================================
+  // Conversion Functions
+  // ===========================================================================
+
+  describe('convertToWav', () => {
+    it('should convert blob to WAV format', async () => {
+      // Create a blob with arrayBuffer method
+      const mockArrayBuffer = new ArrayBuffer(100);
+      const inputBlob = {
+        arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+        type: 'audio/webm',
+        size: 100,
+      } as unknown as Blob;
+
+      const result = await convertToWav(inputBlob);
+
+      expect(result).toBeInstanceOf(Blob);
+      expect(result.type).toBe('audio/wav');
+    });
+
+    it('should respect quality options', async () => {
+      const mockArrayBuffer = new ArrayBuffer(100);
+      const inputBlob = {
+        arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+        type: 'audio/webm',
+        size: 100,
+      } as unknown as Blob;
+
+      const result = await convertToWav(inputBlob, {
+        sampleRate: 48000,
+        channels: 1,
+        bitDepth: 24,
+      });
+
+      expect(result).toBeInstanceOf(Blob);
+      expect(result.type).toBe('audio/wav');
+    });
+
+    it('should throw when AudioContext is unavailable', async () => {
+      const temp = globalThis.AudioContext;
+      // @ts-expect-error - intentionally setting to undefined
+      globalThis.AudioContext = undefined;
+
+      const inputBlob = new Blob(['test audio'], { type: 'audio/webm' });
+      await expect(convertToWav(inputBlob)).rejects.toThrow(
+        'WAV conversion is not supported'
+      );
+
+      globalThis.AudioContext = temp;
+    });
+  });
+
+  describe('combineAudioTracks', () => {
+    it('should combine two audio tracks', async () => {
+      const mockArrayBuffer = new ArrayBuffer(100);
+      const recordingBlob = {
+        arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+        type: 'audio/webm',
+        size: 100,
+      } as unknown as Blob;
+      const melodyBlob = {
+        arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+        type: 'audio/webm',
+        size: 100,
+      } as unknown as Blob;
+
+      const result = await combineAudioTracks(recordingBlob, melodyBlob);
+
+      expect(result).toBeInstanceOf(Blob);
+      expect(result.type).toBe('audio/wav');
+    });
+
+    it('should respect volume options', async () => {
+      const mockArrayBuffer = new ArrayBuffer(100);
+      const recordingBlob = {
+        arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+        type: 'audio/webm',
+        size: 100,
+      } as unknown as Blob;
+      const melodyBlob = {
+        arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+        type: 'audio/webm',
+        size: 100,
+      } as unknown as Blob;
+
+      const result = await combineAudioTracks(recordingBlob, melodyBlob, {
+        recordingVolume: 0.8,
+        melodyVolume: 0.3,
+      });
+
+      expect(result).toBeInstanceOf(Blob);
+    });
+
+    it('should throw when AudioContext is unavailable', async () => {
+      const temp = globalThis.AudioContext;
+      // @ts-expect-error - intentionally setting to undefined
+      globalThis.AudioContext = undefined;
+
+      const recordingBlob = new Blob(['recording'], { type: 'audio/webm' });
+      const melodyBlob = new Blob(['melody'], { type: 'audio/webm' });
+
+      await expect(combineAudioTracks(recordingBlob, melodyBlob)).rejects.toThrow(
+        'Audio combining is not supported'
+      );
+
+      globalThis.AudioContext = temp;
+    });
+  });
+
+  // ===========================================================================
+  // High-Level Export Functions
+  // ===========================================================================
+
+  describe('exportRecording', () => {
+    it('should export recording as WebM', async () => {
+      const result = await exportRecording('blob:http://localhost/test', {
+        format: 'webm',
+      });
+
+      expect(result.blob).toBeDefined();
+      expect(result.mimeType).toBe('audio/webm');
+      expect(result.filename).toContain('.webm');
+    });
+
+    it('should export recording as WAV', async () => {
+      const result = await exportRecording('blob:http://localhost/test', {
+        format: 'wav',
+      });
+
+      expect(result.blob).toBeInstanceOf(Blob);
+      expect(result.mimeType).toBe('audio/wav');
+      expect(result.filename).toContain('.wav');
+    });
+
+    it('should use custom filename', async () => {
+      const result = await exportRecording('blob:http://localhost/test', {
+        format: 'webm',
+        filename: 'my-custom-recording',
+      });
+
+      expect(result.filename).toBe('my-custom-recording.webm');
+    });
+
+    it('should include file size in result', async () => {
+      const result = await exportRecording('blob:http://localhost/test');
+
+      expect(result.size).toBeGreaterThan(0);
+    });
+  });
+
+  describe('exportAndDownload', () => {
+    it('should export and trigger download', async () => {
+      const result = await exportAndDownload(
+        'blob:http://localhost/test',
+        'My Poem',
+        { format: 'webm' }
+      );
+
+      expect(result.blob).toBeDefined();
+      expect(mockLink.click).toHaveBeenCalled();
+    });
+
+    it('should use poem title in filename', async () => {
+      const result = await exportAndDownload(
+        'blob:http://localhost/test',
+        'My Great Poem'
+      );
+
+      expect(result.filename).toContain('My-Great-Poem');
+    });
+
+    it('should default to webm format', async () => {
+      const result = await exportAndDownload('blob:http://localhost/test');
+
+      expect(result.mimeType).toBe('audio/webm');
+    });
+  });
+
+  // ===========================================================================
+  // WAV Encoding Tests
+  // ===========================================================================
+
+  describe('WAV encoding', () => {
+    it('should create blob with audio/wav type', async () => {
+      const mockArrayBuffer = new ArrayBuffer(100);
+      const inputBlob = {
+        arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+        type: 'audio/webm',
+        size: 100,
+      } as unknown as Blob;
+
+      const result = await convertToWav(inputBlob);
+
+      // Verify it's a valid WAV blob
+      expect(result).toBeInstanceOf(Blob);
+      expect(result.type).toBe('audio/wav');
+      expect(result.size).toBeGreaterThan(44); // WAV header is 44 bytes
+    });
+
+    it('should encode with different bit depths', async () => {
+      const mockArrayBuffer = new ArrayBuffer(100);
+      const inputBlob = {
+        arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+        type: 'audio/webm',
+        size: 100,
+      } as unknown as Blob;
+
+      for (const bitDepth of [8, 16, 24, 32] as const) {
+        const result = await convertToWav(inputBlob, { bitDepth });
+        expect(result).toBeInstanceOf(Blob);
+        expect(result.type).toBe('audio/wav');
+      }
+    });
+  });
+});

--- a/web/src/lib/audio/export.ts
+++ b/web/src/lib/audio/export.ts
@@ -1,0 +1,740 @@
+/**
+ * Audio Export Module
+ *
+ * Provides utilities for exporting, converting, and downloading audio.
+ * Supports WebM (native), WAV (conversion), and audio track combining.
+ *
+ * @module lib/audio/export
+ */
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[AudioExport] ${message}`, ...args);
+  }
+};
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Supported export formats
+ */
+export type ExportFormat = 'webm' | 'wav';
+
+/**
+ * Export quality options for WAV conversion
+ */
+export interface ExportQuality {
+  /** Sample rate in Hz (default: 44100) */
+  sampleRate?: number;
+  /** Number of channels (1 = mono, 2 = stereo, default: 2) */
+  channels?: number;
+  /** Bits per sample (8, 16, 24, 32, default: 16) */
+  bitDepth?: 8 | 16 | 24 | 32;
+}
+
+/**
+ * Options for audio export
+ */
+export interface ExportOptions {
+  /** Export format */
+  format?: ExportFormat;
+  /** Quality settings for WAV */
+  quality?: ExportQuality;
+  /** Custom filename (without extension) */
+  filename?: string;
+}
+
+/**
+ * Options for combining audio tracks
+ */
+export interface CombineOptions {
+  /** Volume of the recording track (0-1, default: 1) */
+  recordingVolume?: number;
+  /** Volume of the melody track (0-1, default: 0.5) */
+  melodyVolume?: number;
+  /** Output format */
+  format?: ExportFormat;
+  /** Quality settings */
+  quality?: ExportQuality;
+}
+
+/**
+ * Result of an export operation
+ */
+export interface ExportResult {
+  /** The exported audio blob */
+  blob: Blob;
+  /** The filename with extension */
+  filename: string;
+  /** The MIME type */
+  mimeType: string;
+  /** File size in bytes */
+  size: number;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const DEFAULT_SAMPLE_RATE = 44100;
+const DEFAULT_CHANNELS = 2;
+const DEFAULT_BIT_DEPTH = 16;
+
+const MIME_TYPES: Record<ExportFormat, string> = {
+  webm: 'audio/webm',
+  wav: 'audio/wav',
+};
+
+const FILE_EXTENSIONS: Record<ExportFormat, string> = {
+  webm: '.webm',
+  wav: '.wav',
+};
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Check if WAV conversion is supported in the current browser
+ */
+export function isWavConversionSupported(): boolean {
+  const supported =
+    typeof window !== 'undefined' &&
+    typeof AudioContext !== 'undefined' &&
+    typeof OfflineAudioContext !== 'undefined';
+
+  log('WAV conversion support check:', supported);
+  return supported;
+}
+
+/**
+ * Get supported export formats
+ */
+export function getSupportedFormats(): ExportFormat[] {
+  const formats: ExportFormat[] = ['webm']; // WebM is always available
+
+  if (isWavConversionSupported()) {
+    formats.push('wav');
+  }
+
+  log('Supported export formats:', formats);
+  return formats;
+}
+
+/**
+ * Sanitize a filename for safe download
+ */
+export function sanitizeFilename(filename: string): string {
+  // Remove or replace characters that are problematic in filenames
+  return filename
+    .replace(/[<>:"/\\|?*]/g, '') // Remove Windows-forbidden characters
+    .replace(/\s+/g, '-') // Replace spaces with hyphens
+    .replace(/-+/g, '-') // Collapse multiple hyphens
+    .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
+    .trim()
+    .slice(0, 200); // Limit length
+}
+
+/**
+ * Generate a filename for export
+ */
+export function generateFilename(
+  poemTitle: string | undefined,
+  format: ExportFormat,
+  takeNumber?: number
+): string {
+  const timestamp = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+  const title = poemTitle ? sanitizeFilename(poemTitle) : 'recording';
+  const take = takeNumber ? `-take-${takeNumber}` : '';
+
+  return `${title}${take}-${timestamp}${FILE_EXTENSIONS[format]}`;
+}
+
+// =============================================================================
+// Core Export Functions
+// =============================================================================
+
+/**
+ * Download an audio blob as a file
+ *
+ * @param blob - The audio blob to download
+ * @param filename - The filename for the download
+ *
+ * @example
+ * ```typescript
+ * downloadAudio(audioBlob, 'my-song.webm');
+ * ```
+ */
+export function downloadAudio(blob: Blob, filename: string): void {
+  log('Downloading audio:', filename, 'size:', blob.size);
+
+  // Create a temporary URL for the blob
+  const url = URL.createObjectURL(blob);
+
+  try {
+    // Create a link element
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+
+    // Append to body (required for Firefox)
+    document.body.appendChild(link);
+
+    // Trigger download
+    link.click();
+
+    // Clean up
+    document.body.removeChild(link);
+
+    log('Download initiated successfully');
+  } finally {
+    // Always revoke the URL to free memory
+    // Use setTimeout to ensure the download has started
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+      log('Revoked download URL');
+    }, 1000);
+  }
+}
+
+/**
+ * Fetch a blob from a URL (blob URL or data URL)
+ */
+export async function fetchBlobFromUrl(url: string): Promise<Blob> {
+  log('Fetching blob from URL:', url.slice(0, 50) + '...');
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch blob: ${response.statusText}`);
+  }
+
+  const blob = await response.blob();
+  log('Fetched blob:', blob.size, 'bytes, type:', blob.type);
+
+  return blob;
+}
+
+/**
+ * Convert an audio blob to WAV format
+ *
+ * This uses the Web Audio API to decode the audio and re-encode it as WAV.
+ *
+ * @param blob - The source audio blob (WebM, OGG, etc.)
+ * @param quality - Quality settings for the output
+ * @returns A Promise resolving to a WAV blob
+ *
+ * @example
+ * ```typescript
+ * const wavBlob = await convertToWav(webmBlob);
+ * downloadAudio(wavBlob, 'recording.wav');
+ * ```
+ */
+export async function convertToWav(
+  blob: Blob,
+  quality: ExportQuality = {}
+): Promise<Blob> {
+  const {
+    sampleRate = DEFAULT_SAMPLE_RATE,
+    channels = DEFAULT_CHANNELS,
+    bitDepth = DEFAULT_BIT_DEPTH,
+  } = quality;
+
+  log('Converting to WAV:', {
+    inputSize: blob.size,
+    inputType: blob.type,
+    sampleRate,
+    channels,
+    bitDepth,
+  });
+
+  if (!isWavConversionSupported()) {
+    throw new Error('WAV conversion is not supported in this browser');
+  }
+
+  // Get the array buffer from the blob
+  const arrayBuffer = await blob.arrayBuffer();
+
+  // Create an audio context for decoding
+  const audioContext = new AudioContext({ sampleRate });
+
+  try {
+    // Decode the audio data
+    log('Decoding audio data...');
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+
+    log('Decoded audio:', {
+      duration: audioBuffer.duration,
+      numberOfChannels: audioBuffer.numberOfChannels,
+      sampleRate: audioBuffer.sampleRate,
+      length: audioBuffer.length,
+    });
+
+    // Create an offline context for rendering
+    const offlineContext = new OfflineAudioContext(
+      channels,
+      Math.ceil(audioBuffer.duration * sampleRate),
+      sampleRate
+    );
+
+    // Create a buffer source
+    const source = offlineContext.createBufferSource();
+    source.buffer = audioBuffer;
+    source.connect(offlineContext.destination);
+    source.start(0);
+
+    // Render the audio
+    log('Rendering audio...');
+    const renderedBuffer = await offlineContext.startRendering();
+
+    // Encode as WAV
+    log('Encoding as WAV...');
+    const wavBlob = encodeWav(renderedBuffer, bitDepth);
+
+    log('WAV conversion complete:', wavBlob.size, 'bytes');
+    return wavBlob;
+  } finally {
+    // Clean up the audio context
+    await audioContext.close();
+  }
+}
+
+/**
+ * Encode an AudioBuffer as a WAV file
+ */
+function encodeWav(audioBuffer: AudioBuffer, bitDepth: number = 16): Blob {
+  const numChannels = audioBuffer.numberOfChannels;
+  const sampleRate = audioBuffer.sampleRate;
+  const bytesPerSample = bitDepth / 8;
+  const blockAlign = numChannels * bytesPerSample;
+
+  // Interleave the channel data
+  const channelData: Float32Array[] = [];
+  for (let i = 0; i < numChannels; i++) {
+    channelData.push(audioBuffer.getChannelData(i));
+  }
+
+  const length = channelData[0].length;
+  const dataLength = length * blockAlign;
+
+  // Create the WAV file buffer
+  const buffer = new ArrayBuffer(44 + dataLength);
+  const view = new DataView(buffer);
+
+  // Write RIFF header
+  writeString(view, 0, 'RIFF');
+  view.setUint32(4, 36 + dataLength, true);
+  writeString(view, 8, 'WAVE');
+
+  // Write fmt chunk
+  writeString(view, 12, 'fmt ');
+  view.setUint32(16, 16, true); // fmt chunk size
+  view.setUint16(20, 1, true); // PCM format
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * blockAlign, true); // byte rate
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bitDepth, true);
+
+  // Write data chunk
+  writeString(view, 36, 'data');
+  view.setUint32(40, dataLength, true);
+
+  // Write audio samples
+  let offset = 44;
+  for (let i = 0; i < length; i++) {
+    for (let channel = 0; channel < numChannels; channel++) {
+      const sample = Math.max(-1, Math.min(1, channelData[channel][i]));
+      writeSample(view, offset, sample, bitDepth);
+      offset += bytesPerSample;
+    }
+  }
+
+  return new Blob([buffer], { type: 'audio/wav' });
+}
+
+/**
+ * Write a string to a DataView
+ */
+function writeString(view: DataView, offset: number, string: string): void {
+  for (let i = 0; i < string.length; i++) {
+    view.setUint8(offset + i, string.charCodeAt(i));
+  }
+}
+
+/**
+ * Write a sample to a DataView based on bit depth
+ */
+function writeSample(
+  view: DataView,
+  offset: number,
+  sample: number,
+  bitDepth: number
+): void {
+  switch (bitDepth) {
+    case 8:
+      // 8-bit is unsigned
+      view.setUint8(offset, Math.round((sample + 1) * 127.5));
+      break;
+    case 16:
+      view.setInt16(offset, Math.round(sample * 32767), true);
+      break;
+    case 24: {
+      // 24-bit requires manual byte writing
+      const val24 = Math.round(sample * 8388607);
+      view.setUint8(offset, val24 & 0xff);
+      view.setUint8(offset + 1, (val24 >> 8) & 0xff);
+      view.setUint8(offset + 2, (val24 >> 16) & 0xff);
+      break;
+    }
+    case 32:
+      view.setInt32(offset, Math.round(sample * 2147483647), true);
+      break;
+  }
+}
+
+/**
+ * Combine a recording audio track with a melody audio track
+ *
+ * This mixes both tracks together into a single audio file.
+ *
+ * @param recordingBlob - The vocal recording blob
+ * @param melodyBlob - The melody/accompaniment blob
+ * @param options - Combine options (volumes, format, quality)
+ * @returns A Promise resolving to the combined audio blob
+ *
+ * @example
+ * ```typescript
+ * const combined = await combineAudioTracks(vocalBlob, melodyBlob, {
+ *   recordingVolume: 1.0,
+ *   melodyVolume: 0.5,
+ * });
+ * ```
+ */
+export async function combineAudioTracks(
+  recordingBlob: Blob,
+  melodyBlob: Blob,
+  options: CombineOptions = {}
+): Promise<Blob> {
+  const {
+    recordingVolume = 1.0,
+    melodyVolume = 0.5,
+    format = 'wav',
+    quality = {},
+  } = options;
+
+  const { sampleRate = DEFAULT_SAMPLE_RATE, channels = DEFAULT_CHANNELS } =
+    quality;
+
+  log('Combining audio tracks:', {
+    recordingSize: recordingBlob.size,
+    melodySize: melodyBlob.size,
+    recordingVolume,
+    melodyVolume,
+  });
+
+  if (!isWavConversionSupported()) {
+    throw new Error('Audio combining is not supported in this browser');
+  }
+
+  // Get array buffers from both blobs
+  const [recordingBuffer, melodyBuffer] = await Promise.all([
+    recordingBlob.arrayBuffer(),
+    melodyBlob.arrayBuffer(),
+  ]);
+
+  // Create an audio context for decoding
+  const audioContext = new AudioContext({ sampleRate });
+
+  try {
+    // Decode both audio files
+    log('Decoding audio files...');
+    const [recordingAudio, melodyAudio] = await Promise.all([
+      audioContext.decodeAudioData(recordingBuffer),
+      audioContext.decodeAudioData(melodyBuffer),
+    ]);
+
+    log('Decoded:', {
+      recording: {
+        duration: recordingAudio.duration,
+        channels: recordingAudio.numberOfChannels,
+      },
+      melody: {
+        duration: melodyAudio.duration,
+        channels: melodyAudio.numberOfChannels,
+      },
+    });
+
+    // Determine output duration (use the longer of the two)
+    const duration = Math.max(recordingAudio.duration, melodyAudio.duration);
+    const length = Math.ceil(duration * sampleRate);
+
+    // Create an offline context for rendering
+    const offlineContext = new OfflineAudioContext(channels, length, sampleRate);
+
+    // Create gain nodes for volume control
+    const recordingGain = offlineContext.createGain();
+    recordingGain.gain.value = recordingVolume;
+
+    const melodyGain = offlineContext.createGain();
+    melodyGain.gain.value = melodyVolume;
+
+    // Create buffer sources
+    const recordingSource = offlineContext.createBufferSource();
+    recordingSource.buffer = recordingAudio;
+    recordingSource.connect(recordingGain);
+    recordingGain.connect(offlineContext.destination);
+
+    const melodySource = offlineContext.createBufferSource();
+    melodySource.buffer = melodyAudio;
+    melodySource.connect(melodyGain);
+    melodyGain.connect(offlineContext.destination);
+
+    // Start both sources
+    recordingSource.start(0);
+    melodySource.start(0);
+
+    // Render the combined audio
+    log('Rendering combined audio...');
+    const renderedBuffer = await offlineContext.startRendering();
+
+    // Encode to the requested format
+    let outputBlob: Blob;
+    if (format === 'wav') {
+      outputBlob = encodeWav(renderedBuffer, quality.bitDepth ?? DEFAULT_BIT_DEPTH);
+    } else {
+      // For WebM, we need to use MediaRecorder (more complex)
+      // For now, return WAV and let the caller handle format conversion if needed
+      log('WebM output requested but not directly supported for combined audio, outputting WAV');
+      outputBlob = encodeWav(renderedBuffer, quality.bitDepth ?? DEFAULT_BIT_DEPTH);
+    }
+
+    log('Audio combining complete:', outputBlob.size, 'bytes');
+    return outputBlob;
+  } finally {
+    // Clean up the audio context
+    await audioContext.close();
+  }
+}
+
+// =============================================================================
+// High-Level Export Functions
+// =============================================================================
+
+/**
+ * Export a recording take with the specified options
+ *
+ * @param blobUrl - The blob URL of the recording
+ * @param options - Export options
+ * @returns The export result
+ *
+ * @example
+ * ```typescript
+ * const result = await exportRecording(take.blobUrl, {
+ *   format: 'wav',
+ *   filename: 'my-recording',
+ * });
+ * downloadAudio(result.blob, result.filename);
+ * ```
+ */
+export async function exportRecording(
+  blobUrl: string,
+  options: ExportOptions = {}
+): Promise<ExportResult> {
+  const { format = 'webm', quality = {}, filename } = options;
+
+  log('Exporting recording:', { blobUrl: blobUrl.slice(0, 50), format });
+
+  // Fetch the blob from the URL
+  const sourceBlob = await fetchBlobFromUrl(blobUrl);
+
+  let outputBlob: Blob;
+
+  if (format === 'wav') {
+    outputBlob = await convertToWav(sourceBlob, quality);
+  } else {
+    // WebM - use as-is
+    outputBlob = sourceBlob;
+  }
+
+  const outputFilename = filename
+    ? `${sanitizeFilename(filename)}${FILE_EXTENSIONS[format]}`
+    : `recording-${Date.now()}${FILE_EXTENSIONS[format]}`;
+
+  return {
+    blob: outputBlob,
+    filename: outputFilename,
+    mimeType: MIME_TYPES[format],
+    size: outputBlob.size,
+  };
+}
+
+/**
+ * Export and download a recording in one step
+ *
+ * @param blobUrl - The blob URL of the recording
+ * @param poemTitle - Optional poem title for the filename
+ * @param options - Export options
+ *
+ * @example
+ * ```typescript
+ * await exportAndDownload(take.blobUrl, 'My Poem', { format: 'wav' });
+ * ```
+ */
+export async function exportAndDownload(
+  blobUrl: string,
+  poemTitle?: string,
+  options: ExportOptions = {}
+): Promise<ExportResult> {
+  const format = options.format ?? 'webm';
+  const filename =
+    options.filename ?? generateFilename(poemTitle, format, undefined);
+
+  log('Export and download:', { poemTitle, format, filename });
+
+  const result = await exportRecording(blobUrl, {
+    ...options,
+    format,
+    filename: filename.replace(/\.[^.]+$/, ''), // Remove extension since exportRecording adds it
+  });
+
+  downloadAudio(result.blob, result.filename);
+
+  return result;
+}
+
+/**
+ * Export a combined recording (vocals + melody)
+ *
+ * @param recordingBlobUrl - The blob URL of the vocal recording
+ * @param melodyBlobUrl - The blob URL of the melody
+ * @param poemTitle - Optional poem title for the filename
+ * @param options - Combine and export options
+ *
+ * @example
+ * ```typescript
+ * const result = await exportCombined(
+ *   take.blobUrl,
+ *   melodyBlobUrl,
+ *   'My Poem',
+ *   { recordingVolume: 1.0, melodyVolume: 0.5 }
+ * );
+ * ```
+ */
+export async function exportCombined(
+  recordingBlobUrl: string,
+  melodyBlobUrl: string,
+  poemTitle?: string,
+  options: CombineOptions = {}
+): Promise<ExportResult> {
+  const format = options.format ?? 'wav';
+
+  log('Exporting combined audio:', { poemTitle, format });
+
+  // Fetch both blobs
+  const [recordingBlob, melodyBlob] = await Promise.all([
+    fetchBlobFromUrl(recordingBlobUrl),
+    fetchBlobFromUrl(melodyBlobUrl),
+  ]);
+
+  // Combine the tracks
+  const combinedBlob = await combineAudioTracks(recordingBlob, melodyBlob, options);
+
+  const filename = generateFilename(poemTitle, format, undefined).replace(
+    /(\.[^.]+)$/,
+    '-combined$1'
+  );
+
+  return {
+    blob: combinedBlob,
+    filename,
+    mimeType: MIME_TYPES[format],
+    size: combinedBlob.size,
+  };
+}
+
+/**
+ * Export and download combined audio in one step
+ */
+export async function exportCombinedAndDownload(
+  recordingBlobUrl: string,
+  melodyBlobUrl: string,
+  poemTitle?: string,
+  options: CombineOptions = {}
+): Promise<ExportResult> {
+  const result = await exportCombined(
+    recordingBlobUrl,
+    melodyBlobUrl,
+    poemTitle,
+    options
+  );
+
+  downloadAudio(result.blob, result.filename);
+
+  return result;
+}
+
+// =============================================================================
+// Format Information
+// =============================================================================
+
+/**
+ * Get information about an export format
+ */
+export function getFormatInfo(format: ExportFormat): {
+  name: string;
+  mimeType: string;
+  extension: string;
+  description: string;
+  isSupported: boolean;
+} {
+  const formatInfo = {
+    webm: {
+      name: 'WebM',
+      mimeType: MIME_TYPES.webm,
+      extension: FILE_EXTENSIONS.webm,
+      description: 'Web-optimized audio format, widely supported in browsers',
+      isSupported: true,
+    },
+    wav: {
+      name: 'WAV',
+      mimeType: MIME_TYPES.wav,
+      extension: FILE_EXTENSIONS.wav,
+      description: 'Uncompressed audio format, high quality',
+      isSupported: isWavConversionSupported(),
+    },
+  };
+
+  return formatInfo[format];
+}
+
+/**
+ * Get all format info
+ */
+export function getAllFormatsInfo(): ReturnType<typeof getFormatInfo>[] {
+  return (['webm', 'wav'] as ExportFormat[]).map(getFormatInfo);
+}
+
+// =============================================================================
+// Default Export
+// =============================================================================
+
+export default {
+  downloadAudio,
+  convertToWav,
+  combineAudioTracks,
+  exportRecording,
+  exportAndDownload,
+  exportCombined,
+  exportCombinedAndDownload,
+  fetchBlobFromUrl,
+  generateFilename,
+  sanitizeFilename,
+  getSupportedFormats,
+  isWavConversionSupported,
+  getFormatInfo,
+  getAllFormatsInfo,
+};

--- a/web/src/lib/audio/index.ts
+++ b/web/src/lib/audio/index.ts
@@ -1,7 +1,7 @@
 /**
  * Audio Module
  *
- * Re-exports microphone access, audio analysis, and recording utilities.
+ * Re-exports microphone access, audio analysis, recording, and export utilities.
  *
  * @module lib/audio
  */
@@ -11,3 +11,6 @@ export { default as microphone } from './microphone';
 
 export * from './recorder';
 export { default as recorder } from './recorder';
+
+export * from './export';
+export { default as audioExport } from './export';


### PR DESCRIPTION
## Summary
- Implement complete audio export functionality with format selection and download capability
- Support WebM (native) and WAV (converted via Web Audio API) formats
- Enable combined export with recording + melody audio mixing
- Build intuitive ExportButton and ExportDialog components

## Changes
- `web/src/lib/audio/export.ts` - Core export functions:
  - `downloadAudio()` - Browser download trigger
  - `convertToWav()` - WebM to WAV conversion using Web Audio API
  - `combineAudioTracks()` - Mix recording + melody with volume control
  - `exportRecording()`, `exportAndDownload()` - High-level export workflows
  - Format info helpers and filename utilities
- `web/src/lib/audio/export.test.ts` - Comprehensive unit tests
- `web/src/components/Recording/ExportButton.tsx` - Download button with format dropdown
- `web/src/components/Recording/ExportButton.test.tsx` - Button tests
- `web/src/components/Recording/ExportDialog.tsx` - Full-featured export modal with:
  - Export mode selection (single/combined)
  - Format selection with quality options
  - Volume controls for combined export
  - Custom filename input
  - File size estimation
- `web/src/components/Recording/ExportDialog.test.tsx` - Dialog tests
- `web/src/components/Recording/index.ts` - Component exports
- `web/src/lib/audio/index.ts` - Module exports

## Testing
- [x] Unit tests pass (`npm test`) - 3787 tests passing
- [x] Check passes (`npm run check`)
- [ ] Manual testing performed

## Notes
- WAV conversion requires AudioContext and OfflineAudioContext browser support
- Combined export currently outputs WAV format (WebM mixing not directly supported)
- Components are ready to be integrated with RecordingStore and TakeItem

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)