### PR TITLE
feat(GH-47): Implement ABC notation source view

### DIFF
--- a/web/src/components/Notation/ABCSourceView.css
+++ b/web/src/components/Notation/ABCSourceView.css
@@ -1,0 +1,432 @@
+/**
+ * ABCSourceView Component Styles
+ *
+ * CSS for ABC notation source view, syntax highlighting, and toolbar.
+ */
+
+/* Container */
+.abc-source-view {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 0.5rem;
+  background-color: var(--bg-primary, #ffffff);
+  overflow: hidden;
+}
+
+/* Toolbar */
+.abc-source-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--bg-secondary, #f9fafb);
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.abc-source-toolbar-left,
+.abc-source-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* View Toggle */
+.abc-view-toggle {
+  display: flex;
+  background-color: var(--bg-tertiary, #f3f4f6);
+  border-radius: 0.375rem;
+  padding: 0.125rem;
+}
+
+.abc-view-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: none;
+  border-radius: 0.25rem;
+  background-color: transparent;
+  color: var(--text-secondary, #6b7280);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.abc-view-toggle-btn:hover {
+  color: var(--text-primary, #1f2937);
+}
+
+.abc-view-toggle-btn.active {
+  background-color: var(--bg-primary, #ffffff);
+  color: var(--text-primary, #1f2937);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.abc-view-toggle-btn svg {
+  flex-shrink: 0;
+}
+
+/* Validation Status */
+.abc-validation-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 0.25rem;
+}
+
+.abc-validation-status.valid {
+  color: #059669;
+  background-color: #ecfdf5;
+}
+
+.abc-validation-status.invalid {
+  color: #dc2626;
+  background-color: #fef2f2;
+}
+
+/* Toolbar Buttons */
+.abc-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 0.375rem;
+  background-color: var(--bg-primary, #ffffff);
+  color: var(--text-secondary, #6b7280);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.abc-toolbar-btn:hover {
+  background-color: var(--bg-hover, #f3f4f6);
+  color: var(--text-primary, #1f2937);
+  border-color: var(--border-hover, #d1d5db);
+}
+
+.abc-toolbar-btn:active {
+  background-color: var(--bg-active, #e5e7eb);
+}
+
+.abc-toolbar-btn svg {
+  flex-shrink: 0;
+}
+
+/* Content Area */
+.abc-source-content {
+  flex: 1;
+  min-height: 200px;
+  overflow: auto;
+}
+
+/* Rendered View */
+.abc-rendered-view {
+  padding: 1rem;
+  min-height: 200px;
+}
+
+.abc-rendered-view svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Source Display (Read-only with syntax highlighting) */
+.abc-source-display {
+  padding: 0;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  background-color: var(--bg-code, #f8f9fa);
+  overflow: auto;
+}
+
+.abc-source-display:focus {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
+.abc-source-pre {
+  margin: 0;
+  padding: 1rem;
+}
+
+.abc-source-code {
+  display: block;
+}
+
+.abc-source-line {
+  display: flex;
+  white-space: pre;
+  min-height: 1.5em;
+}
+
+.abc-line-number {
+  flex-shrink: 0;
+  width: 3rem;
+  padding-right: 1rem;
+  text-align: right;
+  color: var(--text-muted, #9ca3af);
+  user-select: none;
+}
+
+.abc-line-content {
+  flex: 1;
+}
+
+.abc-empty-line {
+  opacity: 0;
+}
+
+/* Editable Source View */
+.abc-editable-source {
+  display: flex;
+  flex-direction: column;
+}
+
+.abc-source-textarea {
+  width: 100%;
+  min-height: 300px;
+  padding: 1rem;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border: none;
+  resize: vertical;
+  background-color: var(--bg-code, #f8f9fa);
+  color: var(--text-primary, #1f2937);
+}
+
+.abc-source-textarea:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent-primary, #3b82f6);
+}
+
+/* Validation Errors */
+.abc-validation-errors {
+  padding: 0.75rem 1rem;
+  background-color: var(--bg-error, #fef2f2);
+  border-top: 1px solid var(--border-error, #fecaca);
+}
+
+.abc-validation-error,
+.abc-validation-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  font-size: 0.8125rem;
+}
+
+.abc-validation-error {
+  color: #dc2626;
+}
+
+.abc-validation-warning {
+  color: #d97706;
+}
+
+.abc-validation-error svg,
+.abc-validation-warning svg {
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+/* Syntax Highlighting Tokens */
+.abc-token-field-key {
+  color: var(--syntax-field-key, #7c3aed);
+  font-weight: 600;
+}
+
+.abc-token-field-value {
+  color: var(--syntax-field-value, #0891b2);
+}
+
+.abc-token-note {
+  color: var(--syntax-note, #059669);
+  font-weight: 500;
+}
+
+.abc-token-rest {
+  color: var(--syntax-rest, #9ca3af);
+}
+
+.abc-token-bar {
+  color: var(--syntax-bar, #374151);
+  font-weight: 600;
+}
+
+.abc-token-chord {
+  color: var(--syntax-chord, #db2777);
+}
+
+.abc-token-lyric {
+  color: var(--syntax-lyric, #2563eb);
+  font-style: italic;
+}
+
+.abc-token-comment {
+  color: var(--syntax-comment, #6b7280);
+  font-style: italic;
+}
+
+.abc-token-decoration {
+  color: var(--syntax-decoration, #ea580c);
+}
+
+.abc-token-duration {
+  color: var(--syntax-duration, #0d9488);
+}
+
+.abc-token-accidental {
+  color: var(--syntax-accidental, #dc2626);
+}
+
+.abc-token-text {
+  color: var(--syntax-text, #374151);
+}
+
+.abc-token-header {
+  color: var(--syntax-header, #7c3aed);
+  font-weight: 600;
+}
+
+/* Dark Mode Support */
+@media (prefers-color-scheme: dark) {
+  .abc-source-view {
+    background-color: var(--bg-primary-dark, #1f2937);
+    border-color: var(--border-color-dark, #374151);
+  }
+
+  .abc-source-toolbar {
+    background-color: var(--bg-secondary-dark, #111827);
+    border-color: var(--border-color-dark, #374151);
+  }
+
+  .abc-view-toggle {
+    background-color: var(--bg-tertiary-dark, #1f2937);
+  }
+
+  .abc-view-toggle-btn {
+    color: var(--text-secondary-dark, #9ca3af);
+  }
+
+  .abc-view-toggle-btn:hover,
+  .abc-view-toggle-btn.active {
+    color: var(--text-primary-dark, #f9fafb);
+  }
+
+  .abc-view-toggle-btn.active {
+    background-color: var(--bg-primary-dark, #374151);
+  }
+
+  .abc-toolbar-btn {
+    background-color: var(--bg-primary-dark, #1f2937);
+    border-color: var(--border-color-dark, #374151);
+    color: var(--text-secondary-dark, #9ca3af);
+  }
+
+  .abc-toolbar-btn:hover {
+    background-color: var(--bg-hover-dark, #374151);
+    color: var(--text-primary-dark, #f9fafb);
+  }
+
+  .abc-source-display,
+  .abc-source-textarea {
+    background-color: var(--bg-code-dark, #111827);
+    color: var(--text-primary-dark, #f9fafb);
+  }
+
+  .abc-line-number {
+    color: var(--text-muted-dark, #6b7280);
+  }
+
+  /* Dark mode syntax highlighting */
+  .abc-token-field-key {
+    color: var(--syntax-field-key-dark, #a78bfa);
+  }
+
+  .abc-token-field-value {
+    color: var(--syntax-field-value-dark, #22d3ee);
+  }
+
+  .abc-token-note {
+    color: var(--syntax-note-dark, #34d399);
+  }
+
+  .abc-token-rest {
+    color: var(--syntax-rest-dark, #6b7280);
+  }
+
+  .abc-token-bar {
+    color: var(--syntax-bar-dark, #d1d5db);
+  }
+
+  .abc-token-chord {
+    color: var(--syntax-chord-dark, #f472b6);
+  }
+
+  .abc-token-lyric {
+    color: var(--syntax-lyric-dark, #60a5fa);
+  }
+
+  .abc-token-comment {
+    color: var(--syntax-comment-dark, #9ca3af);
+  }
+
+  .abc-token-decoration {
+    color: var(--syntax-decoration-dark, #fb923c);
+  }
+
+  .abc-token-duration {
+    color: var(--syntax-duration-dark, #2dd4bf);
+  }
+
+  .abc-token-accidental {
+    color: var(--syntax-accidental-dark, #f87171);
+  }
+
+  .abc-token-text {
+    color: var(--syntax-text-dark, #e5e7eb);
+  }
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+  .abc-source-toolbar {
+    padding: 0.375rem 0.5rem;
+  }
+
+  .abc-view-toggle-btn {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+  }
+
+  .abc-view-toggle-btn span {
+    display: none;
+  }
+
+  .abc-toolbar-btn {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+  }
+
+  .abc-toolbar-btn span {
+    display: none;
+  }
+
+  .abc-line-number {
+    width: 2rem;
+    padding-right: 0.5rem;
+    font-size: 0.75rem;
+  }
+}

--- a/web/src/components/Notation/ABCSourceView.test.tsx
+++ b/web/src/components/Notation/ABCSourceView.test.tsx
@@ -1,0 +1,592 @@
+/**
+ * Tests for ABCSourceView Component
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ABCSourceView, type ABCSourceViewProps } from './ABCSourceView';
+
+// Mock the abcRenderer module
+vi.mock('@/lib/music/abcRenderer', () => ({
+  renderABC: vi.fn(() => ({
+    tuneObjects: [{ tuneNumber: 0 }],
+    success: true,
+  })),
+}));
+
+describe('ABCSourceView', () => {
+  const sampleABC = `X:1
+T:Test Melody
+M:4/4
+L:1/8
+Q:1/4=100
+K:C
+% This is a comment
+CDEF|GABc|"Am"c2B2|A4|]
+w: Do Re Mi Fa Sol La Ti Do`;
+
+  const defaultProps: ABCSourceViewProps = {
+    abc: sampleABC,
+  };
+
+  // Mock clipboard API
+  const mockWriteText = vi.fn(() => Promise.resolve());
+
+  // Mock URL API
+  const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
+  const mockRevokeObjectURL = vi.fn();
+
+  // Mock anchor click
+  const mockAnchorClick = vi.fn();
+
+  beforeEach(() => {
+    // Setup clipboard mock
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      writable: true,
+      configurable: true,
+    });
+
+    // Setup URL mocks
+    global.URL.createObjectURL = mockCreateObjectURL;
+    global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+    // Mock createElement to capture anchor properties
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName === 'a') {
+        element.click = mockAnchorClick;
+      }
+      return element;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders the component container', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const container = screen.getByTestId('abc-source-view');
+      expect(container).toBeInTheDocument();
+    });
+
+    it('applies custom className', () => {
+      render(<ABCSourceView {...defaultProps} className="custom-class" />);
+
+      const container = screen.getByTestId('abc-source-view');
+      expect(container).toHaveClass('abc-source-view', 'custom-class');
+    });
+
+    it('applies custom style', () => {
+      render(
+        <ABCSourceView
+          {...defaultProps}
+          style={{ marginTop: '20px', padding: '10px' }}
+        />
+      );
+
+      const container = screen.getByTestId('abc-source-view');
+      expect(container.style.marginTop).toBe('20px');
+      expect(container.style.padding).toBe('10px');
+    });
+
+    it('renders toolbar by default', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const toolbar = screen.getByTestId('abc-source-toolbar');
+      expect(toolbar).toBeInTheDocument();
+    });
+
+    it('hides toolbar when showToolbar is false', () => {
+      render(<ABCSourceView {...defaultProps} showToolbar={false} />);
+
+      const toolbar = screen.queryByTestId('abc-source-toolbar');
+      expect(toolbar).not.toBeInTheDocument();
+    });
+
+    it('shows rendered view by default', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const renderedView = screen.getByTestId('rendered-view');
+      expect(renderedView).toBeInTheDocument();
+    });
+
+    it('shows source view when initialViewMode is source', () => {
+      render(<ABCSourceView {...defaultProps} initialViewMode="source" />);
+
+      const sourceView = screen.getByTestId('source-view');
+      expect(sourceView).toBeInTheDocument();
+    });
+  });
+
+  describe('view toggle', () => {
+    it('renders view toggle buttons', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const renderedButton = screen.getByTestId('view-toggle-rendered');
+      const sourceButton = screen.getByTestId('view-toggle-source');
+
+      expect(renderedButton).toBeInTheDocument();
+      expect(sourceButton).toBeInTheDocument();
+    });
+
+    it('toggles to source view when source button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<ABCSourceView {...defaultProps} />);
+
+      const sourceButton = screen.getByTestId('view-toggle-source');
+      await user.click(sourceButton);
+
+      const sourceView = screen.getByTestId('source-view');
+      expect(sourceView).toBeInTheDocument();
+    });
+
+    it('toggles back to rendered view when rendered button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<ABCSourceView {...defaultProps} initialViewMode="source" />);
+
+      const renderedButton = screen.getByTestId('view-toggle-rendered');
+      await user.click(renderedButton);
+
+      const renderedView = screen.getByTestId('rendered-view');
+      expect(renderedView).toBeInTheDocument();
+    });
+
+    it('marks active toggle button correctly', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const renderedButton = screen.getByTestId('view-toggle-rendered');
+      const sourceButton = screen.getByTestId('view-toggle-source');
+
+      expect(renderedButton).toHaveClass('active');
+      expect(sourceButton).not.toHaveClass('active');
+    });
+
+    it('has correct aria-selected attributes', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const renderedButton = screen.getByTestId('view-toggle-rendered');
+      const sourceButton = screen.getByTestId('view-toggle-source');
+
+      expect(renderedButton).toHaveAttribute('aria-selected', 'true');
+      expect(sourceButton).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  describe('syntax highlighting', () => {
+    it('renders source code with line numbers by default', async () => {
+      const user = userEvent.setup();
+      render(<ABCSourceView {...defaultProps} />);
+
+      await user.click(screen.getByTestId('view-toggle-source'));
+
+      const lineNumbers = screen.getAllByText(/^\d+$/);
+      expect(lineNumbers.length).toBeGreaterThan(0);
+    });
+
+    it('hides line numbers when showLineNumbers is false', () => {
+      render(<ABCSourceView {...defaultProps} initialViewMode="source" showLineNumbers={false} />);
+
+      // Line numbers should not be present as separate elements
+      const sourceView = screen.getByTestId('source-view');
+      const lineNumberElements = sourceView.querySelectorAll('.abc-line-number');
+      expect(lineNumberElements.length).toBe(0);
+    });
+
+    it('highlights header fields', async () => {
+      const user = userEvent.setup();
+      render(<ABCSourceView {...defaultProps} />);
+
+      await user.click(screen.getByTestId('view-toggle-source'));
+
+      const sourceView = screen.getByTestId('source-view');
+      const fieldKeys = sourceView.querySelectorAll('.abc-token-field-key');
+      expect(fieldKeys.length).toBeGreaterThan(0);
+    });
+
+    it('highlights comments', async () => {
+      const user = userEvent.setup();
+      render(<ABCSourceView {...defaultProps} />);
+
+      await user.click(screen.getByTestId('view-toggle-source'));
+
+      const sourceView = screen.getByTestId('source-view');
+      const comments = sourceView.querySelectorAll('.abc-token-comment');
+      expect(comments.length).toBeGreaterThan(0);
+    });
+
+    it('highlights notes', async () => {
+      const user = userEvent.setup();
+      render(<ABCSourceView {...defaultProps} />);
+
+      await user.click(screen.getByTestId('view-toggle-source'));
+
+      const sourceView = screen.getByTestId('source-view');
+      const notes = sourceView.querySelectorAll('.abc-token-note');
+      expect(notes.length).toBeGreaterThan(0);
+    });
+
+    it('highlights chords', async () => {
+      const user = userEvent.setup();
+      render(<ABCSourceView {...defaultProps} />);
+
+      await user.click(screen.getByTestId('view-toggle-source'));
+
+      const sourceView = screen.getByTestId('source-view');
+      const chords = sourceView.querySelectorAll('.abc-token-chord');
+      expect(chords.length).toBeGreaterThan(0);
+    });
+
+    it('highlights bar lines', async () => {
+      const user = userEvent.setup();
+      render(<ABCSourceView {...defaultProps} />);
+
+      await user.click(screen.getByTestId('view-toggle-source'));
+
+      const sourceView = screen.getByTestId('source-view');
+      const bars = sourceView.querySelectorAll('.abc-token-bar');
+      expect(bars.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('copy to clipboard', () => {
+    it('renders copy button', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const copyButton = screen.getByTestId('copy-button');
+      expect(copyButton).toBeInTheDocument();
+    });
+
+    it('copies ABC to clipboard when clicked and shows success message', async () => {
+      const user = userEvent.setup();
+      render(<ABCSourceView {...defaultProps} />);
+
+      const copyButton = screen.getByTestId('copy-button');
+      await user.click(copyButton);
+
+      // The success message proves copy was triggered (either via clipboard API or fallback)
+      await waitFor(() => {
+        expect(screen.getByText('Copied!')).toBeInTheDocument();
+      });
+    });
+
+    it('has correct aria-label', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const copyButton = screen.getByTestId('copy-button');
+      expect(copyButton).toHaveAttribute('aria-label', 'Copy ABC to clipboard');
+    });
+  });
+
+  describe('download functionality', () => {
+    it('renders download button', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const downloadButton = screen.getByTestId('download-button');
+      expect(downloadButton).toBeInTheDocument();
+    });
+
+    it('creates blob and triggers download when clicked', async () => {
+      const user = userEvent.setup();
+
+      render(<ABCSourceView {...defaultProps} downloadTitle="my-melody" />);
+
+      const downloadButton = screen.getByTestId('download-button');
+      await user.click(downloadButton);
+
+      // Verify blob was created
+      expect(mockCreateObjectURL).toHaveBeenCalled();
+      // Verify URL was revoked after download
+      expect(mockRevokeObjectURL).toHaveBeenCalled();
+      // Verify anchor was clicked to trigger download
+      expect(mockAnchorClick).toHaveBeenCalled();
+    });
+
+    it('creates download with default filename', async () => {
+      const user = userEvent.setup();
+
+      render(<ABCSourceView {...defaultProps} />);
+
+      const downloadButton = screen.getByTestId('download-button');
+      await user.click(downloadButton);
+
+      // Download was triggered
+      expect(mockAnchorClick).toHaveBeenCalled();
+    });
+
+    it('has correct aria-label', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const downloadButton = screen.getByTestId('download-button');
+      expect(downloadButton).toHaveAttribute('aria-label', 'Download as ABC file');
+    });
+  });
+
+  describe('editing functionality', () => {
+    it('shows textarea when editable and in source view', () => {
+      render(<ABCSourceView {...defaultProps} editable initialViewMode="source" />);
+
+      const textarea = screen.getByTestId('abc-textarea');
+      expect(textarea).toBeInTheDocument();
+    });
+
+    it('shows read-only source when not editable', () => {
+      render(<ABCSourceView {...defaultProps} initialViewMode="source" />);
+
+      const sourceView = screen.getByTestId('source-view');
+      expect(sourceView).toBeInTheDocument();
+      expect(sourceView).toHaveAttribute('aria-readonly', 'true');
+    });
+
+    it('calls onABCChange when editing', async () => {
+      const user = userEvent.setup();
+      const onABCChange = vi.fn();
+
+      render(
+        <ABCSourceView
+          {...defaultProps}
+          editable
+          initialViewMode="source"
+          onABCChange={onABCChange}
+        />
+      );
+
+      const textarea = screen.getByTestId('abc-textarea');
+      await user.clear(textarea);
+      await user.type(textarea, 'X:1');
+
+      expect(onABCChange).toHaveBeenCalled();
+    });
+
+    it('shows edit toggle button when editable', () => {
+      render(<ABCSourceView {...defaultProps} editable />);
+
+      const editButton = screen.getByTestId('edit-toggle-button');
+      expect(editButton).toBeInTheDocument();
+    });
+
+    it('hides edit toggle button when not editable', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const editButton = screen.queryByTestId('edit-toggle-button');
+      expect(editButton).not.toBeInTheDocument();
+    });
+  });
+
+  describe('validation', () => {
+    it('shows validation status in source view', () => {
+      render(<ABCSourceView {...defaultProps} initialViewMode="source" />);
+
+      const validationStatus = screen.getByTestId('validation-status');
+      expect(validationStatus).toBeInTheDocument();
+    });
+
+    it('shows valid status for valid ABC', async () => {
+      render(<ABCSourceView {...defaultProps} initialViewMode="source" />);
+
+      const validationStatus = screen.getByTestId('validation-status');
+      expect(validationStatus).toHaveClass('valid');
+    });
+
+    it('shows invalid status for ABC without K: field', async () => {
+      const invalidABC = `X:1
+T:Test
+M:4/4
+CDEF|`;
+
+      render(<ABCSourceView abc={invalidABC} initialViewMode="source" />);
+
+      await waitFor(() => {
+        const validationStatus = screen.getByTestId('validation-status');
+        expect(validationStatus).toHaveClass('invalid');
+      });
+    });
+
+    it('calls onValidationChange when validation state changes', async () => {
+      const onValidationChange = vi.fn();
+
+      render(
+        <ABCSourceView
+          {...defaultProps}
+          onValidationChange={onValidationChange}
+        />
+      );
+
+      await waitFor(() => {
+        expect(onValidationChange).toHaveBeenCalled();
+      });
+    });
+
+    it('shows validation errors for editable source', async () => {
+      const invalidABC = `X:1
+T:Test
+M:4/4
+CDEF|`;
+
+      render(
+        <ABCSourceView
+          abc={invalidABC}
+          editable
+          initialViewMode="source"
+        />
+      );
+
+      await waitFor(() => {
+        const errors = screen.getByTestId('validation-errors');
+        expect(errors).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('notation rendering', () => {
+    it('renders ABC notation when in rendered view', async () => {
+      const { renderABC } = await import('@/lib/music/abcRenderer');
+
+      render(<ABCSourceView {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(renderABC).toHaveBeenCalled();
+      });
+    });
+
+    it('passes correct options to renderABC', async () => {
+      const { renderABC } = await import('@/lib/music/abcRenderer');
+
+      render(<ABCSourceView {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(renderABC).toHaveBeenCalledWith(
+          sampleABC,
+          expect.any(String),
+          expect.objectContaining({
+            responsive: 'resize',
+            add_classes: true,
+          })
+        );
+      });
+    });
+
+    it('uses custom notationId when provided', async () => {
+      const { renderABC } = await import('@/lib/music/abcRenderer');
+
+      render(<ABCSourceView {...defaultProps} notationId="custom-notation-id" />);
+
+      await waitFor(() => {
+        expect(renderABC).toHaveBeenCalledWith(
+          sampleABC,
+          'custom-notation-id',
+          expect.any(Object)
+        );
+      });
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has correct role for view toggle', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const tablist = screen.getByRole('tablist');
+      expect(tablist).toBeInTheDocument();
+    });
+
+    it('source view has correct ARIA attributes', () => {
+      render(<ABCSourceView {...defaultProps} initialViewMode="source" />);
+
+      const sourceView = screen.getByTestId('source-view');
+      expect(sourceView).toHaveAttribute('role', 'textbox');
+      expect(sourceView).toHaveAttribute('aria-readonly', 'true');
+      expect(sourceView).toHaveAttribute('aria-multiline', 'true');
+      expect(sourceView).toHaveAttribute('aria-label', 'ABC notation source');
+    });
+
+    it('rendered view has correct aria-label', () => {
+      render(<ABCSourceView {...defaultProps} />);
+
+      const renderedView = screen.getByTestId('rendered-view');
+      expect(renderedView).toHaveAttribute('aria-label', 'Rendered music notation');
+    });
+
+    it('editable textarea has correct aria-label', () => {
+      render(<ABCSourceView {...defaultProps} editable initialViewMode="source" />);
+
+      const textarea = screen.getByTestId('abc-textarea');
+      expect(textarea).toHaveAttribute('aria-label', 'ABC notation editor');
+    });
+  });
+
+  describe('ABC updates', () => {
+    it('updates when abc prop changes', async () => {
+      const { rerender } = render(<ABCSourceView {...defaultProps} initialViewMode="source" />);
+
+      const newABC = `X:2
+T:New Melody
+K:G
+GABc|`;
+
+      rerender(<ABCSourceView abc={newABC} initialViewMode="source" />);
+
+      await waitFor(() => {
+        const sourceView = screen.getByTestId('source-view');
+        expect(sourceView.textContent).toContain('New Melody');
+      });
+    });
+  });
+
+  describe('special ABC notation tokens', () => {
+    it('highlights accidentals correctly', async () => {
+      const abcWithAccidentals = `X:1
+K:C
+^C _D =E|`;
+
+      render(<ABCSourceView abc={abcWithAccidentals} initialViewMode="source" />);
+
+      const sourceView = screen.getByTestId('source-view');
+      const accidentals = sourceView.querySelectorAll('.abc-token-accidental');
+      expect(accidentals.length).toBeGreaterThan(0);
+    });
+
+    it('highlights rests correctly', async () => {
+      const abcWithRests = `X:1
+K:C
+CDz2EF|`;
+
+      render(<ABCSourceView abc={abcWithRests} initialViewMode="source" />);
+
+      const sourceView = screen.getByTestId('source-view');
+      const rests = sourceView.querySelectorAll('.abc-token-rest');
+      expect(rests.length).toBeGreaterThan(0);
+    });
+
+    it('highlights lyrics (w: field) correctly', async () => {
+      const abcWithLyrics = `X:1
+K:C
+CDEF|
+w: Do Re Mi Fa`;
+
+      render(<ABCSourceView abc={abcWithLyrics} initialViewMode="source" />);
+
+      const sourceView = screen.getByTestId('source-view');
+      const lyrics = sourceView.querySelectorAll('.abc-token-lyric');
+      expect(lyrics.length).toBeGreaterThan(0);
+    });
+
+    it('highlights decorations correctly', async () => {
+      const abcWithDecorations = `X:1
+K:C
+!fermata!C D E F|`;
+
+      render(<ABCSourceView abc={abcWithDecorations} initialViewMode="source" />);
+
+      const sourceView = screen.getByTestId('source-view');
+      const decorations = sourceView.querySelectorAll('.abc-token-decoration');
+      expect(decorations.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/web/src/components/Notation/ABCSourceView.tsx
+++ b/web/src/components/Notation/ABCSourceView.tsx
@@ -1,0 +1,748 @@
+/**
+ * ABCSourceView Component
+ *
+ * Provides view and optional editing of ABC notation source code.
+ * Features:
+ * - Toggle between rendered and source view
+ * - Syntax highlighting for ABC notation
+ * - Copy to clipboard button
+ * - Download as .abc file
+ * - Optional basic editing with validation
+ */
+
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { renderABC } from '@/lib/music/abcRenderer';
+import './ABCSourceView.css';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[ABCSourceView] ${message}`, ...args);
+  }
+};
+
+/**
+ * View mode for the ABC display
+ */
+export type ViewMode = 'rendered' | 'source';
+
+/**
+ * Validation result for ABC notation
+ */
+export interface ABCValidationResult {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Props for ABCSourceView component
+ */
+export interface ABCSourceViewProps {
+  /** ABC notation string to display */
+  abc: string;
+  /** Initial view mode (default: 'rendered') */
+  initialViewMode?: ViewMode;
+  /** Whether editing is enabled (default: false) */
+  editable?: boolean;
+  /** Callback when ABC notation changes (only called in editable mode) */
+  onABCChange?: (abc: string) => void;
+  /** Callback when validation state changes */
+  onValidationChange?: (result: ABCValidationResult) => void;
+  /** Custom CSS class name */
+  className?: string;
+  /** Custom styling for the container */
+  style?: React.CSSProperties;
+  /** Title for the file when downloading (default: 'melody') */
+  downloadTitle?: string;
+  /** Whether to show the toolbar (default: true) */
+  showToolbar?: boolean;
+  /** Whether to show line numbers in source view (default: true) */
+  showLineNumbers?: boolean;
+  /** Element ID for the notation display (auto-generated if not provided) */
+  notationId?: string;
+}
+
+/**
+ * ABC notation token types for syntax highlighting
+ */
+type TokenType =
+  | 'header'
+  | 'field-key'
+  | 'field-value'
+  | 'note'
+  | 'rest'
+  | 'bar'
+  | 'chord'
+  | 'lyric'
+  | 'comment'
+  | 'decoration'
+  | 'duration'
+  | 'accidental'
+  | 'text';
+
+/**
+ * Token for syntax highlighting
+ */
+interface Token {
+  type: TokenType;
+  value: string;
+}
+
+/**
+ * Generate a unique ID for notation container
+ */
+let idCounter = 0;
+function generateNotationId(): string {
+  return `abc-source-view-notation-${++idCounter}`;
+}
+
+/**
+ * Tokenize a line of ABC notation for syntax highlighting
+ */
+function tokenizeLine(line: string): Token[] {
+  const tokens: Token[] = [];
+  const remaining = line;
+
+  // Comment line
+  if (remaining.startsWith('%')) {
+    tokens.push({ type: 'comment', value: remaining });
+    return tokens;
+  }
+
+  // Lyrics line (w: or W:) - check before general header to use lyric styling
+  if (remaining.match(/^[wW]:\s*/)) {
+    const lyricMatch = remaining.match(/^([wW]:)\s*(.*)$/);
+    if (lyricMatch) {
+      tokens.push({ type: 'field-key', value: lyricMatch[1] });
+      if (lyricMatch[2]) {
+        tokens.push({ type: 'lyric', value: lyricMatch[2] });
+      }
+      return tokens;
+    }
+  }
+
+  // Header field line (e.g., X:1, T:Title, M:4/4, K:C)
+  const headerMatch = remaining.match(/^([A-Za-z]):\s*(.*)$/);
+  if (headerMatch) {
+    tokens.push({ type: 'field-key', value: headerMatch[1] + ':' });
+    if (headerMatch[2]) {
+      tokens.push({ type: 'field-value', value: headerMatch[2] });
+    }
+    return tokens;
+  }
+
+  // Music notation line - tokenize character by character
+  let i = 0;
+  while (i < remaining.length) {
+    const char = remaining[i];
+    const ahead = remaining.slice(i);
+
+    // Bar lines
+    if (char === '|' || char === ':') {
+      const barMatch = ahead.match(/^(\|?\|?:?:?\|?\|?|:\||\|\]|\[\||\|:|\|)/);
+      if (barMatch) {
+        tokens.push({ type: 'bar', value: barMatch[1] });
+        i += barMatch[1].length;
+        continue;
+      }
+    }
+
+    // Chord symbols in quotes
+    if (char === '"') {
+      const chordMatch = ahead.match(/^"([^"]*)"/);
+      if (chordMatch) {
+        tokens.push({ type: 'chord', value: chordMatch[0] });
+        i += chordMatch[0].length;
+        continue;
+      }
+    }
+
+    // Decorations (e.g., !fermata!, +accent+)
+    if (char === '!' || char === '+') {
+      const decorMatch = ahead.match(/^[!+][^!+]*[!+]/);
+      if (decorMatch) {
+        tokens.push({ type: 'decoration', value: decorMatch[0] });
+        i += decorMatch[0].length;
+        continue;
+      }
+    }
+
+    // Grace notes
+    if (char === '{') {
+      const graceMatch = ahead.match(/^\{[^}]*\}/);
+      if (graceMatch) {
+        tokens.push({ type: 'decoration', value: graceMatch[0] });
+        i += graceMatch[0].length;
+        continue;
+      }
+    }
+
+    // Accidentals
+    if (char === '^' || char === '_' || char === '=') {
+      const accMatch = ahead.match(/^[\^_=]+/);
+      if (accMatch) {
+        tokens.push({ type: 'accidental', value: accMatch[0] });
+        i += accMatch[0].length;
+        continue;
+      }
+    }
+
+    // Rest
+    if (char === 'z' || char === 'Z' || char === 'x') {
+      const restMatch = ahead.match(/^[zZx][0-9]*\/?[0-9]*/);
+      if (restMatch) {
+        tokens.push({ type: 'rest', value: restMatch[0] });
+        i += restMatch[0].length;
+        continue;
+      }
+    }
+
+    // Notes (including octave markers and durations)
+    if (/[A-Ga-g]/.test(char)) {
+      const noteMatch = ahead.match(/^[A-Ga-g][',]*[0-9]*\/?[0-9]*/);
+      if (noteMatch) {
+        tokens.push({ type: 'note', value: noteMatch[0] });
+        i += noteMatch[0].length;
+        continue;
+      }
+    }
+
+    // Durations attached to notes
+    if (/[0-9/]/.test(char)) {
+      const durMatch = ahead.match(/^[0-9]+\/?[0-9]*/);
+      if (durMatch) {
+        tokens.push({ type: 'duration', value: durMatch[0] });
+        i += durMatch[0].length;
+        continue;
+      }
+    }
+
+    // Any other character
+    tokens.push({ type: 'text', value: char });
+    i++;
+  }
+
+  return tokens;
+}
+
+/**
+ * Get CSS class for token type
+ */
+function getTokenClass(type: TokenType): string {
+  const classMap: Record<TokenType, string> = {
+    'header': 'abc-token-header',
+    'field-key': 'abc-token-field-key',
+    'field-value': 'abc-token-field-value',
+    'note': 'abc-token-note',
+    'rest': 'abc-token-rest',
+    'bar': 'abc-token-bar',
+    'chord': 'abc-token-chord',
+    'lyric': 'abc-token-lyric',
+    'comment': 'abc-token-comment',
+    'decoration': 'abc-token-decoration',
+    'duration': 'abc-token-duration',
+    'accidental': 'abc-token-accidental',
+    'text': 'abc-token-text',
+  };
+  return classMap[type];
+}
+
+/**
+ * Validate ABC notation by attempting to parse it
+ */
+function validateABC(abc: string): ABCValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!abc.trim()) {
+    errors.push('ABC notation is empty');
+    return { isValid: false, errors, warnings };
+  }
+
+  // Check for required header fields
+  const lines = abc.split('\n');
+  let hasXField = false;
+  let hasKField = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('X:')) hasXField = true;
+    if (trimmed.startsWith('K:')) hasKField = true;
+  }
+
+  if (!hasXField) {
+    warnings.push('Missing X: (reference number) field');
+  }
+  if (!hasKField) {
+    errors.push('Missing K: (key) field - required for ABC notation');
+  }
+
+  // Try to render the ABC to check for parse errors
+  try {
+    // Create a temporary container for validation
+    const tempDiv = document.createElement('div');
+    tempDiv.id = 'abc-validation-temp';
+    tempDiv.style.display = 'none';
+    document.body.appendChild(tempDiv);
+
+    try {
+      const result = renderABC(abc, 'abc-validation-temp');
+      if (!result.success) {
+        errors.push(result.error ?? 'Failed to parse ABC notation');
+      }
+    } finally {
+      document.body.removeChild(tempDiv);
+    }
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    errors.push(`Parse error: ${errorMessage}`);
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * ABCSourceView provides a view and optional editing interface for ABC notation.
+ *
+ * Features:
+ * - Toggle between rendered sheet music and source code view
+ * - Syntax highlighting for ABC notation
+ * - Copy to clipboard functionality
+ * - Download as .abc file
+ * - Optional editing with real-time validation
+ *
+ * @example
+ * ```tsx
+ * <ABCSourceView
+ *   abc={abcNotation}
+ *   editable
+ *   onABCChange={(newAbc) => setAbcNotation(newAbc)}
+ *   downloadTitle="my-melody"
+ * />
+ * ```
+ */
+export function ABCSourceView({
+  abc,
+  initialViewMode = 'rendered',
+  editable = false,
+  onABCChange,
+  onValidationChange,
+  className = '',
+  style,
+  downloadTitle = 'melody',
+  showToolbar = true,
+  showLineNumbers = true,
+  notationId,
+}: ABCSourceViewProps): React.ReactElement {
+  const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
+  const [localAbc, setLocalAbc] = useState(abc);
+  const [validation, setValidation] = useState<ABCValidationResult>({ isValid: true, errors: [], warnings: [] });
+  const [copySuccess, setCopySuccess] = useState(false);
+  const [containerId] = useState(() => notationId ?? generateNotationId());
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const notationContainerRef = useRef<HTMLDivElement>(null);
+
+  // Update local ABC when prop changes
+  useEffect(() => {
+    setLocalAbc(abc);
+  }, [abc]);
+
+  // Validate ABC when it changes
+  useEffect(() => {
+    const result = validateABC(localAbc);
+    setValidation(result);
+    onValidationChange?.(result);
+  }, [localAbc, onValidationChange]);
+
+  // Render notation when in rendered view mode
+  useEffect(() => {
+    if (viewMode === 'rendered' && notationContainerRef.current && localAbc) {
+      log('Rendering ABC notation');
+      renderABC(localAbc, containerId, {
+        responsive: 'resize',
+        add_classes: true,
+      });
+    }
+  }, [viewMode, localAbc, containerId]);
+
+  // Handle view mode toggle
+  const handleToggleView = useCallback(() => {
+    const newMode = viewMode === 'rendered' ? 'source' : 'rendered';
+    log('Toggling view mode:', viewMode, '->', newMode);
+    setViewMode(newMode);
+  }, [viewMode]);
+
+  // Handle copy to clipboard
+  const handleCopy = useCallback(async () => {
+    log('Copying ABC to clipboard');
+    try {
+      await navigator.clipboard.writeText(localAbc);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000);
+      log('Copy successful');
+    } catch (err) {
+      log('Copy failed:', err);
+      // Fallback for older browsers
+      const textarea = document.createElement('textarea');
+      textarea.value = localAbc;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000);
+    }
+  }, [localAbc]);
+
+  // Handle download as .abc file
+  const handleDownload = useCallback(() => {
+    log('Downloading ABC file');
+    const blob = new Blob([localAbc], { type: 'text/vnd.abc' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${downloadTitle}.abc`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    log('Download initiated');
+  }, [localAbc, downloadTitle]);
+
+  // Handle ABC editing
+  const handleABCChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const newAbc = e.target.value;
+      setLocalAbc(newAbc);
+      onABCChange?.(newAbc);
+      log('ABC changed, length:', newAbc.length);
+    },
+    [onABCChange]
+  );
+
+  // Generate syntax-highlighted HTML for source view
+  const highlightedSource = useMemo(() => {
+    const lines = localAbc.split('\n');
+    return lines.map((line, index) => {
+      const tokens = tokenizeLine(line);
+      return (
+        <div key={index} className="abc-source-line">
+          {showLineNumbers && (
+            <span className="abc-line-number">{index + 1}</span>
+          )}
+          <span className="abc-line-content">
+            {tokens.length > 0 ? (
+              tokens.map((token, tokenIndex) => (
+                <span key={tokenIndex} className={getTokenClass(token.type)}>
+                  {token.value}
+                </span>
+              ))
+            ) : (
+              <span className="abc-empty-line">&nbsp;</span>
+            )}
+          </span>
+        </div>
+      );
+    });
+  }, [localAbc, showLineNumbers]);
+
+  // Container styles
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    ...style,
+  };
+
+  return (
+    <div
+      className={`abc-source-view ${className}`.trim()}
+      style={containerStyle}
+      data-testid="abc-source-view"
+    >
+      {/* Toolbar */}
+      {showToolbar && (
+        <div className="abc-source-toolbar" data-testid="abc-source-toolbar">
+          <div className="abc-source-toolbar-left">
+            {/* View Toggle */}
+            <div className="abc-view-toggle" role="tablist">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={viewMode === 'rendered'}
+                className={`abc-view-toggle-btn ${viewMode === 'rendered' ? 'active' : ''}`}
+                onClick={() => setViewMode('rendered')}
+                data-testid="view-toggle-rendered"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  width="16"
+                  height="16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  aria-hidden="true"
+                >
+                  <path d="M9 19V6l12-3v13" />
+                  <circle cx="6" cy="18" r="3" />
+                  <circle cx="18" cy="16" r="3" />
+                </svg>
+                <span>Rendered</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={viewMode === 'source'}
+                className={`abc-view-toggle-btn ${viewMode === 'source' ? 'active' : ''}`}
+                onClick={() => setViewMode('source')}
+                data-testid="view-toggle-source"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  width="16"
+                  height="16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  aria-hidden="true"
+                >
+                  <polyline points="16,18 22,12 16,6" />
+                  <polyline points="8,6 2,12 8,18" />
+                </svg>
+                <span>Source</span>
+              </button>
+            </div>
+
+            {/* Validation Status */}
+            {viewMode === 'source' && (
+              <div
+                className={`abc-validation-status ${validation.isValid ? 'valid' : 'invalid'}`}
+                data-testid="validation-status"
+              >
+                {validation.isValid ? (
+                  <>
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="14"
+                      height="14"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      aria-hidden="true"
+                    >
+                      <polyline points="20,6 9,17 4,12" />
+                    </svg>
+                    <span>Valid</span>
+                  </>
+                ) : (
+                  <>
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="14"
+                      height="14"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      aria-hidden="true"
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                      <line x1="12" y1="8" x2="12" y2="12" />
+                      <line x1="12" y1="16" x2="12.01" y2="16" />
+                    </svg>
+                    <span>{validation.errors.length} error(s)</span>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="abc-source-toolbar-right">
+            {/* Copy Button */}
+            <button
+              type="button"
+              className="abc-toolbar-btn"
+              onClick={handleCopy}
+              aria-label="Copy ABC to clipboard"
+              data-testid="copy-button"
+            >
+              {copySuccess ? (
+                <>
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20,6 9,17 4,12" />
+                  </svg>
+                  <span>Copied!</span>
+                </>
+              ) : (
+                <>
+                  <svg
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    aria-hidden="true"
+                  >
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                  </svg>
+                  <span>Copy</span>
+                </>
+              )}
+            </button>
+
+            {/* Download Button */}
+            <button
+              type="button"
+              className="abc-toolbar-btn"
+              onClick={handleDownload}
+              aria-label="Download as ABC file"
+              data-testid="download-button"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width="16"
+                height="16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden="true"
+              >
+                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                <polyline points="7,10 12,15 17,10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
+              </svg>
+              <span>Download</span>
+            </button>
+
+            {/* Edit Toggle (when editable) */}
+            {editable && (
+              <button
+                type="button"
+                className="abc-toolbar-btn abc-edit-toggle"
+                onClick={handleToggleView}
+                aria-label={viewMode === 'source' ? 'Switch to rendered view' : 'Switch to edit source'}
+                data-testid="edit-toggle-button"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  width="16"
+                  height="16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  aria-hidden="true"
+                >
+                  <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+                  <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+                </svg>
+                <span>Edit</span>
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Content Area */}
+      <div className="abc-source-content" data-testid="abc-source-content">
+        {viewMode === 'rendered' ? (
+          /* Rendered View */
+          <div
+            ref={notationContainerRef}
+            id={containerId}
+            className="abc-rendered-view"
+            data-testid="rendered-view"
+            aria-label="Rendered music notation"
+          >
+            {/* abcjs will inject the SVG here */}
+          </div>
+        ) : editable ? (
+          /* Editable Source View */
+          <div className="abc-editable-source" data-testid="editable-source-view">
+            <textarea
+              ref={textareaRef}
+              className="abc-source-textarea"
+              value={localAbc}
+              onChange={handleABCChange}
+              spellCheck={false}
+              aria-label="ABC notation editor"
+              data-testid="abc-textarea"
+            />
+            {/* Validation Errors */}
+            {!validation.isValid && (
+              <div className="abc-validation-errors" data-testid="validation-errors">
+                {validation.errors.map((error, index) => (
+                  <div key={index} className="abc-validation-error">
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="14"
+                      height="14"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      aria-hidden="true"
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                      <line x1="15" y1="9" x2="9" y2="15" />
+                      <line x1="9" y1="9" x2="15" y2="15" />
+                    </svg>
+                    <span>{error}</span>
+                  </div>
+                ))}
+                {validation.warnings.map((warning, index) => (
+                  <div key={`warn-${index}`} className="abc-validation-warning">
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="14"
+                      height="14"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      aria-hidden="true"
+                    >
+                      <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                      <line x1="12" y1="9" x2="12" y2="13" />
+                      <line x1="12" y1="17" x2="12.01" y2="17" />
+                    </svg>
+                    <span>{warning}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          /* Read-only Source View with Syntax Highlighting */
+          <div
+            className="abc-source-display"
+            data-testid="source-view"
+            role="textbox"
+            aria-readonly="true"
+            aria-multiline="true"
+            aria-label="ABC notation source"
+            tabIndex={0}
+          >
+            <pre className="abc-source-pre">
+              <code className="abc-source-code">{highlightedSource}</code>
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ABCSourceView;

--- a/web/src/components/Notation/index.ts
+++ b/web/src/components/Notation/index.ts
@@ -6,3 +6,9 @@
 
 export { NotationDisplay, type NotationDisplayProps, type NoteClickData } from './NotationDisplay';
 export { PlaybackControls, type PlaybackControlsProps, TEMPO_PRESETS } from './PlaybackControls';
+export {
+  ABCSourceView,
+  type ABCSourceViewProps,
+  type ABCValidationResult,
+  type ViewMode,
+} from './ABCSourceView';


### PR DESCRIPTION
## Summary
Implement a new ABCSourceView component that allows users to view and optionally edit ABC notation directly.

## Changes
- `web/src/components/Notation/ABCSourceView.tsx` - Main component with:
  - Toggle between rendered sheet music and source code view
  - Syntax highlighting for ABC notation (headers, notes, bars, chords, lyrics, comments, etc.)
  - Copy to clipboard functionality
  - Download as .abc file functionality
  - Optional editing mode with real-time validation
- `web/src/components/Notation/ABCSourceView.css` - Comprehensive styling including dark mode support
- `web/src/components/Notation/ABCSourceView.test.tsx` - Comprehensive test suite (45+ test cases)
- `web/src/components/Notation/index.ts` - Export the new component

## Features
- **View Toggle**: Seamlessly switch between rendered notation (using abcjs) and source code view
- **Syntax Highlighting**: Color-coded ABC notation elements:
  - Header fields (X:, T:, M:, K:, etc.)
  - Notes with octave markers and durations
  - Bar lines and repeat markers
  - Chord symbols in quotes
  - Lyrics (w: fields)
  - Comments (%)
  - Decorations and grace notes
  - Accidentals
- **Copy to Clipboard**: One-click copy with visual feedback
- **Download**: Export as .abc file with customizable filename
- **Editing Mode**: Optional editing with real-time ABC validation
- **Accessibility**: ARIA roles, labels, and keyboard support
- **Responsive**: Mobile-friendly layout with adaptive toolbar

## Testing
- [x] Unit tests pass (`npm test`)
- [x] Check passes (`npm run check`)
- [x] Comprehensive test coverage for all features

## Notes
- The component validates ABC notation by checking for required fields (K:) and attempting to parse with abcjs
- Syntax highlighting handles all standard ABC notation elements
- Dark mode styles are included via CSS media queries

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)