### PR TITLE
feat(GH-62): Implement MIDI file export from ABC notation

### DIFF
--- a/web/src/lib/music/index.ts
+++ b/web/src/lib/music/index.ts
@@ -1,8 +1,9 @@
 /**
  * Music rendering and playback module
  *
- * Provides ABC notation rendering to SVG and MIDI synthesis playback
- * using the abcjs library.
+ * Provides ABC notation rendering to SVG, MIDI synthesis playback,
+ * and MIDI file export using the abcjs library.
  */
 
 export * from './abcRenderer';
+export * from './midiExport';

--- a/web/src/lib/music/midiExport.test.ts
+++ b/web/src/lib/music/midiExport.test.ts
@@ -1,0 +1,571 @@
+/**
+ * Tests for MIDI Export Module
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  generateMidiFile,
+  generateMidiFromTune,
+  downloadMidi,
+  exportAndDownloadMidi,
+  isMidiExportSupported,
+  getAvailableInstruments,
+  getMidiFormatInfo,
+  resolveInstrument,
+  validateTempo,
+  extractTitleFromAbc,
+  sanitizeFilename,
+  generateMidiFilename,
+  MIDI_INSTRUMENTS,
+  type MidiExportOptions,
+  type MidiExportResult,
+} from './midiExport';
+
+// Mock abcjs module
+const mockGetMidiFile = vi.fn();
+
+vi.mock('abcjs', () => ({
+  default: {
+    renderAbc: vi.fn(() => [{ tuneNumber: 0 }]),
+    synth: {
+      getMidiFile: (...args: unknown[]) => mockGetMidiFile(...args),
+    },
+  },
+}));
+
+// Mock URL.createObjectURL and URL.revokeObjectURL
+const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
+const mockRevokeObjectURL = vi.fn();
+vi.stubGlobal('URL', {
+  createObjectURL: mockCreateObjectURL,
+  revokeObjectURL: mockRevokeObjectURL,
+});
+
+describe('MIDI Export Module', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default mock returns a Blob
+    mockGetMidiFile.mockReturnValue(new Blob(['MThd...'], { type: 'audio/midi' }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('resolveInstrument', () => {
+    it('returns default piano for undefined', () => {
+      expect(resolveInstrument(undefined)).toBe(0);
+    });
+
+    it('resolves instrument names to MIDI program numbers', () => {
+      expect(resolveInstrument('piano')).toBe(0);
+      expect(resolveInstrument('flute')).toBe(73);
+      expect(resolveInstrument('violin')).toBe(40);
+      expect(resolveInstrument('acousticGuitar')).toBe(24);
+    });
+
+    it('returns direct MIDI program numbers', () => {
+      expect(resolveInstrument(0)).toBe(0);
+      expect(resolveInstrument(73)).toBe(73);
+      expect(resolveInstrument(127)).toBe(127);
+    });
+
+    it('clamps invalid MIDI program numbers', () => {
+      expect(resolveInstrument(-1)).toBe(0);
+      expect(resolveInstrument(128)).toBe(0);
+      expect(resolveInstrument(256)).toBe(0);
+    });
+
+    it('returns default for unknown instrument names', () => {
+      // @ts-expect-error - testing invalid input
+      expect(resolveInstrument('unknown')).toBe(0);
+    });
+  });
+
+  describe('validateTempo', () => {
+    it('returns undefined for undefined input', () => {
+      expect(validateTempo(undefined)).toBeUndefined();
+    });
+
+    it('returns valid tempo values unchanged', () => {
+      expect(validateTempo(120)).toBe(120);
+      expect(validateTempo(60)).toBe(60);
+      expect(validateTempo(180)).toBe(180);
+    });
+
+    it('clamps tempo below minimum to 20', () => {
+      expect(validateTempo(10)).toBe(20);
+      expect(validateTempo(0)).toBe(20);
+      expect(validateTempo(-50)).toBe(20);
+    });
+
+    it('clamps tempo above maximum to 300', () => {
+      expect(validateTempo(400)).toBe(300);
+      expect(validateTempo(1000)).toBe(300);
+    });
+
+    it('rounds fractional tempos', () => {
+      expect(validateTempo(120.5)).toBe(121);
+      expect(validateTempo(99.4)).toBe(99);
+    });
+  });
+
+  describe('extractTitleFromAbc', () => {
+    it('extracts title from ABC notation', () => {
+      const abc = 'X:1\nT:My Melody\nM:4/4\nK:C\nCDEF|';
+      expect(extractTitleFromAbc(abc)).toBe('My Melody');
+    });
+
+    it('handles title with leading/trailing whitespace', () => {
+      const abc = 'X:1\nT:  Spaced Title  \nK:C\nCDEF|';
+      expect(extractTitleFromAbc(abc)).toBe('Spaced Title');
+    });
+
+    it('returns undefined for ABC without title', () => {
+      const abc = 'X:1\nM:4/4\nK:C\nCDEF|';
+      expect(extractTitleFromAbc(abc)).toBeUndefined();
+    });
+
+    it('returns first title when multiple present', () => {
+      const abc = 'X:1\nT:First Title\nT:Second Title\nK:C\nCDEF|';
+      expect(extractTitleFromAbc(abc)).toBe('First Title');
+    });
+  });
+
+  describe('sanitizeFilename', () => {
+    it('removes forbidden characters', () => {
+      expect(sanitizeFilename('song<>:"/\\|?*.mid')).toBe('song.mid');
+    });
+
+    it('replaces spaces with hyphens', () => {
+      expect(sanitizeFilename('my cool song')).toBe('my-cool-song');
+    });
+
+    it('collapses multiple hyphens', () => {
+      expect(sanitizeFilename('song---name')).toBe('song-name');
+    });
+
+    it('removes leading/trailing hyphens', () => {
+      expect(sanitizeFilename('-song-name-')).toBe('song-name');
+    });
+
+    it('truncates long filenames', () => {
+      const longName = 'a'.repeat(150);
+      expect(sanitizeFilename(longName).length).toBe(100);
+    });
+  });
+
+  describe('generateMidiFilename', () => {
+    it('uses custom filename when provided', () => {
+      const abc = 'X:1\nT:Original Title\nK:C\nCDEF|';
+      expect(generateMidiFilename(abc, 'custom-name')).toBe('custom-name.mid');
+    });
+
+    it('adds .mid extension if missing', () => {
+      const abc = 'X:1\nT:Test\nK:C\nCDEF|';
+      expect(generateMidiFilename(abc, 'song')).toBe('song.mid');
+    });
+
+    it('does not double .mid extension', () => {
+      const abc = 'X:1\nT:Test\nK:C\nCDEF|';
+      expect(generateMidiFilename(abc, 'song.mid')).toBe('song.mid');
+    });
+
+    it('uses ABC title when no custom filename', () => {
+      const abc = 'X:1\nT:My Song\nK:C\nCDEF|';
+      expect(generateMidiFilename(abc)).toBe('My-Song.mid');
+    });
+
+    it('generates timestamp filename when no title available', () => {
+      const abc = 'X:1\nK:C\nCDEF|';
+      const filename = generateMidiFilename(abc);
+      expect(filename).toMatch(/^melody-\d+\.mid$/);
+    });
+  });
+
+  describe('generateMidiFile', () => {
+    const validAbc = `X:1
+T:Test Melody
+M:4/4
+L:1/8
+Q:1/4=120
+K:C
+CDEF GABc|`;
+
+    it('generates MIDI file from ABC notation', async () => {
+      const result = await generateMidiFile(validAbc);
+
+      expect(result).toBeDefined();
+      expect(result.blob).toBeInstanceOf(Blob);
+      expect(result.filename).toBe('Test-Melody.mid');
+      expect(result.mimeType).toBe('audio/midi');
+      expect(result.size).toBeGreaterThan(0);
+    });
+
+    it('throws error for empty ABC notation', async () => {
+      await expect(generateMidiFile('')).rejects.toThrow('ABC notation is required');
+      await expect(generateMidiFile('   ')).rejects.toThrow('ABC notation is required');
+    });
+
+    it('passes tempo option to abcjs', async () => {
+      await generateMidiFile(validAbc, { tempo: 140 });
+
+      expect(mockGetMidiFile).toHaveBeenCalledWith(
+        validAbc,
+        expect.objectContaining({ bpm: 140 })
+      );
+    });
+
+    it('passes instrument option to abcjs', async () => {
+      await generateMidiFile(validAbc, { instrument: 'flute' });
+
+      expect(mockGetMidiFile).toHaveBeenCalledWith(
+        validAbc,
+        expect.objectContaining({ program: 73 })
+      );
+    });
+
+    it('passes click track option to abcjs', async () => {
+      await generateMidiFile(validAbc, { includeClickTrack: true });
+
+      expect(mockGetMidiFile).toHaveBeenCalledWith(
+        validAbc,
+        expect.objectContaining({
+          drumOn: true,
+          drumIntro: 0,
+          drumBars: 1000,
+        })
+      );
+    });
+
+    it('uses custom filename when provided', async () => {
+      const result = await generateMidiFile(validAbc, { filename: 'custom-song' });
+
+      expect(result.filename).toBe('custom-song.mid');
+    });
+
+    it('sets chordsOff to true by default', async () => {
+      await generateMidiFile(validAbc);
+
+      expect(mockGetMidiFile).toHaveBeenCalledWith(
+        validAbc,
+        expect.objectContaining({ chordsOff: true })
+      );
+    });
+
+    it('allows chordsOff to be disabled', async () => {
+      await generateMidiFile(validAbc, { chordsOff: false });
+
+      expect(mockGetMidiFile).toHaveBeenCalledWith(
+        validAbc,
+        expect.objectContaining({ chordsOff: false })
+      );
+    });
+
+    it('handles ArrayBuffer result from abcjs', async () => {
+      const arrayBuffer = new ArrayBuffer(10);
+      mockGetMidiFile.mockReturnValue(arrayBuffer);
+
+      const result = await generateMidiFile(validAbc);
+
+      expect(result.blob).toBeInstanceOf(Blob);
+    });
+
+    it('handles encoded string result from abcjs', async () => {
+      mockGetMidiFile.mockReturnValue('%4D%54%68%64'); // 'MThd' encoded
+
+      const result = await generateMidiFile(validAbc);
+
+      expect(result.blob).toBeInstanceOf(Blob);
+    });
+
+    it('handles object with data property', async () => {
+      mockGetMidiFile.mockReturnValue({ data: new Blob(['test']) });
+
+      const result = await generateMidiFile(validAbc);
+
+      expect(result.blob).toBeInstanceOf(Blob);
+    });
+
+    it('throws error when abcjs synth is unavailable', async () => {
+      // Temporarily override the mock
+      const originalMock = mockGetMidiFile;
+      mockGetMidiFile.mockImplementation(() => {
+        throw new Error('synth not available');
+      });
+
+      await expect(generateMidiFile(validAbc)).rejects.toThrow('Failed to generate MIDI file');
+
+      mockGetMidiFile.mockImplementation(originalMock);
+    });
+  });
+
+  describe('generateMidiFromTune', () => {
+    const mockTuneObject = {
+      tuneNumber: 0,
+      metaText: { title: 'Tune Title' },
+    };
+
+    it('generates MIDI from tune object', async () => {
+      // @ts-expect-error - mock tune object
+      const result = await generateMidiFromTune(mockTuneObject);
+
+      expect(result).toBeDefined();
+      expect(result.blob).toBeInstanceOf(Blob);
+      expect(result.mimeType).toBe('audio/midi');
+    });
+
+    it('uses tune title for filename', async () => {
+      // @ts-expect-error - mock tune object
+      const result = await generateMidiFromTune(mockTuneObject);
+
+      expect(result.filename).toBe('Tune-Title.mid');
+    });
+
+    it('uses custom filename when provided', async () => {
+      // @ts-expect-error - mock tune object
+      const result = await generateMidiFromTune(mockTuneObject, {
+        filename: 'my-tune',
+      });
+
+      expect(result.filename).toBe('my-tune.mid');
+    });
+
+    it('generates timestamp filename when no title', async () => {
+      const tuneWithoutTitle = { tuneNumber: 0 };
+
+      // @ts-expect-error - mock tune object
+      const result = await generateMidiFromTune(tuneWithoutTitle);
+
+      expect(result.filename).toMatch(/^melody-\d+\.mid$/);
+    });
+  });
+
+  describe('downloadMidi', () => {
+    let appendChildSpy: ReturnType<typeof vi.spyOn>;
+    let removeChildSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+      removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node);
+    });
+
+    afterEach(() => {
+      appendChildSpy.mockRestore();
+      removeChildSpy.mockRestore();
+    });
+
+    it('creates download link and triggers click', () => {
+      const blob = new Blob(['test'], { type: 'audio/midi' });
+
+      downloadMidi(blob, 'test.mid');
+
+      expect(mockCreateObjectURL).toHaveBeenCalledWith(blob);
+      expect(appendChildSpy).toHaveBeenCalled();
+      // Link was clicked (we can verify appendChild was called with an anchor)
+      expect(removeChildSpy).toHaveBeenCalled();
+    });
+
+    it('revokes object URL after timeout', () => {
+      vi.useFakeTimers();
+
+      const blob = new Blob(['test'], { type: 'audio/midi' });
+      downloadMidi(blob, 'test.mid');
+
+      expect(mockRevokeObjectURL).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('exportAndDownloadMidi', () => {
+    let appendChildSpy: ReturnType<typeof vi.spyOn>;
+    let removeChildSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+      removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node);
+    });
+
+    afterEach(() => {
+      appendChildSpy.mockRestore();
+      removeChildSpy.mockRestore();
+    });
+
+    it('generates and downloads MIDI in one step', async () => {
+      const abc = 'X:1\nT:Test\nK:C\nCDEF|';
+
+      const result = await exportAndDownloadMidi(abc, { filename: 'download-test' });
+
+      expect(result.blob).toBeInstanceOf(Blob);
+      expect(result.filename).toBe('download-test.mid');
+      expect(mockCreateObjectURL).toHaveBeenCalled();
+    });
+  });
+
+  describe('isMidiExportSupported', () => {
+    it('returns true when abcjs synth.getMidiFile is available', () => {
+      expect(isMidiExportSupported()).toBe(true);
+    });
+  });
+
+  describe('getAvailableInstruments', () => {
+    it('returns all instrument presets', () => {
+      const instruments = getAvailableInstruments();
+
+      expect(instruments.length).toBe(Object.keys(MIDI_INSTRUMENTS).length);
+
+      // Check structure
+      instruments.forEach((inst) => {
+        expect(inst).toHaveProperty('name');
+        expect(inst).toHaveProperty('program');
+        expect(inst).toHaveProperty('displayName');
+        expect(typeof inst.name).toBe('string');
+        expect(typeof inst.program).toBe('number');
+        expect(typeof inst.displayName).toBe('string');
+      });
+    });
+
+    it('includes piano as first instrument', () => {
+      const instruments = getAvailableInstruments();
+      const piano = instruments.find((i) => i.name === 'piano');
+
+      expect(piano).toBeDefined();
+      expect(piano?.program).toBe(0);
+      expect(piano?.displayName).toBe('Piano');
+    });
+
+    it('includes expected instruments', () => {
+      const instruments = getAvailableInstruments();
+      const names = instruments.map((i) => i.name);
+
+      expect(names).toContain('piano');
+      expect(names).toContain('flute');
+      expect(names).toContain('violin');
+      expect(names).toContain('acousticGuitar');
+    });
+  });
+
+  describe('getMidiFormatInfo', () => {
+    it('returns correct format information', () => {
+      const info = getMidiFormatInfo();
+
+      expect(info.name).toBe('MIDI');
+      expect(info.mimeType).toBe('audio/midi');
+      expect(info.extension).toBe('.mid');
+      expect(info.description).toContain('Standard MIDI File');
+      expect(typeof info.isSupported).toBe('boolean');
+    });
+  });
+
+  describe('MIDI_INSTRUMENTS constant', () => {
+    it('contains expected instruments', () => {
+      expect(MIDI_INSTRUMENTS.piano).toBe(0);
+      expect(MIDI_INSTRUMENTS.flute).toBe(73);
+      expect(MIDI_INSTRUMENTS.violin).toBe(40);
+      expect(MIDI_INSTRUMENTS.trumpet).toBe(56);
+    });
+
+    it('has all values in valid MIDI range', () => {
+      Object.values(MIDI_INSTRUMENTS).forEach((value) => {
+        expect(value).toBeGreaterThanOrEqual(0);
+        expect(value).toBeLessThanOrEqual(127);
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles ABC with special characters in title', async () => {
+      const abc = 'X:1\nT:Song: "The Best" - Part 1\nK:C\nCDEF|';
+
+      const result = await generateMidiFile(abc);
+
+      expect(result.filename).not.toContain(':');
+      expect(result.filename).not.toContain('"');
+    });
+
+    it('handles very long ABC notation', async () => {
+      const measures = Array(100).fill('CDEF|').join('');
+      const abc = `X:1\nT:Long Melody\nM:4/4\nK:C\n${measures}`;
+
+      const result = await generateMidiFile(abc);
+
+      expect(result.blob).toBeInstanceOf(Blob);
+    });
+
+    it('handles ABC with lyrics', async () => {
+      const abc = `X:1
+T:Song with Lyrics
+M:4/4
+K:C
+CDEF|
+w:One two three four`;
+
+      const result = await generateMidiFile(abc);
+
+      expect(result.blob).toBeInstanceOf(Blob);
+    });
+
+    it('handles extreme tempo values', async () => {
+      const abc = 'X:1\nT:Test\nK:C\nCDEF|';
+
+      // Very low tempo
+      await generateMidiFile(abc, { tempo: 1 });
+      expect(mockGetMidiFile).toHaveBeenCalledWith(
+        abc,
+        expect.objectContaining({ bpm: 20 })
+      );
+
+      mockGetMidiFile.mockClear();
+
+      // Very high tempo
+      await generateMidiFile(abc, { tempo: 1000 });
+      expect(mockGetMidiFile).toHaveBeenCalledWith(
+        abc,
+        expect.objectContaining({ bpm: 300 })
+      );
+    });
+  });
+
+  describe('type safety', () => {
+    it('MidiExportOptions accepts all valid options', () => {
+      const options: MidiExportOptions = {
+        tempo: 120,
+        instrument: 'piano',
+        includeClickTrack: true,
+        filename: 'test',
+        chordsOff: false,
+        volume: 80,
+      };
+
+      expect(options).toBeDefined();
+    });
+
+    it('MidiExportResult has all required fields', () => {
+      const result: MidiExportResult = {
+        blob: new Blob(),
+        filename: 'test.mid',
+        mimeType: 'audio/midi',
+        size: 100,
+      };
+
+      expect(result).toBeDefined();
+    });
+
+    it('MidiExportResult accepts optional duration', () => {
+      const result: MidiExportResult = {
+        blob: new Blob(),
+        filename: 'test.mid',
+        mimeType: 'audio/midi',
+        size: 100,
+        duration: 30.5,
+      };
+
+      expect(result.duration).toBe(30.5);
+    });
+  });
+});

--- a/web/src/lib/music/midiExport.ts
+++ b/web/src/lib/music/midiExport.ts
@@ -1,0 +1,631 @@
+/**
+ * MIDI Export Module
+ *
+ * Generates downloadable MIDI files from ABC notation melodies.
+ * Uses abcjs MIDI generation capability for Standard MIDI File (SMF) output.
+ *
+ * @module midiExport
+ */
+
+import abcjs from 'abcjs';
+import type { TuneObject } from 'abcjs';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[midiExport] ${message}`, ...args);
+  }
+};
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * General MIDI instrument numbers (0-127)
+ * See: https://www.midi.org/specifications-old/item/gm-level-1-sound-set
+ */
+export type MidiInstrument =
+  | 0   // Acoustic Grand Piano
+  | 1   // Bright Acoustic Piano
+  | 4   // Electric Piano 1
+  | 5   // Electric Piano 2
+  | 24  // Acoustic Guitar (nylon)
+  | 25  // Acoustic Guitar (steel)
+  | 40  // Violin
+  | 41  // Viola
+  | 42  // Cello
+  | 56  // Trumpet
+  | 57  // Trombone
+  | 65  // Alto Sax
+  | 68  // Oboe
+  | 71  // Clarinet
+  | 73  // Flute
+  | 74  // Recorder
+  | number; // Allow any valid MIDI instrument (0-127)
+
+/**
+ * Standard MIDI instrument presets with friendly names
+ */
+export const MIDI_INSTRUMENTS = {
+  piano: 0,
+  brightPiano: 1,
+  electricPiano: 4,
+  acousticGuitar: 24,
+  steelGuitar: 25,
+  violin: 40,
+  viola: 41,
+  cello: 42,
+  trumpet: 56,
+  trombone: 57,
+  altoSax: 65,
+  oboe: 68,
+  clarinet: 71,
+  flute: 73,
+  recorder: 74,
+} as const;
+
+/**
+ * Instrument name type for presets
+ */
+export type InstrumentName = keyof typeof MIDI_INSTRUMENTS;
+
+/**
+ * Options for MIDI export
+ */
+export interface MidiExportOptions {
+  /**
+   * Tempo in beats per minute. If not specified, uses tempo from ABC notation.
+   * Range: 20-300 BPM
+   */
+  tempo?: number;
+
+  /**
+   * MIDI instrument to use (0-127 or preset name)
+   * Default: piano (0)
+   */
+  instrument?: MidiInstrument | InstrumentName;
+
+  /**
+   * Whether to include a click track (metronome) on channel 10
+   * Default: false
+   */
+  includeClickTrack?: boolean;
+
+  /**
+   * Custom filename for download (without .mid extension)
+   * Default: derived from ABC title or 'melody'
+   */
+  filename?: string;
+
+  /**
+   * Whether to disable chord symbols from generating sound
+   * Default: true (for clean single-track output)
+   */
+  chordsOff?: boolean;
+
+  /**
+   * Volume level for the melody (0-127)
+   * Default: 100
+   */
+  volume?: number;
+}
+
+/**
+ * Result of MIDI export operation
+ */
+export interface MidiExportResult {
+  /** The MIDI file as a Blob */
+  blob: Blob;
+  /** The filename with .mid extension */
+  filename: string;
+  /** MIME type */
+  mimeType: string;
+  /** File size in bytes */
+  size: number;
+  /** Duration in seconds (if available) */
+  duration?: number;
+}
+
+/**
+ * Options passed to abcjs getMidiFile
+ */
+interface AbcjsMidiOptions {
+  midiOutputType: 'binary' | 'encoded' | 'link';
+  bpm?: number;
+  chordsOff?: boolean;
+  program?: number;
+  drumOn?: boolean;
+  drumIntro?: number;
+  drumBars?: number;
+  channel?: number;
+  pan?: number[];
+  generateInline?: boolean;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const MIN_TEMPO = 20;
+const MAX_TEMPO = 300;
+const DEFAULT_INSTRUMENT = 0; // Piano
+const MIDI_MIME_TYPE = 'audio/midi';
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Resolves instrument to MIDI program number
+ */
+export function resolveInstrument(instrument: MidiInstrument | InstrumentName | undefined): number {
+  if (instrument === undefined) {
+    return DEFAULT_INSTRUMENT;
+  }
+
+  if (typeof instrument === 'string') {
+    const programNumber = MIDI_INSTRUMENTS[instrument];
+    if (programNumber === undefined) {
+      log(`Unknown instrument name: ${instrument}, using piano`);
+      return DEFAULT_INSTRUMENT;
+    }
+    return programNumber;
+  }
+
+  // Validate MIDI range
+  if (instrument < 0 || instrument > 127) {
+    log(`Invalid MIDI program number: ${instrument}, using piano`);
+    return DEFAULT_INSTRUMENT;
+  }
+
+  return instrument;
+}
+
+/**
+ * Validates and clamps tempo to valid range
+ */
+export function validateTempo(tempo: number | undefined): number | undefined {
+  if (tempo === undefined) {
+    return undefined;
+  }
+
+  if (tempo < MIN_TEMPO) {
+    log(`Tempo ${tempo} below minimum, clamping to ${MIN_TEMPO}`);
+    return MIN_TEMPO;
+  }
+
+  if (tempo > MAX_TEMPO) {
+    log(`Tempo ${tempo} above maximum, clamping to ${MAX_TEMPO}`);
+    return MAX_TEMPO;
+  }
+
+  return Math.round(tempo);
+}
+
+/**
+ * Extracts title from ABC notation string
+ */
+export function extractTitleFromAbc(abc: string): string | undefined {
+  const titleMatch = abc.match(/^T:\s*(.+)$/m);
+  if (titleMatch && titleMatch[1]) {
+    return titleMatch[1].trim();
+  }
+  return undefined;
+}
+
+/**
+ * Sanitizes a filename for safe download
+ */
+export function sanitizeFilename(filename: string): string {
+  return filename
+    .replace(/[<>:"/\\|?*]/g, '') // Remove Windows-forbidden characters
+    .replace(/\s+/g, '-') // Replace spaces with hyphens
+    .replace(/-+/g, '-') // Collapse multiple hyphens
+    .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
+    .trim()
+    .slice(0, 100); // Limit length
+}
+
+/**
+ * Generates a filename for MIDI export
+ */
+export function generateMidiFilename(abc: string, customFilename?: string): string {
+  if (customFilename) {
+    const sanitized = sanitizeFilename(customFilename);
+    return sanitized.endsWith('.mid') ? sanitized : `${sanitized}.mid`;
+  }
+
+  const title = extractTitleFromAbc(abc);
+  if (title) {
+    return `${sanitizeFilename(title)}.mid`;
+  }
+
+  return `melody-${Date.now()}.mid`;
+}
+
+// =============================================================================
+// Core Export Functions
+// =============================================================================
+
+/**
+ * Generate a MIDI file from ABC notation
+ *
+ * Uses abcjs MIDI generation to create a Standard MIDI File (SMF).
+ *
+ * @param abc - ABC notation string
+ * @param options - Export options (tempo, instrument, etc.)
+ * @returns Promise resolving to MidiExportResult
+ *
+ * @example
+ * ```typescript
+ * const abc = `X:1\nT:My Melody\nM:4/4\nL:1/8\nQ:1/4=120\nK:C\nCDEF GABc|`;
+ *
+ * const result = await generateMidiFile(abc, {
+ *   tempo: 140,
+ *   instrument: 'flute',
+ * });
+ *
+ * downloadMidi(result.blob, result.filename);
+ * ```
+ */
+export async function generateMidiFile(
+  abc: string,
+  options: MidiExportOptions = {}
+): Promise<MidiExportResult> {
+  log('generateMidiFile called with options:', options);
+
+  if (!abc || abc.trim().length === 0) {
+    throw new Error('ABC notation is required');
+  }
+
+  const {
+    tempo,
+    instrument,
+    includeClickTrack = false,
+    filename,
+    chordsOff = true,
+    // Note: volume is not currently supported by abcjs getMidiFile
+    // but kept in interface for future implementation
+  } = options;
+
+  // Build abcjs options
+  const midiOptions: AbcjsMidiOptions = {
+    midiOutputType: 'binary',
+    chordsOff,
+  };
+
+  // Add tempo if specified
+  const validatedTempo = validateTempo(tempo);
+  if (validatedTempo !== undefined) {
+    midiOptions.bpm = validatedTempo;
+  }
+
+  // Add instrument
+  const program = resolveInstrument(instrument);
+  if (program !== DEFAULT_INSTRUMENT) {
+    midiOptions.program = program;
+  }
+
+  // Add click track options
+  if (includeClickTrack) {
+    midiOptions.drumOn = true;
+    midiOptions.drumIntro = 0; // No intro measures
+    midiOptions.drumBars = 1000; // Play throughout (large number)
+  }
+
+  log('Generating MIDI with options:', midiOptions);
+
+  try {
+    // Access the synth module from abcjs
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const synthModule = (abcjs as any).synth;
+
+    if (!synthModule || typeof synthModule.getMidiFile !== 'function') {
+      throw new Error('abcjs MIDI generation not available');
+    }
+
+    // Generate the MIDI file
+    const midiResult = synthModule.getMidiFile(abc, midiOptions);
+
+    log('MIDI generation result type:', typeof midiResult);
+
+    // Handle different result types
+    let midiBlob: Blob;
+
+    if (midiResult instanceof Blob) {
+      midiBlob = midiResult;
+    } else if (midiResult instanceof ArrayBuffer) {
+      midiBlob = new Blob([midiResult], { type: MIDI_MIME_TYPE });
+    } else if (typeof midiResult === 'string') {
+      // Encoded string - convert to blob
+      const binaryString = decodeURIComponent(midiResult);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      midiBlob = new Blob([bytes], { type: MIDI_MIME_TYPE });
+    } else if (midiResult && typeof midiResult === 'object') {
+      // Could be an object with data property
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data = (midiResult as any).data || midiResult;
+      if (data instanceof Blob) {
+        midiBlob = data;
+      } else if (data instanceof ArrayBuffer) {
+        midiBlob = new Blob([data], { type: MIDI_MIME_TYPE });
+      } else if (Array.isArray(data)) {
+        midiBlob = new Blob([new Uint8Array(data)], { type: MIDI_MIME_TYPE });
+      } else {
+        throw new Error(`Unexpected MIDI result format: ${typeof data}`);
+      }
+    } else {
+      throw new Error(`Unexpected MIDI result format: ${typeof midiResult}`);
+    }
+
+    const exportFilename = generateMidiFilename(abc, filename);
+
+    log('MIDI file generated:', {
+      filename: exportFilename,
+      size: midiBlob.size,
+    });
+
+    return {
+      blob: midiBlob,
+      filename: exportFilename,
+      mimeType: MIDI_MIME_TYPE,
+      size: midiBlob.size,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    log('MIDI generation error:', errorMessage);
+    throw new Error(`Failed to generate MIDI file: ${errorMessage}`);
+  }
+}
+
+/**
+ * Generate MIDI file from a pre-rendered tune object
+ *
+ * Use this when you already have a TuneObject from renderAbc().
+ *
+ * @param tuneObject - The tune object from abcjs.renderAbc()
+ * @param options - Export options
+ * @returns Promise resolving to MidiExportResult
+ */
+export async function generateMidiFromTune(
+  tuneObject: TuneObject,
+  options: MidiExportOptions = {}
+): Promise<MidiExportResult> {
+  log('generateMidiFromTune called');
+
+  const {
+    tempo,
+    instrument,
+    includeClickTrack = false,
+    filename,
+    chordsOff = true,
+  } = options;
+
+  // Build abcjs options
+  const midiOptions: AbcjsMidiOptions = {
+    midiOutputType: 'binary',
+    chordsOff,
+  };
+
+  const validatedTempo = validateTempo(tempo);
+  if (validatedTempo !== undefined) {
+    midiOptions.bpm = validatedTempo;
+  }
+
+  const program = resolveInstrument(instrument);
+  if (program !== DEFAULT_INSTRUMENT) {
+    midiOptions.program = program;
+  }
+
+  if (includeClickTrack) {
+    midiOptions.drumOn = true;
+    midiOptions.drumIntro = 0;
+    midiOptions.drumBars = 1000;
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const synthModule = (abcjs as any).synth;
+
+    if (!synthModule || typeof synthModule.getMidiFile !== 'function') {
+      throw new Error('abcjs MIDI generation not available');
+    }
+
+    const midiResult = synthModule.getMidiFile(tuneObject, midiOptions);
+
+    let midiBlob: Blob;
+    if (midiResult instanceof Blob) {
+      midiBlob = midiResult;
+    } else if (midiResult instanceof ArrayBuffer) {
+      midiBlob = new Blob([midiResult], { type: MIDI_MIME_TYPE });
+    } else if (typeof midiResult === 'string') {
+      const binaryString = decodeURIComponent(midiResult);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      midiBlob = new Blob([bytes], { type: MIDI_MIME_TYPE });
+    } else {
+      throw new Error(`Unexpected MIDI result format: ${typeof midiResult}`);
+    }
+
+    // Try to extract title from tune object
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tuneTitle = (tuneObject as any).metaText?.title;
+    const exportFilename = filename
+      ? `${sanitizeFilename(filename)}.mid`
+      : tuneTitle
+        ? `${sanitizeFilename(tuneTitle)}.mid`
+        : `melody-${Date.now()}.mid`;
+
+    return {
+      blob: midiBlob,
+      filename: exportFilename,
+      mimeType: MIDI_MIME_TYPE,
+      size: midiBlob.size,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    log('MIDI generation from tune error:', errorMessage);
+    throw new Error(`Failed to generate MIDI file: ${errorMessage}`);
+  }
+}
+
+// =============================================================================
+// Download Functions
+// =============================================================================
+
+/**
+ * Download a MIDI blob as a file
+ *
+ * @param blob - The MIDI blob to download
+ * @param filename - The filename for the download
+ */
+export function downloadMidi(blob: Blob, filename: string): void {
+  log('Downloading MIDI:', filename, 'size:', blob.size);
+
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+
+    // Required for Firefox
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    log('Download initiated successfully');
+  } finally {
+    // Revoke URL after download starts
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+      log('Revoked download URL');
+    }, 1000);
+  }
+}
+
+/**
+ * Generate and download MIDI file in one step
+ *
+ * @param abc - ABC notation string
+ * @param options - Export options
+ * @returns Promise resolving to MidiExportResult
+ *
+ * @example
+ * ```typescript
+ * await exportAndDownloadMidi(abcNotation, {
+ *   tempo: 120,
+ *   instrument: 'piano',
+ *   filename: 'my-song',
+ * });
+ * ```
+ */
+export async function exportAndDownloadMidi(
+  abc: string,
+  options: MidiExportOptions = {}
+): Promise<MidiExportResult> {
+  const result = await generateMidiFile(abc, options);
+  downloadMidi(result.blob, result.filename);
+  return result;
+}
+
+// =============================================================================
+// Validation and Info Functions
+// =============================================================================
+
+/**
+ * Check if MIDI export is supported
+ *
+ * MIDI export requires abcjs synth module to be available.
+ */
+export function isMidiExportSupported(): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const synthModule = (abcjs as any).synth;
+    const supported = synthModule && typeof synthModule.getMidiFile === 'function';
+    log('MIDI export support check:', supported);
+    return supported;
+  } catch {
+    log('MIDI export support check failed');
+    return false;
+  }
+}
+
+/**
+ * Get information about available MIDI instruments
+ */
+export function getAvailableInstruments(): Array<{
+  name: InstrumentName;
+  program: number;
+  displayName: string;
+}> {
+  const displayNames: Record<InstrumentName, string> = {
+    piano: 'Piano',
+    brightPiano: 'Bright Piano',
+    electricPiano: 'Electric Piano',
+    acousticGuitar: 'Acoustic Guitar (Nylon)',
+    steelGuitar: 'Acoustic Guitar (Steel)',
+    violin: 'Violin',
+    viola: 'Viola',
+    cello: 'Cello',
+    trumpet: 'Trumpet',
+    trombone: 'Trombone',
+    altoSax: 'Alto Saxophone',
+    oboe: 'Oboe',
+    clarinet: 'Clarinet',
+    flute: 'Flute',
+    recorder: 'Recorder',
+  };
+
+  return (Object.keys(MIDI_INSTRUMENTS) as InstrumentName[]).map((name) => ({
+    name,
+    program: MIDI_INSTRUMENTS[name],
+    displayName: displayNames[name],
+  }));
+}
+
+/**
+ * Get MIDI export format info
+ */
+export function getMidiFormatInfo(): {
+  name: string;
+  mimeType: string;
+  extension: string;
+  description: string;
+  isSupported: boolean;
+} {
+  return {
+    name: 'MIDI',
+    mimeType: MIDI_MIME_TYPE,
+    extension: '.mid',
+    description: 'Standard MIDI File (SMF) - playable in any MIDI player',
+    isSupported: isMidiExportSupported(),
+  };
+}
+
+// =============================================================================
+// Default Export
+// =============================================================================
+
+export default {
+  generateMidiFile,
+  generateMidiFromTune,
+  downloadMidi,
+  exportAndDownloadMidi,
+  isMidiExportSupported,
+  getAvailableInstruments,
+  getMidiFormatInfo,
+  resolveInstrument,
+  validateTempo,
+  extractTitleFromAbc,
+  sanitizeFilename,
+  generateMidiFilename,
+  MIDI_INSTRUMENTS,
+};


### PR DESCRIPTION
## Summary
- Implement MIDI file export from ABC notation using abcjs MIDI generation capability
- Create downloadable Standard MIDI Files (SMF) playable in any MIDI player
- Support configurable tempo, instrument selection, and click track

## Changes
- `web/src/lib/music/midiExport.ts` - New MIDI export module with:
  - `generateMidiFile()` - Generate MIDI from ABC notation string
  - `generateMidiFromTune()` - Generate MIDI from pre-rendered TuneObject
  - `downloadMidi()` - Browser download helper
  - `exportAndDownloadMidi()` - One-step generate and download
  - `isMidiExportSupported()` - Feature detection
  - `getAvailableInstruments()` - List of 15 preset instruments
  - Support for configurable tempo (20-300 BPM)
  - Support for any General MIDI instrument (0-127)
  - Support for click track / metronome inclusion
  - Automatic filename generation from ABC title
- `web/src/lib/music/midiExport.test.ts` - Comprehensive test suite (57 tests)
- `web/src/lib/music/index.ts` - Export new module

## Testing
- [x] Unit tests pass (`npm test` - 57 new tests, 4099 total)
- [x] Check passes (`npm run check` - lint + typecheck)
- [x] Manual testing performed

## Notes
- Uses abcjs `synth.getMidiFile()` API for MIDI generation
- MIDI files are Standard MIDI Format (SMF), playable in VLC, GarageBand, Logic, etc.
- Volume option is included in interface but not currently supported by abcjs getMidiFile

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)