### PR TITLE
feat(GH-38): Implement keyboard shortcuts system

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -155,6 +155,7 @@ vi.mock('@/stores/useMelodyStore', () => ({
   }),
   selectHasMelody: (state: typeof mockMelodyStoreState) => state.abcNotation !== null,
   selectIsGenerating: (state: typeof mockMelodyStoreState) => state.isGenerating,
+  selectIsPlaying: (state: typeof mockMelodyStoreState) => state.playbackState === 'playing',
 }));
 
 const mockRecordingStoreState: {

--- a/web/src/components/KeyboardShortcuts/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcuts/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Tests for KeyboardShortcutsDialog Component
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { KeyboardShortcutsDialog } from './KeyboardShortcutsDialog';
+import { SHORTCUT_DEFINITIONS } from '@/hooks/useKeyboardShortcuts';
+
+describe('KeyboardShortcutsDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Reset body overflow after each test
+    document.body.style.overflow = '';
+  });
+
+  describe('rendering', () => {
+    it('renders when isOpen is true', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      expect(screen.getByTestId('keyboard-shortcuts-dialog')).toBeInTheDocument();
+    });
+
+    it('does not render when isOpen is false', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} isOpen={false} />);
+
+      expect(screen.queryByTestId('keyboard-shortcuts-dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders the dialog title', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
+    });
+
+    it('renders the close button', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      expect(screen.getByTestId('keyboard-shortcuts-close')).toBeInTheDocument();
+    });
+
+    it('renders the footer hint', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      // The hint contains a kbd element, so we need to find by partial text
+      const footer = screen.getByText(/anytime to show this dialog/);
+      expect(footer).toBeInTheDocument();
+    });
+  });
+
+  describe('shortcuts display', () => {
+    it('renders all category sections', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      expect(screen.getByText('Playback')).toBeInTheDocument();
+      expect(screen.getByText('Creation')).toBeInTheDocument();
+      expect(screen.getByText('Editing')).toBeInTheDocument();
+      expect(screen.getByText('Navigation')).toBeInTheDocument();
+    });
+
+    it('renders shortcut descriptions', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      // Check for some expected shortcuts
+      expect(screen.getByText('Play/Pause melody playback')).toBeInTheDocument();
+      expect(screen.getByText('Stop playback')).toBeInTheDocument();
+      expect(screen.getByText('Generate melody')).toBeInTheDocument();
+    });
+
+    it('renders a shortcut for each definition', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      for (const shortcut of SHORTCUT_DEFINITIONS) {
+        const element = screen.getByTestId(`shortcut-${shortcut.action}`);
+        expect(element).toBeInTheDocument();
+      }
+    });
+
+    it('shows key labels for shortcuts', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      // Check for some expected key labels
+      expect(screen.getByText('Space')).toBeInTheDocument();
+      expect(screen.getByText('Esc')).toBeInTheDocument();
+      expect(screen.getByText('R')).toBeInTheDocument();
+    });
+  });
+
+  describe('closing behavior', () => {
+    it('calls onClose when close button is clicked', () => {
+      const onClose = vi.fn();
+      render(<KeyboardShortcutsDialog isOpen={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByTestId('keyboard-shortcuts-close'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when overlay is clicked', () => {
+      const onClose = vi.fn();
+      render(<KeyboardShortcutsDialog isOpen={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByTestId('keyboard-shortcuts-dialog'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose when dialog content is clicked', () => {
+      const onClose = vi.fn();
+      render(<KeyboardShortcutsDialog isOpen={true} onClose={onClose} />);
+
+      // Click on the title inside the dialog
+      fireEvent.click(screen.getByText('Keyboard Shortcuts'));
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when Escape is pressed', () => {
+      const onClose = vi.fn();
+      render(<KeyboardShortcutsDialog isOpen={true} onClose={onClose} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('body scroll prevention', () => {
+    it('sets body overflow to hidden when open', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      expect(document.body.style.overflow).toBe('hidden');
+    });
+
+    it('resets body overflow when closed', () => {
+      const { rerender } = render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      rerender(<KeyboardShortcutsDialog {...defaultProps} isOpen={false} />);
+
+      expect(document.body.style.overflow).toBe('');
+    });
+
+    it('resets body overflow on unmount', () => {
+      const { unmount } = render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      unmount();
+
+      expect(document.body.style.overflow).toBe('');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has role="dialog"', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('has aria-modal="true"', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      expect(screen.getByTestId('keyboard-shortcuts-dialog')).toHaveAttribute(
+        'aria-modal',
+        'true'
+      );
+    });
+
+    it('has aria-labelledby pointing to the title', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      const dialog = screen.getByTestId('keyboard-shortcuts-dialog');
+      const titleId = dialog.getAttribute('aria-labelledby');
+
+      expect(titleId).toBeTruthy();
+      expect(document.getElementById(titleId!)).toHaveTextContent('Keyboard Shortcuts');
+    });
+
+    it('close button has aria-label', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      expect(screen.getByTestId('keyboard-shortcuts-close')).toHaveAttribute(
+        'aria-label',
+        'Close'
+      );
+    });
+  });
+
+  describe('platform-specific display', () => {
+    it('shows modifier keys in key labels', () => {
+      render(<KeyboardShortcutsDialog {...defaultProps} />);
+
+      // The component should display Cmd or Ctrl depending on platform
+      // We check that some modifier is shown for shortcuts that need it
+      const undoShortcut = screen.getByTestId('shortcut-undo');
+      const keyLabel = undoShortcut.querySelector('kbd');
+
+      expect(keyLabel).toBeInTheDocument();
+      // Either shows Cmd (Mac) or Ctrl (Windows/Linux)
+      expect(keyLabel?.textContent).toMatch(/[⌘Ctrl]\+Z/);
+    });
+  });
+});

--- a/web/src/components/KeyboardShortcuts/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcuts/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,399 @@
+/**
+ * KeyboardShortcutsDialog Component
+ *
+ * A modal dialog that displays all available keyboard shortcuts organized by category.
+ * Can be opened by pressing the '?' key or through the help menu.
+ *
+ * @module components/KeyboardShortcuts/KeyboardShortcutsDialog
+ */
+
+import { useEffect, useCallback } from 'react';
+import { getShortcutsByCategory, type ShortcutDefinition } from '@/hooks/useKeyboardShortcuts';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[KeyboardShortcutsDialog] ${message}`, ...args);
+  }
+};
+
+/**
+ * Props for KeyboardShortcutsDialog component
+ */
+export interface KeyboardShortcutsDialogProps {
+  /** Whether the dialog is open */
+  isOpen: boolean;
+  /** Callback to close the dialog */
+  onClose: () => void;
+}
+
+/**
+ * Renders a single shortcut row
+ */
+function ShortcutRow({ shortcut }: { shortcut: ShortcutDefinition }): React.ReactElement {
+  // Determine platform-specific modifier key display
+  const isMac =
+    typeof navigator !== 'undefined' &&
+    navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+
+  // Replace command symbol with platform-specific key
+  const keyLabel = isMac
+    ? shortcut.keyLabel
+    : shortcut.keyLabel.replace(/⌘/g, 'Ctrl');
+
+  return (
+    <div className="keyboard-shortcut-row" data-testid={`shortcut-${shortcut.action}`}>
+      <span className="keyboard-shortcut-description">{shortcut.description}</span>
+      <kbd className="keyboard-shortcut-key">{keyLabel}</kbd>
+    </div>
+  );
+}
+
+/**
+ * Renders a category section with its shortcuts
+ */
+function CategorySection({
+  title,
+  shortcuts,
+}: {
+  title: string;
+  shortcuts: ShortcutDefinition[];
+}): React.ReactElement {
+  return (
+    <div className="keyboard-shortcut-category">
+      <h3 className="keyboard-shortcut-category-title">{title}</h3>
+      <div className="keyboard-shortcut-list">
+        {shortcuts.map((shortcut) => (
+          <ShortcutRow key={shortcut.action} shortcut={shortcut} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * KeyboardShortcutsDialog displays all available keyboard shortcuts.
+ *
+ * Features:
+ * - Organized by category (Playback, Creation, Editing, Navigation)
+ * - Platform-specific modifier key display (Cmd on Mac, Ctrl on Windows)
+ * - Accessible modal dialog with escape to close
+ * - Click outside to close
+ *
+ * @example
+ * ```tsx
+ * <KeyboardShortcutsDialog
+ *   isOpen={showHelp}
+ *   onClose={() => setShowHelp(false)}
+ * />
+ * ```
+ */
+export function KeyboardShortcutsDialog({
+  isOpen,
+  onClose,
+}: KeyboardShortcutsDialogProps): React.ReactElement | null {
+  log('Rendering dialog:', { isOpen });
+
+  // Handle escape key to close
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        log('Escape pressed, closing dialog');
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    log('Adding escape key listener');
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      log('Removing escape key listener');
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, handleKeyDown]);
+
+  // Prevent body scroll when dialog is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  // Don't render if not open
+  if (!isOpen) {
+    return null;
+  }
+
+  const shortcutsByCategory = getShortcutsByCategory();
+
+  // Handle overlay click
+  const handleOverlayClick = (event: React.MouseEvent): void => {
+    if (event.target === event.currentTarget) {
+      log('Overlay clicked, closing dialog');
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="keyboard-shortcuts-overlay"
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="keyboard-shortcuts-title"
+      data-testid="keyboard-shortcuts-dialog"
+    >
+      <div className="keyboard-shortcuts-dialog">
+        {/* Header */}
+        <div className="keyboard-shortcuts-header">
+          <h2 id="keyboard-shortcuts-title" className="keyboard-shortcuts-title">
+            Keyboard Shortcuts
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="keyboard-shortcuts-close-button"
+            aria-label="Close"
+            data-testid="keyboard-shortcuts-close"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="keyboard-shortcuts-content">
+          <div className="keyboard-shortcuts-grid">
+            {Object.entries(shortcutsByCategory).map(([category, shortcuts]) => (
+              <CategorySection key={category} title={category} shortcuts={shortcuts} />
+            ))}
+          </div>
+
+          {/* Footer with hint */}
+          <div className="keyboard-shortcuts-footer">
+            <p className="keyboard-shortcuts-hint">
+              Press <kbd>?</kbd> anytime to show this dialog
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <style>{`
+        .keyboard-shortcuts-overlay {
+          position: fixed;
+          inset: 0;
+          background-color: rgba(0, 0, 0, 0.5);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          z-index: 100;
+          padding: 1rem;
+          animation: fadeIn 0.15s ease-out;
+        }
+
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
+        }
+
+        .keyboard-shortcuts-dialog {
+          background-color: var(--color-surface, white);
+          border-radius: 12px;
+          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+          width: 100%;
+          max-width: 560px;
+          max-height: 80vh;
+          overflow: hidden;
+          display: flex;
+          flex-direction: column;
+          animation: slideIn 0.2s ease-out;
+        }
+
+        @keyframes slideIn {
+          from {
+            opacity: 0;
+            transform: translateY(-20px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+
+        .keyboard-shortcuts-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 1rem 1.25rem;
+          border-bottom: 1px solid var(--color-border, #e5e7eb);
+        }
+
+        .keyboard-shortcuts-title {
+          margin: 0;
+          font-size: 1.125rem;
+          font-weight: 600;
+          color: var(--color-text-primary, #111827);
+        }
+
+        .keyboard-shortcuts-close-button {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 0.375rem;
+          background: none;
+          border: none;
+          border-radius: 6px;
+          cursor: pointer;
+          color: var(--color-text-secondary, #6b7280);
+          transition: all 0.15s;
+        }
+
+        .keyboard-shortcuts-close-button:hover {
+          background-color: var(--color-hover, #f3f4f6);
+          color: var(--color-text-primary, #111827);
+        }
+
+        .keyboard-shortcuts-content {
+          padding: 1.25rem;
+          overflow-y: auto;
+        }
+
+        .keyboard-shortcuts-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+          gap: 1.5rem;
+        }
+
+        .keyboard-shortcut-category {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+        }
+
+        .keyboard-shortcut-category-title {
+          margin: 0;
+          font-size: 0.75rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          color: var(--color-text-muted, #9ca3af);
+        }
+
+        .keyboard-shortcut-list {
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+        }
+
+        .keyboard-shortcut-row {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 1rem;
+          padding: 0.5rem 0;
+        }
+
+        .keyboard-shortcut-description {
+          font-size: 0.875rem;
+          color: var(--color-text-primary, #374151);
+        }
+
+        .keyboard-shortcut-key {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          min-width: 1.75rem;
+          height: 1.5rem;
+          padding: 0 0.5rem;
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace;
+          font-size: 0.75rem;
+          font-weight: 500;
+          color: var(--color-text-secondary, #4b5563);
+          background-color: var(--color-kbd-bg, #f3f4f6);
+          border: 1px solid var(--color-kbd-border, #d1d5db);
+          border-radius: 4px;
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+          white-space: nowrap;
+        }
+
+        .keyboard-shortcuts-footer {
+          margin-top: 1.5rem;
+          padding-top: 1rem;
+          border-top: 1px solid var(--color-border, #e5e7eb);
+        }
+
+        .keyboard-shortcuts-hint {
+          margin: 0;
+          font-size: 0.8125rem;
+          color: var(--color-text-muted, #9ca3af);
+          text-align: center;
+        }
+
+        .keyboard-shortcuts-hint kbd {
+          margin: 0 0.25rem;
+        }
+
+        /* Dark mode support */
+        .dark .keyboard-shortcuts-dialog {
+          background-color: var(--color-surface-dark, #1f2937);
+        }
+
+        .dark .keyboard-shortcuts-title,
+        .dark .keyboard-shortcut-description {
+          color: var(--color-text-primary-dark, #f9fafb);
+        }
+
+        .dark .keyboard-shortcut-category-title,
+        .dark .keyboard-shortcuts-hint {
+          color: var(--color-text-muted-dark, #9ca3af);
+        }
+
+        .dark .keyboard-shortcut-key {
+          background-color: var(--color-kbd-bg-dark, #374151);
+          border-color: var(--color-kbd-border-dark, #4b5563);
+          color: var(--color-text-secondary-dark, #e5e7eb);
+        }
+
+        .dark .keyboard-shortcuts-close-button {
+          color: var(--color-text-secondary-dark, #9ca3af);
+        }
+
+        .dark .keyboard-shortcuts-close-button:hover {
+          background-color: var(--color-hover-dark, #374151);
+          color: var(--color-text-primary-dark, #f9fafb);
+        }
+
+        .dark .keyboard-shortcuts-header,
+        .dark .keyboard-shortcuts-footer {
+          border-color: var(--color-border-dark, #374151);
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default KeyboardShortcutsDialog;

--- a/web/src/components/KeyboardShortcuts/index.ts
+++ b/web/src/components/KeyboardShortcuts/index.ts
@@ -1,0 +1,12 @@
+/**
+ * KeyboardShortcuts Components
+ *
+ * Components for displaying and managing keyboard shortcuts.
+ *
+ * @module components/KeyboardShortcuts
+ */
+
+export {
+  KeyboardShortcutsDialog,
+  type KeyboardShortcutsDialogProps,
+} from './KeyboardShortcutsDialog';

--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -13,3 +13,14 @@ export {
   type SwipeEvent,
   type SwipeGestureCallbacks,
 } from './useSwipeGesture';
+
+export {
+  useKeyboardShortcuts,
+  getShortcutForAction,
+  getShortcutsByCategory,
+  SHORTCUT_DEFINITIONS,
+  type ShortcutAction,
+  type ShortcutDefinition,
+  type ShortcutCallbacks,
+  type KeyboardShortcutsOptions,
+} from './useKeyboardShortcuts';

--- a/web/src/hooks/useKeyboardShortcuts.test.ts
+++ b/web/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Tests for useKeyboardShortcuts Hook
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useKeyboardShortcuts,
+  SHORTCUT_DEFINITIONS,
+  getShortcutForAction,
+  getShortcutsByCategory,
+  type ShortcutCallbacks,
+} from './useKeyboardShortcuts';
+
+describe('useKeyboardShortcuts', () => {
+  beforeEach(() => {
+    // Clear any existing event listeners
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createKeyboardEvent = (
+    key: string,
+    options: Partial<KeyboardEventInit> = {}
+  ): KeyboardEvent => {
+    return new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...options,
+    });
+  };
+
+  const dispatchKeydown = (
+    key: string,
+    options: Partial<KeyboardEventInit> = {}
+  ): void => {
+    const event = createKeyboardEvent(key, options);
+    document.dispatchEvent(event);
+  };
+
+  describe('space key - play/pause', () => {
+    it('calls onPlayPause when Space is pressed', () => {
+      const onPlayPause = vi.fn();
+      const callbacks: ShortcutCallbacks = { onPlayPause };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown(' ');
+      });
+
+      expect(onPlayPause).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onPlayPause when Space is pressed with modifiers', () => {
+      const onPlayPause = vi.fn();
+      const callbacks: ShortcutCallbacks = { onPlayPause };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown(' ', { metaKey: true });
+      });
+
+      expect(onPlayPause).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Escape key - stop', () => {
+    it('calls onStop when Escape is pressed', () => {
+      const onStop = vi.fn();
+      const callbacks: ShortcutCallbacks = { onStop };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('Escape');
+      });
+
+      expect(onStop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Cmd+Enter - generate melody', () => {
+    it('calls onGenerateMelody when Cmd+Enter is pressed', () => {
+      const onGenerateMelody = vi.fn();
+      const callbacks: ShortcutCallbacks = { onGenerateMelody };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('Enter', { metaKey: true });
+      });
+
+      expect(onGenerateMelody).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onGenerateMelody when Enter is pressed without Cmd', () => {
+      const onGenerateMelody = vi.fn();
+      const callbacks: ShortcutCallbacks = { onGenerateMelody };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('Enter');
+      });
+
+      expect(onGenerateMelody).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Cmd+Z - undo', () => {
+    it('calls onUndo when Cmd+Z is pressed', () => {
+      const onUndo = vi.fn();
+      const callbacks: ShortcutCallbacks = { onUndo };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('z', { metaKey: true });
+      });
+
+      expect(onUndo).toHaveBeenCalledTimes(1);
+    });
+
+    it('is case-insensitive for letter keys', () => {
+      const onUndo = vi.fn();
+      const callbacks: ShortcutCallbacks = { onUndo };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('Z', { metaKey: true });
+      });
+
+      expect(onUndo).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Cmd+Shift+Z - redo', () => {
+    it('calls onRedo when Cmd+Shift+Z is pressed', () => {
+      const onRedo = vi.fn();
+      const callbacks: ShortcutCallbacks = { onRedo };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('z', { metaKey: true, shiftKey: true });
+      });
+
+      expect(onRedo).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onUndo when Shift is held', () => {
+      const onUndo = vi.fn();
+      const onRedo = vi.fn();
+      const callbacks: ShortcutCallbacks = { onUndo, onRedo };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('z', { metaKey: true, shiftKey: true });
+      });
+
+      expect(onUndo).not.toHaveBeenCalled();
+      expect(onRedo).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Cmd+S - save', () => {
+    it('calls onSave when Cmd+S is pressed', () => {
+      const onSave = vi.fn();
+      const callbacks: ShortcutCallbacks = { onSave };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('s', { metaKey: true });
+      });
+
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('R key - toggle recording', () => {
+    it('calls onToggleRecording when R is pressed', () => {
+      const onToggleRecording = vi.fn();
+      const callbacks: ShortcutCallbacks = { onToggleRecording };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('r');
+      });
+
+      expect(onToggleRecording).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onToggleRecording when R is pressed with Cmd', () => {
+      const onToggleRecording = vi.fn();
+      const callbacks: ShortcutCallbacks = { onToggleRecording };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('r', { metaKey: true });
+      });
+
+      expect(onToggleRecording).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Tab navigation', () => {
+    it('calls onNavigateNext when Tab is pressed', () => {
+      const onNavigateNext = vi.fn();
+      const callbacks: ShortcutCallbacks = { onNavigateNext };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('Tab');
+      });
+
+      expect(onNavigateNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onNavigatePrev when Shift+Tab is pressed', () => {
+      const onNavigatePrev = vi.fn();
+      const callbacks: ShortcutCallbacks = { onNavigatePrev };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('Tab', { shiftKey: true });
+      });
+
+      expect(onNavigatePrev).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('? key - show help', () => {
+    it('calls onShowHelp when ? is pressed', () => {
+      const onShowHelp = vi.fn();
+      const callbacks: ShortcutCallbacks = { onShowHelp };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      act(() => {
+        dispatchKeydown('?');
+      });
+
+      expect(onShowHelp).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('enabled option', () => {
+    it('does not call callbacks when disabled', () => {
+      const onPlayPause = vi.fn();
+      const callbacks: ShortcutCallbacks = { onPlayPause };
+
+      renderHook(() =>
+        useKeyboardShortcuts(callbacks, { enabled: false })
+      );
+
+      act(() => {
+        dispatchKeydown(' ');
+      });
+
+      expect(onPlayPause).not.toHaveBeenCalled();
+    });
+
+    it('calls callbacks when enabled', () => {
+      const onPlayPause = vi.fn();
+      const callbacks: ShortcutCallbacks = { onPlayPause };
+
+      renderHook(() =>
+        useKeyboardShortcuts(callbacks, { enabled: true })
+      );
+
+      act(() => {
+        dispatchKeydown(' ');
+      });
+
+      expect(onPlayPause).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('text input handling', () => {
+    it('ignores shortcuts when text input is focused', () => {
+      const onPlayPause = vi.fn();
+      const callbacks: ShortcutCallbacks = { onPlayPause };
+
+      // Create and focus a text input
+      const input = document.createElement('input');
+      input.type = 'text';
+      document.body.appendChild(input);
+      input.focus();
+
+      renderHook(() =>
+        useKeyboardShortcuts(callbacks, { disableInTextInput: true })
+      );
+
+      act(() => {
+        dispatchKeydown(' ');
+      });
+
+      expect(onPlayPause).not.toHaveBeenCalled();
+
+      // Cleanup
+      input.blur();
+      document.body.removeChild(input);
+    });
+
+    it('ignores shortcuts when textarea is focused', () => {
+      const onPlayPause = vi.fn();
+      const callbacks: ShortcutCallbacks = { onPlayPause };
+
+      // Create and focus a textarea
+      const textarea = document.createElement('textarea');
+      document.body.appendChild(textarea);
+      textarea.focus();
+
+      renderHook(() =>
+        useKeyboardShortcuts(callbacks, { disableInTextInput: true })
+      );
+
+      act(() => {
+        dispatchKeydown(' ');
+      });
+
+      expect(onPlayPause).not.toHaveBeenCalled();
+
+      // Cleanup
+      textarea.blur();
+      document.body.removeChild(textarea);
+    });
+
+    it('allows Escape even when text input is focused', () => {
+      const onStop = vi.fn();
+      const callbacks: ShortcutCallbacks = { onStop };
+
+      // Create and focus a text input
+      const input = document.createElement('input');
+      input.type = 'text';
+      document.body.appendChild(input);
+      input.focus();
+
+      renderHook(() =>
+        useKeyboardShortcuts(callbacks, { disableInTextInput: true })
+      );
+
+      act(() => {
+        dispatchKeydown('Escape');
+      });
+
+      expect(onStop).toHaveBeenCalledTimes(1);
+
+      // Cleanup
+      input.blur();
+      document.body.removeChild(input);
+    });
+
+    it('allows Cmd+S even when text input is focused', () => {
+      const onSave = vi.fn();
+      const callbacks: ShortcutCallbacks = { onSave };
+
+      // Create and focus a text input
+      const input = document.createElement('input');
+      input.type = 'text';
+      document.body.appendChild(input);
+      input.focus();
+
+      renderHook(() =>
+        useKeyboardShortcuts(callbacks, { disableInTextInput: true })
+      );
+
+      act(() => {
+        dispatchKeydown('s', { metaKey: true });
+      });
+
+      expect(onSave).toHaveBeenCalledTimes(1);
+
+      // Cleanup
+      input.blur();
+      document.body.removeChild(input);
+    });
+
+    it('allows ? even when text input is focused', () => {
+      const onShowHelp = vi.fn();
+      const callbacks: ShortcutCallbacks = { onShowHelp };
+
+      // Create and focus a text input
+      const input = document.createElement('input');
+      input.type = 'text';
+      document.body.appendChild(input);
+      input.focus();
+
+      renderHook(() =>
+        useKeyboardShortcuts(callbacks, { disableInTextInput: true })
+      );
+
+      act(() => {
+        dispatchKeydown('?');
+      });
+
+      expect(onShowHelp).toHaveBeenCalledTimes(1);
+
+      // Cleanup
+      input.blur();
+      document.body.removeChild(input);
+    });
+
+    it('respects shortcuts when disableInTextInput is false', () => {
+      const onPlayPause = vi.fn();
+      const callbacks: ShortcutCallbacks = { onPlayPause };
+
+      // Create and focus a text input
+      const input = document.createElement('input');
+      input.type = 'text';
+      document.body.appendChild(input);
+      input.focus();
+
+      renderHook(() =>
+        useKeyboardShortcuts(callbacks, { disableInTextInput: false })
+      );
+
+      act(() => {
+        dispatchKeydown(' ');
+      });
+
+      expect(onPlayPause).toHaveBeenCalledTimes(1);
+
+      // Cleanup
+      input.blur();
+      document.body.removeChild(input);
+    });
+  });
+
+  describe('event prevention', () => {
+    it('prevents default when shortcut is handled', () => {
+      const onPlayPause = vi.fn();
+      const callbacks: ShortcutCallbacks = { onPlayPause };
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      const event = createKeyboardEvent(' ');
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+      act(() => {
+        document.dispatchEvent(event);
+      });
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('does not prevent default when no callback is provided', () => {
+      const callbacks: ShortcutCallbacks = {};
+
+      renderHook(() => useKeyboardShortcuts(callbacks));
+
+      const event = createKeyboardEvent(' ');
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+      act(() => {
+        document.dispatchEvent(event);
+      });
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('callback updates', () => {
+    it('uses the latest callback when called', () => {
+      const onPlayPause1 = vi.fn();
+      const onPlayPause2 = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ callbacks }) => useKeyboardShortcuts(callbacks),
+        {
+          initialProps: { callbacks: { onPlayPause: onPlayPause1 } },
+        }
+      );
+
+      // Update the callback
+      rerender({ callbacks: { onPlayPause: onPlayPause2 } });
+
+      act(() => {
+        dispatchKeydown(' ');
+      });
+
+      expect(onPlayPause1).not.toHaveBeenCalled();
+      expect(onPlayPause2).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('getShortcutForAction', () => {
+  it('returns the shortcut for a valid action', () => {
+    const shortcut = getShortcutForAction('playPause');
+    expect(shortcut).toBeDefined();
+    expect(shortcut?.key).toBe(' ');
+  });
+
+  it('returns undefined for an invalid action', () => {
+    // @ts-expect-error - Testing invalid action
+    const shortcut = getShortcutForAction('invalidAction');
+    expect(shortcut).toBeUndefined();
+  });
+});
+
+describe('getShortcutsByCategory', () => {
+  it('returns shortcuts organized by category', () => {
+    const categories = getShortcutsByCategory();
+
+    expect(categories).toHaveProperty('Playback');
+    expect(categories).toHaveProperty('Creation');
+    expect(categories).toHaveProperty('Editing');
+    expect(categories).toHaveProperty('Navigation');
+  });
+
+  it('includes playPause and stop in Playback category', () => {
+    const categories = getShortcutsByCategory();
+    const playbackActions = categories.Playback.map((s) => s.action);
+
+    expect(playbackActions).toContain('playPause');
+    expect(playbackActions).toContain('stop');
+  });
+
+  it('includes generateMelody and toggleRecording in Creation category', () => {
+    const categories = getShortcutsByCategory();
+    const creationActions = categories.Creation.map((s) => s.action);
+
+    expect(creationActions).toContain('generateMelody');
+    expect(creationActions).toContain('toggleRecording');
+  });
+
+  it('includes undo, redo, and save in Editing category', () => {
+    const categories = getShortcutsByCategory();
+    const editingActions = categories.Editing.map((s) => s.action);
+
+    expect(editingActions).toContain('undo');
+    expect(editingActions).toContain('redo');
+    expect(editingActions).toContain('save');
+  });
+
+  it('includes navigation shortcuts in Navigation category', () => {
+    const categories = getShortcutsByCategory();
+    const navigationActions = categories.Navigation.map((s) => s.action);
+
+    expect(navigationActions).toContain('navigateNext');
+    expect(navigationActions).toContain('navigatePrev');
+    expect(navigationActions).toContain('showHelp');
+  });
+});
+
+describe('SHORTCUT_DEFINITIONS', () => {
+  it('contains all expected shortcuts', () => {
+    const actions = SHORTCUT_DEFINITIONS.map((s) => s.action);
+
+    expect(actions).toContain('playPause');
+    expect(actions).toContain('stop');
+    expect(actions).toContain('generateMelody');
+    expect(actions).toContain('undo');
+    expect(actions).toContain('redo');
+    expect(actions).toContain('save');
+    expect(actions).toContain('toggleRecording');
+    expect(actions).toContain('navigateNext');
+    expect(actions).toContain('navigatePrev');
+    expect(actions).toContain('showHelp');
+  });
+
+  it('has descriptions for all shortcuts', () => {
+    for (const shortcut of SHORTCUT_DEFINITIONS) {
+      expect(shortcut.description).toBeTruthy();
+    }
+  });
+
+  it('has key labels for all shortcuts', () => {
+    for (const shortcut of SHORTCUT_DEFINITIONS) {
+      expect(shortcut.keyLabel).toBeTruthy();
+    }
+  });
+});

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,410 @@
+/**
+ * useKeyboardShortcuts Hook
+ *
+ * Provides global keyboard shortcut handling for the Ghost Note application.
+ * Implements shortcuts for playback, recording, melody generation, and navigation.
+ *
+ * @module hooks/useKeyboardShortcuts
+ */
+
+import { useEffect, useCallback, useRef } from 'react';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[useKeyboardShortcuts] ${message}`, ...args);
+  }
+};
+
+/**
+ * Shortcut action identifiers
+ */
+export type ShortcutAction =
+  | 'playPause'
+  | 'stop'
+  | 'generateMelody'
+  | 'undo'
+  | 'redo'
+  | 'save'
+  | 'toggleRecording'
+  | 'navigateNext'
+  | 'navigatePrev'
+  | 'showHelp';
+
+/**
+ * Definition of a keyboard shortcut
+ */
+export interface ShortcutDefinition {
+  /** Unique action identifier */
+  action: ShortcutAction;
+  /** The key code (e.g., 'Space', 'Escape', 'Enter') */
+  key: string;
+  /** Whether Cmd/Ctrl is required */
+  metaKey?: boolean;
+  /** Whether Shift is required */
+  shiftKey?: boolean;
+  /** Whether Alt is required */
+  altKey?: boolean;
+  /** Human-readable description */
+  description: string;
+  /** Human-readable key label for display */
+  keyLabel: string;
+}
+
+/**
+ * Callbacks for shortcut actions
+ */
+export interface ShortcutCallbacks {
+  onPlayPause?: () => void;
+  onStop?: () => void;
+  onGenerateMelody?: () => void;
+  onUndo?: () => void;
+  onRedo?: () => void;
+  onSave?: () => void;
+  onToggleRecording?: () => void;
+  onNavigateNext?: () => void;
+  onNavigatePrev?: () => void;
+  onShowHelp?: () => void;
+}
+
+/**
+ * Options for keyboard shortcut behavior
+ */
+export interface KeyboardShortcutsOptions {
+  /** Whether shortcuts are enabled (default: true) */
+  enabled?: boolean;
+  /** Whether to disable shortcuts when in text input (default: true) */
+  disableInTextInput?: boolean;
+}
+
+/**
+ * All available keyboard shortcuts with their definitions
+ */
+export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
+  {
+    action: 'playPause',
+    key: ' ',
+    description: 'Play/Pause melody playback',
+    keyLabel: 'Space',
+  },
+  {
+    action: 'stop',
+    key: 'Escape',
+    description: 'Stop playback',
+    keyLabel: 'Esc',
+  },
+  {
+    action: 'generateMelody',
+    key: 'Enter',
+    metaKey: true,
+    description: 'Generate melody',
+    keyLabel: '⌘+Enter',
+  },
+  {
+    action: 'undo',
+    key: 'z',
+    metaKey: true,
+    description: 'Undo last change',
+    keyLabel: '⌘+Z',
+  },
+  {
+    action: 'redo',
+    key: 'z',
+    metaKey: true,
+    shiftKey: true,
+    description: 'Redo last change',
+    keyLabel: '⌘+Shift+Z',
+  },
+  {
+    action: 'save',
+    key: 's',
+    metaKey: true,
+    description: 'Save/Export',
+    keyLabel: '⌘+S',
+  },
+  {
+    action: 'toggleRecording',
+    key: 'r',
+    description: 'Start/Stop recording',
+    keyLabel: 'R',
+  },
+  {
+    action: 'navigateNext',
+    key: 'Tab',
+    description: 'Navigate to next section',
+    keyLabel: 'Tab',
+  },
+  {
+    action: 'navigatePrev',
+    key: 'Tab',
+    shiftKey: true,
+    description: 'Navigate to previous section',
+    keyLabel: 'Shift+Tab',
+  },
+  {
+    action: 'showHelp',
+    key: '?',
+    description: 'Show keyboard shortcuts',
+    keyLabel: '?',
+  },
+];
+
+/**
+ * Check if the current focus is on a text input element
+ */
+function isTextInputFocused(): boolean {
+  const activeElement = document.activeElement;
+  if (!activeElement) return false;
+
+  const tagName = activeElement.tagName.toLowerCase();
+
+  // Check if it's a text input field
+  if (tagName === 'input') {
+    const inputType = (activeElement as HTMLInputElement).type.toLowerCase();
+    const textTypes = [
+      'text',
+      'password',
+      'email',
+      'number',
+      'search',
+      'tel',
+      'url',
+    ];
+    return textTypes.includes(inputType);
+  }
+
+  // Check for textarea or contenteditable
+  if (tagName === 'textarea') return true;
+  if ((activeElement as HTMLElement).isContentEditable) return true;
+
+  return false;
+}
+
+/**
+ * Check if a keyboard event matches a shortcut definition
+ */
+function matchesShortcut(
+  event: KeyboardEvent,
+  shortcut: ShortcutDefinition
+): boolean {
+  // Check key (case-insensitive for letters)
+  const eventKey = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+  const shortcutKey = shortcut.key.length === 1 ? shortcut.key.toLowerCase() : shortcut.key;
+
+  if (eventKey !== shortcutKey) {
+    return false;
+  }
+
+  // Check modifier keys
+  // Support both metaKey (Mac) and ctrlKey (Windows/Linux) for command shortcuts
+  // This allows shortcuts to work cross-platform
+  const hasCommandModifier = event.metaKey || event.ctrlKey;
+
+  if (shortcut.metaKey && !hasCommandModifier) return false;
+  if (!shortcut.metaKey && hasCommandModifier) return false;
+
+  if (shortcut.shiftKey && !event.shiftKey) return false;
+  if (!shortcut.shiftKey && event.shiftKey && shortcut.key !== '?') return false;
+
+  if (shortcut.altKey && !event.altKey) return false;
+  if (!shortcut.altKey && event.altKey) return false;
+
+  return true;
+}
+
+/**
+ * Get the shortcut definition for an action
+ */
+export function getShortcutForAction(action: ShortcutAction): ShortcutDefinition | undefined {
+  return SHORTCUT_DEFINITIONS.find((s) => s.action === action);
+}
+
+/**
+ * Get a grouped list of shortcuts for display
+ */
+export function getShortcutsByCategory(): Record<string, ShortcutDefinition[]> {
+  return {
+    Playback: SHORTCUT_DEFINITIONS.filter((s) =>
+      ['playPause', 'stop'].includes(s.action)
+    ),
+    Creation: SHORTCUT_DEFINITIONS.filter((s) =>
+      ['generateMelody', 'toggleRecording'].includes(s.action)
+    ),
+    Editing: SHORTCUT_DEFINITIONS.filter((s) =>
+      ['undo', 'redo', 'save'].includes(s.action)
+    ),
+    Navigation: SHORTCUT_DEFINITIONS.filter((s) =>
+      ['navigateNext', 'navigatePrev', 'showHelp'].includes(s.action)
+    ),
+  };
+}
+
+/**
+ * Hook for handling global keyboard shortcuts.
+ *
+ * Provides keyboard shortcut handling with the following features:
+ * - Automatic disabling when focused on text inputs
+ * - Cross-platform modifier key support (Cmd on Mac, Ctrl on Windows)
+ * - Configurable enable/disable state
+ * - Prevents default browser behavior for handled shortcuts
+ *
+ * @param callbacks - Callback functions for each shortcut action
+ * @param options - Configuration options
+ *
+ * @example
+ * ```tsx
+ * useKeyboardShortcuts({
+ *   onPlayPause: () => togglePlayback(),
+ *   onStop: () => stopPlayback(),
+ *   onShowHelp: () => setShowHelpDialog(true),
+ * });
+ * ```
+ */
+export function useKeyboardShortcuts(
+  callbacks: ShortcutCallbacks,
+  options: KeyboardShortcutsOptions = {}
+): void {
+  const { enabled = true, disableInTextInput = true } = options;
+
+  // Store callbacks in ref to avoid re-adding listeners on every callback change
+  const callbacksRef = useRef(callbacks);
+
+  // Update the ref in an effect to comply with React rules
+  useEffect(() => {
+    callbacksRef.current = callbacks;
+  });
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent): void => {
+      // Check if shortcuts are enabled
+      if (!enabled) {
+        log('Shortcuts disabled, ignoring keydown');
+        return;
+      }
+
+      // Check if focused on text input
+      if (disableInTextInput && isTextInputFocused()) {
+        log('Text input focused, ignoring shortcut');
+        // Exception: still allow Escape, Cmd+S, and ? even in text inputs
+        const isAllowedInInput =
+          event.key === 'Escape' ||
+          (event.key === 's' && (event.metaKey || event.ctrlKey)) ||
+          event.key === '?';
+        if (!isAllowedInInput) {
+          return;
+        }
+      }
+
+      log('KeyDown event:', {
+        key: event.key,
+        metaKey: event.metaKey,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+      });
+
+      // Find matching shortcut
+      for (const shortcut of SHORTCUT_DEFINITIONS) {
+        if (matchesShortcut(event, shortcut)) {
+          log('Matched shortcut:', shortcut.action);
+
+          // Get the callback for this action
+          const cb = callbacksRef.current;
+          let handled = false;
+
+          switch (shortcut.action) {
+            case 'playPause':
+              if (cb.onPlayPause) {
+                cb.onPlayPause();
+                handled = true;
+              }
+              break;
+            case 'stop':
+              if (cb.onStop) {
+                cb.onStop();
+                handled = true;
+              }
+              break;
+            case 'generateMelody':
+              if (cb.onGenerateMelody) {
+                cb.onGenerateMelody();
+                handled = true;
+              }
+              break;
+            case 'undo':
+              if (cb.onUndo) {
+                cb.onUndo();
+                handled = true;
+              }
+              break;
+            case 'redo':
+              if (cb.onRedo) {
+                cb.onRedo();
+                handled = true;
+              }
+              break;
+            case 'save':
+              if (cb.onSave) {
+                cb.onSave();
+                handled = true;
+              }
+              break;
+            case 'toggleRecording':
+              if (cb.onToggleRecording) {
+                cb.onToggleRecording();
+                handled = true;
+              }
+              break;
+            case 'navigateNext':
+              if (cb.onNavigateNext) {
+                cb.onNavigateNext();
+                handled = true;
+              }
+              break;
+            case 'navigatePrev':
+              if (cb.onNavigatePrev) {
+                cb.onNavigatePrev();
+                handled = true;
+              }
+              break;
+            case 'showHelp':
+              if (cb.onShowHelp) {
+                cb.onShowHelp();
+                handled = true;
+              }
+              break;
+          }
+
+          if (handled) {
+            // Prevent default browser behavior (e.g., space scrolling, Cmd+S saving)
+            event.preventDefault();
+            event.stopPropagation();
+            log('Shortcut handled, default prevented');
+          }
+
+          // Only match one shortcut per keypress
+          return;
+        }
+      }
+    },
+    [enabled, disableInTextInput]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      log('Shortcuts disabled, not attaching listener');
+      return;
+    }
+
+    log('Attaching keyboard shortcut listener');
+    document.addEventListener('keydown', handleKeyDown, { capture: true });
+
+    return () => {
+      log('Detaching keyboard shortcut listener');
+      document.removeEventListener('keydown', handleKeyDown, { capture: true });
+    };
+  }, [enabled, handleKeyDown]);
+}
+
+export default useKeyboardShortcuts;


### PR DESCRIPTION
## Summary
- Implemented comprehensive keyboard shortcuts system for Ghost Note
- Created `useKeyboardShortcuts` hook with cross-platform support (Cmd on Mac, Ctrl on Windows)
- Built `KeyboardShortcutsDialog` component showing all shortcuts organized by category

## Changes
- `web/src/hooks/useKeyboardShortcuts.ts` - Main hook for keyboard shortcut handling
- `web/src/hooks/useKeyboardShortcuts.test.ts` - Comprehensive tests (36 test cases)
- `web/src/components/KeyboardShortcuts/KeyboardShortcutsDialog.tsx` - Modal dialog displaying shortcuts
- `web/src/components/KeyboardShortcuts/KeyboardShortcutsDialog.test.tsx` - Tests (21 test cases)
- `web/src/components/KeyboardShortcuts/index.ts` - Module exports
- `web/src/hooks/index.ts` - Added hook exports
- `web/src/App.tsx` - Integrated keyboard shortcuts into main app
- `web/src/App.test.tsx` - Updated mock for new selector

## Shortcuts Implemented
| Shortcut | Action |
|----------|--------|
| Space | Play/Pause melody playback |
| Escape | Stop playback |
| ⌘/Ctrl+Enter | Generate melody |
| ⌘/Ctrl+Z | Undo |
| ⌘/Ctrl+Shift+Z | Redo |
| ⌘/Ctrl+S | Save/Export |
| R | Start/Stop recording |
| Tab | Navigate to next section |
| Shift+Tab | Navigate to previous section |
| ? | Show keyboard shortcuts help |

## Testing
- [x] Unit tests pass (`npm test` - 4099 tests passing)
- [x] Check passes (`npm run check`)
- [x] Shortcuts disabled during text input (except Escape, Save, ?)
- [x] Cross-platform modifier support

## Notes
- Shortcuts are globally enabled when the app loads
- Text input fields automatically disable most shortcuts to prevent conflicts
- Help dialog (?) can be shown from anywhere, even in text fields

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)