### PR TITLE
feat(GH-42): Implement project import/export as JSON

### DIFF
--- a/web/src/lib/project/export.test.ts
+++ b/web/src/lib/project/export.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for project export
+ *
+ * @module lib/project/export.test
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { exportProject, serializeProject } from './export';
+import { CURRENT_SCHEMA_VERSION } from './types';
+import { usePoemStore } from '../../stores/usePoemStore';
+import { useAnalysisStore } from '../../stores/useAnalysisStore';
+import { useMelodyStore } from '../../stores/useMelodyStore';
+import { useRecordingStore } from '../../stores/useRecordingStore';
+
+describe('exportProject', () => {
+  beforeEach(() => {
+    // Reset all stores before each test
+    usePoemStore.getState().reset();
+    useAnalysisStore.getState().reset();
+    useMelodyStore.getState().reset();
+    useRecordingStore.getState().reset();
+
+    // Clear localStorage
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+  });
+
+  describe('basic export', () => {
+    it('should export project with correct schema version', () => {
+      const project = exportProject();
+
+      expect(project.version).toBe(CURRENT_SCHEMA_VERSION);
+    });
+
+    it('should include valid ISO timestamp', () => {
+      const beforeExport = new Date().toISOString();
+      const project = exportProject();
+      const afterExport = new Date().toISOString();
+
+      expect(project.exportedAt).toBeDefined();
+      expect(project.exportedAt >= beforeExport).toBe(true);
+      expect(project.exportedAt <= afterExport).toBe(true);
+    });
+
+    it('should export empty project correctly', () => {
+      const project = exportProject();
+
+      expect(project.poem.original).toBe('');
+      expect(project.poem.versions).toEqual([]);
+      expect(project.poem.currentVersionIndex).toBe(-1);
+      expect(project.analysis).toBeNull();
+      expect(project.melody.data).toBeNull();
+      expect(project.melody.abcNotation).toBeNull();
+      expect(project.recordings).toEqual([]);
+    });
+  });
+
+  describe('poem export', () => {
+    it('should export original poem text', () => {
+      usePoemStore.getState().setPoem('Roses are red\nViolets are blue');
+
+      const project = exportProject();
+
+      expect(project.poem.original).toBe('Roses are red\nViolets are blue');
+    });
+
+    it('should export all lyric versions', () => {
+      usePoemStore.getState().setPoem('Original poem');
+      usePoemStore.getState().addVersion('Version 1', 'First edit');
+      usePoemStore.getState().addVersion('Version 2', 'Second edit');
+
+      const project = exportProject();
+
+      expect(project.poem.versions).toHaveLength(2);
+      expect(project.poem.versions[0].lyrics).toBe('Version 1');
+      expect(project.poem.versions[0].description).toBe('First edit');
+      expect(project.poem.versions[1].lyrics).toBe('Version 2');
+      expect(project.poem.versions[1].description).toBe('Second edit');
+    });
+
+    it('should export current version index', () => {
+      usePoemStore.getState().setPoem('Original');
+      usePoemStore.getState().addVersion('V1');
+      usePoemStore.getState().addVersion('V2');
+      usePoemStore.getState().revertToVersion(0);
+
+      const project = exportProject();
+
+      expect(project.poem.currentVersionIndex).toBe(0);
+    });
+
+    it('should preserve version IDs and timestamps', () => {
+      usePoemStore.getState().setPoem('Original');
+      usePoemStore.getState().addVersion('Modified');
+
+      const originalVersion = usePoemStore.getState().versions[0];
+      const project = exportProject();
+
+      expect(project.poem.versions[0].id).toBe(originalVersion.id);
+      expect(project.poem.versions[0].timestamp).toBe(originalVersion.timestamp);
+    });
+  });
+
+  describe('settings export', () => {
+    it('should export melody settings', () => {
+      useMelodyStore.getState().setTempo(120);
+      useMelodyStore.getState().setVolume(0.5);
+      useMelodyStore.getState().toggleLoop();
+      useMelodyStore.getState().setKey('G');
+      useMelodyStore.getState().setTimeSignature('3/4');
+
+      const project = exportProject();
+
+      expect(project.settings.tempo).toBe(120);
+      expect(project.settings.volume).toBe(0.5);
+      expect(project.settings.loop).toBe(true);
+      expect(project.settings.key).toBe('G');
+      expect(project.settings.timeSignature).toBe('3/4');
+    });
+
+    it('should export default settings when not modified', () => {
+      const project = exportProject();
+
+      expect(project.settings.tempo).toBe(100);
+      expect(project.settings.volume).toBe(0.8);
+      expect(project.settings.loop).toBe(false);
+      expect(project.settings.key).toBe('C');
+      expect(project.settings.timeSignature).toBe('4/4');
+    });
+  });
+
+  describe('melody export', () => {
+    it('should export null melody when not generated', () => {
+      const project = exportProject();
+
+      expect(project.melody.data).toBeNull();
+      expect(project.melody.abcNotation).toBeNull();
+    });
+
+    it('should export ABC notation', () => {
+      const abcNotation = 'X:1\nT:Test\nK:C\nCDEF|';
+      useMelodyStore.getState().setAbcNotation(abcNotation);
+
+      const project = exportProject();
+
+      expect(project.melody.abcNotation).toBe(abcNotation);
+    });
+
+    it('should export full melody data', () => {
+      const melody = {
+        params: {
+          title: 'Test Song',
+          timeSignature: '4/4' as const,
+          defaultNoteLength: '1/8' as const,
+          tempo: 100,
+          key: 'C' as const,
+        },
+        measures: [[{ pitch: 'C', octave: 0, duration: 1 }]],
+        lyrics: [['la']],
+      };
+
+      useMelodyStore.getState().setMelody(melody, 'X:1\nT:Test\nK:C\nC|');
+
+      const project = exportProject();
+
+      expect(project.melody.data).toEqual(melody);
+    });
+  });
+
+  describe('recordings export', () => {
+    it('should export empty recordings array when none exist', () => {
+      const project = exportProject();
+
+      expect(project.recordings).toEqual([]);
+    });
+
+    it('should export recording metadata without blob URLs', () => {
+      useRecordingStore.getState().addTake({
+        id: 'take-1',
+        blobUrl: 'blob:http://localhost/secret-audio',
+        duration: 30.5,
+        timestamp: 1704067200000,
+        name: 'Take 1',
+      });
+
+      const project = exportProject();
+
+      expect(project.recordings).toHaveLength(1);
+      expect(project.recordings[0].id).toBe('take-1');
+      expect(project.recordings[0].duration).toBe(30.5);
+      expect(project.recordings[0].name).toBe('Take 1');
+      // blobUrl should not be in the export
+      expect('blobUrl' in project.recordings[0]).toBe(false);
+    });
+
+    it('should export multiple recordings', () => {
+      useRecordingStore.getState().addTake({
+        id: 'take-1',
+        blobUrl: 'blob:1',
+        duration: 30,
+        timestamp: 1000,
+      });
+      useRecordingStore.getState().addTake({
+        id: 'take-2',
+        blobUrl: 'blob:2',
+        duration: 45,
+        timestamp: 2000,
+        melodyVersionId: 'melody-v1',
+        lyricVersionId: 'lyric-v1',
+      });
+
+      const project = exportProject();
+
+      expect(project.recordings).toHaveLength(2);
+      expect(project.recordings[1].melodyVersionId).toBe('melody-v1');
+      expect(project.recordings[1].lyricVersionId).toBe('lyric-v1');
+    });
+  });
+});
+
+describe('serializeProject', () => {
+  beforeEach(() => {
+    usePoemStore.getState().reset();
+    useAnalysisStore.getState().reset();
+    useMelodyStore.getState().reset();
+    useRecordingStore.getState().reset();
+  });
+
+  it('should serialize to valid JSON string', () => {
+    const project = exportProject();
+    const json = serializeProject(project);
+
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+
+  it('should serialize with pretty formatting by default', () => {
+    const project = exportProject();
+    const json = serializeProject(project);
+
+    // Pretty JSON has newlines
+    expect(json).toContain('\n');
+  });
+
+  it('should serialize without pretty formatting when specified', () => {
+    const project = exportProject();
+    const json = serializeProject(project, false);
+
+    // Compact JSON has no newlines except in string values
+    const lineCount = json.split('\n').length;
+    expect(lineCount).toBe(1);
+  });
+
+  it('should produce parseable JSON that matches original data', () => {
+    usePoemStore.getState().setPoem('Test poem');
+    usePoemStore.getState().addVersion('Modified');
+
+    const project = exportProject();
+    const json = serializeProject(project);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.poem.original).toBe(project.poem.original);
+    expect(parsed.poem.versions[0].lyrics).toBe(project.poem.versions[0].lyrics);
+  });
+});

--- a/web/src/lib/project/export.ts
+++ b/web/src/lib/project/export.ts
@@ -1,0 +1,203 @@
+/**
+ * Ghost Note - Project Export
+ *
+ * Functions for exporting project data to JSON.
+ *
+ * @module lib/project/export
+ */
+
+import { usePoemStore } from '../../stores/usePoemStore';
+import { useAnalysisStore } from '../../stores/useAnalysisStore';
+import { useMelodyStore } from '../../stores/useMelodyStore';
+import { useRecordingStore } from '../../stores/useRecordingStore';
+import type { ProjectData, UserSettings, RecordingMetadata } from './types';
+import { CURRENT_SCHEMA_VERSION, takeToMetadata } from './types';
+
+// =============================================================================
+// Export Functions
+// =============================================================================
+
+/**
+ * Exports the current project state to a ProjectData object.
+ *
+ * @returns Complete project data ready for serialization
+ */
+export function exportProject(): ProjectData {
+  console.log('[Project] Exporting project...');
+
+  // Get state from all stores
+  const poemState = usePoemStore.getState();
+  const analysisState = useAnalysisStore.getState();
+  const melodyState = useMelodyStore.getState();
+  const recordingState = useRecordingStore.getState();
+
+  // Build user settings from melody store
+  const settings: UserSettings = {
+    tempo: melodyState.tempo,
+    volume: melodyState.volume,
+    loop: melodyState.loop,
+    key: melodyState.key,
+    timeSignature: melodyState.timeSignature,
+  };
+
+  // Convert recording takes to metadata (strip blob URLs)
+  const recordings: RecordingMetadata[] = recordingState.takes.map(takeToMetadata);
+
+  // Build the project data
+  const projectData: ProjectData = {
+    version: CURRENT_SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    poem: {
+      original: poemState.original,
+      versions: poemState.versions,
+      currentVersionIndex: poemState.currentVersionIndex,
+    },
+    analysis: analysisState.analysis,
+    melody: {
+      data: melodyState.melody,
+      abcNotation: melodyState.abcNotation,
+    },
+    settings,
+    recordings,
+  };
+
+  console.log('[Project] Export complete:', {
+    hasPoem: projectData.poem.original.length > 0,
+    versionCount: projectData.poem.versions.length,
+    hasAnalysis: projectData.analysis !== null,
+    hasMelody: projectData.melody.data !== null,
+    recordingCount: projectData.recordings.length,
+  });
+
+  return projectData;
+}
+
+/**
+ * Serializes project data to a JSON string.
+ *
+ * @param project - Project data to serialize
+ * @param pretty - Whether to format with indentation (default: true)
+ * @returns JSON string representation
+ */
+export function serializeProject(project: ProjectData, pretty: boolean = true): string {
+  console.log('[Project] Serializing project to JSON...');
+  return JSON.stringify(project, null, pretty ? 2 : undefined);
+}
+
+/**
+ * Downloads the current project as a JSON file.
+ *
+ * @param filename - Optional filename (without extension)
+ */
+export function downloadProjectFile(filename?: string): void {
+  console.log('[Project] Downloading project file...');
+
+  // Export the project data
+  const projectData = exportProject();
+
+  // Serialize to JSON
+  const jsonString = serializeProject(projectData);
+
+  // Generate filename if not provided
+  const finalFilename = generateFilename(filename, projectData);
+
+  // Create blob and download
+  const blob = new Blob([jsonString], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+
+  // Create temporary download link
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = finalFilename;
+
+  // Trigger download
+  document.body.appendChild(link);
+  link.click();
+
+  // Cleanup
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+
+  console.log('[Project] Download triggered:', finalFilename);
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Generates a filename for the project export.
+ *
+ * @param customName - Optional custom filename
+ * @param project - Project data for deriving name from content
+ * @returns Complete filename with .json extension
+ */
+function generateFilename(customName: string | undefined, project: ProjectData): string {
+  if (customName) {
+    // Ensure .json extension
+    return customName.endsWith('.json') ? customName : `${customName}.json`;
+  }
+
+  // Try to derive name from poem content
+  const poemTitle = extractTitleFromPoem(project.poem.original);
+  const timestamp = formatTimestamp(new Date(project.exportedAt));
+
+  if (poemTitle) {
+    return `ghost-note-${sanitizeFilename(poemTitle)}-${timestamp}.json`;
+  }
+
+  return `ghost-note-project-${timestamp}.json`;
+}
+
+/**
+ * Extracts a potential title from the first line of a poem.
+ *
+ * @param poem - The original poem text
+ * @returns Extracted title or undefined
+ */
+function extractTitleFromPoem(poem: string): string | undefined {
+  if (!poem.trim()) return undefined;
+
+  // Get first non-empty line
+  const firstLine = poem
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  if (!firstLine || firstLine.length > 50) return undefined;
+
+  return firstLine;
+}
+
+/**
+ * Sanitizes a string for use in a filename.
+ *
+ * @param str - String to sanitize
+ * @returns Safe filename string
+ */
+function sanitizeFilename(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
+    .replace(/\s+/g, '-') // Replace spaces with dashes
+    .replace(/-+/g, '-') // Collapse multiple dashes
+    .substring(0, 30) // Limit length
+    .replace(/^-|-$/g, ''); // Remove leading/trailing dashes
+}
+
+/**
+ * Formats a timestamp for use in a filename.
+ *
+ * @param date - Date to format
+ * @returns Formatted string (YYYYMMDD-HHMMSS)
+ */
+function formatTimestamp(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+
+  return `${year}${month}${day}-${hours}${minutes}${seconds}`;
+}

--- a/web/src/lib/project/import.test.ts
+++ b/web/src/lib/project/import.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Tests for project import
+ *
+ * @module lib/project/import.test
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { importProject, importProjectFromJson } from './import';
+import { exportProject } from './export';
+import { CURRENT_SCHEMA_VERSION, ProjectImportError } from './types';
+import type { ProjectData } from './types';
+import { usePoemStore } from '../../stores/usePoemStore';
+import { useAnalysisStore } from '../../stores/useAnalysisStore';
+import { useMelodyStore } from '../../stores/useMelodyStore';
+import { useRecordingStore } from '../../stores/useRecordingStore';
+import type { PoemAnalysis } from '../../types/analysis';
+
+// Helper to create a valid project data object
+function createValidProjectData(): ProjectData {
+  return {
+    version: CURRENT_SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    poem: {
+      original: 'Roses are red\nViolets are blue',
+      versions: [
+        {
+          id: 'v_test_abc1234',
+          lyrics: 'Roses are red\nViolets are blue\nSugar is sweet',
+          timestamp: Date.now(),
+          changes: [
+            {
+              type: 'modify',
+              start: 0,
+              end: 28,
+              oldText: 'Roses are red\nViolets are blue',
+              newText: 'Roses are red\nViolets are blue\nSugar is sweet',
+            },
+          ],
+          description: 'Added third line',
+        },
+      ],
+      currentVersionIndex: 0,
+    },
+    analysis: null,
+    melody: {
+      data: null,
+      abcNotation: null,
+    },
+    settings: {
+      tempo: 120,
+      volume: 0.7,
+      loop: true,
+      key: 'G',
+      timeSignature: '3/4',
+    },
+    recordings: [],
+  };
+}
+
+// Create a minimal valid PoemAnalysis for testing
+function createTestAnalysis(): PoemAnalysis {
+  return {
+    meta: { lineCount: 2, stanzaCount: 1, wordCount: 6, syllableCount: 8 },
+    structure: { stanzas: [] },
+    prosody: {
+      meter: {
+        pattern: '0101',
+        detectedMeter: 'iambic',
+        footType: 'iamb',
+        feetPerLine: 2,
+        confidence: 0.8,
+        deviations: [],
+      },
+      rhyme: { scheme: 'AA', rhymeGroups: {}, internalRhymes: [] },
+      regularity: 0.9,
+    },
+    emotion: {
+      overallSentiment: 0.5,
+      arousal: 0.5,
+      dominantEmotions: ['joy'],
+      emotionalArc: [],
+      suggestedMusicParams: { mode: 'major', tempoRange: [80, 120], register: 'middle' },
+    },
+    problems: [],
+    melodySuggestions: {
+      timeSignature: '4/4',
+      tempo: 100,
+      key: 'C',
+      mode: 'major',
+      phraseBreaks: [],
+    },
+  };
+}
+
+describe('importProject', () => {
+  beforeEach(() => {
+    // Reset all stores before each test
+    usePoemStore.getState().reset();
+    useAnalysisStore.getState().reset();
+    useMelodyStore.getState().reset();
+    useRecordingStore.getState().reset();
+
+    // Clear localStorage
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+  });
+
+  describe('basic import', () => {
+    it('should import valid project data', () => {
+      const data = createValidProjectData();
+
+      expect(() => importProject(data)).not.toThrow();
+    });
+
+    it('should throw ProjectImportError for invalid data', () => {
+      const invalidData = { invalid: 'data' } as unknown as ProjectData;
+
+      expect(() => importProject(invalidData)).toThrow(ProjectImportError);
+    });
+
+    it('should clear existing data by default', () => {
+      // Set up existing data
+      usePoemStore.getState().setPoem('Existing poem');
+      usePoemStore.getState().addVersion('Existing version');
+
+      // Import new data
+      const data = createValidProjectData();
+      importProject(data);
+
+      // Check that existing data was replaced
+      const poemState = usePoemStore.getState();
+      expect(poemState.original).toBe(data.poem.original);
+      expect(poemState.versions[0].lyrics).toBe(data.poem.versions[0].lyrics);
+    });
+
+    it('should not clear existing data when clearExisting is false', () => {
+      // Set up existing data
+      usePoemStore.getState().setPoem('Existing poem');
+
+      // Import new data without clearing
+      const data = createValidProjectData();
+      // Note: The import will still overwrite poem data due to how setState works
+      // This option primarily affects the explicit reset() call
+      importProject(data, { clearExisting: false });
+
+      // The poem will still be updated because import overwrites
+      expect(usePoemStore.getState().original).toBe(data.poem.original);
+    });
+  });
+
+  describe('poem import', () => {
+    it('should import original poem text', () => {
+      const data = createValidProjectData();
+      data.poem.original = 'My custom poem text';
+
+      importProject(data);
+
+      expect(usePoemStore.getState().original).toBe('My custom poem text');
+    });
+
+    it('should import all lyric versions', () => {
+      const data = createValidProjectData();
+      data.poem.versions = [
+        { id: 'v1', lyrics: 'Version 1', timestamp: 1000, changes: [] },
+        { id: 'v2', lyrics: 'Version 2', timestamp: 2000, changes: [] },
+        { id: 'v3', lyrics: 'Version 3', timestamp: 3000, changes: [] },
+      ];
+
+      importProject(data);
+
+      const versions = usePoemStore.getState().versions;
+      expect(versions).toHaveLength(3);
+      expect(versions[0].lyrics).toBe('Version 1');
+      expect(versions[1].lyrics).toBe('Version 2');
+      expect(versions[2].lyrics).toBe('Version 3');
+    });
+
+    it('should restore current version index', () => {
+      const data = createValidProjectData();
+      data.poem.versions = [
+        { id: 'v1', lyrics: 'V1', timestamp: 1000, changes: [] },
+        { id: 'v2', lyrics: 'V2', timestamp: 2000, changes: [] },
+      ];
+      data.poem.currentVersionIndex = 1;
+
+      importProject(data);
+
+      expect(usePoemStore.getState().currentVersionIndex).toBe(1);
+    });
+
+    it('should preserve version IDs', () => {
+      const data = createValidProjectData();
+      const testId = 'custom-id-12345';
+      data.poem.versions = [{ id: testId, lyrics: 'Test', timestamp: 1000, changes: [] }];
+
+      importProject(data);
+
+      expect(usePoemStore.getState().versions[0].id).toBe(testId);
+    });
+  });
+
+  describe('settings import', () => {
+    it('should import tempo setting', () => {
+      const data = createValidProjectData();
+      data.settings.tempo = 150;
+
+      importProject(data);
+
+      expect(useMelodyStore.getState().tempo).toBe(150);
+    });
+
+    it('should import volume setting', () => {
+      const data = createValidProjectData();
+      data.settings.volume = 0.3;
+
+      importProject(data);
+
+      expect(useMelodyStore.getState().volume).toBe(0.3);
+    });
+
+    it('should import loop setting when true', () => {
+      const data = createValidProjectData();
+      data.settings.loop = true;
+
+      // Ensure loop starts as false
+      const initialLoop = useMelodyStore.getState().loop;
+      expect(initialLoop).toBe(false);
+
+      importProject(data);
+
+      expect(useMelodyStore.getState().loop).toBe(true);
+    });
+
+    it('should import key setting', () => {
+      const data = createValidProjectData();
+      data.settings.key = 'Am';
+
+      importProject(data);
+
+      expect(useMelodyStore.getState().key).toBe('Am');
+    });
+
+    it('should import time signature setting', () => {
+      const data = createValidProjectData();
+      data.settings.timeSignature = '6/8';
+
+      importProject(data);
+
+      expect(useMelodyStore.getState().timeSignature).toBe('6/8');
+    });
+
+    it('should handle invalid key gracefully', () => {
+      const data = createValidProjectData();
+      data.settings.key = 'InvalidKey';
+
+      // Should not throw
+      expect(() => importProject(data)).not.toThrow();
+
+      // Key should remain at default since InvalidKey is not in validKeys
+      expect(useMelodyStore.getState().key).toBe('C');
+    });
+  });
+
+  describe('analysis import', () => {
+    it('should import null analysis', () => {
+      const data = createValidProjectData();
+      data.analysis = null;
+
+      importProject(data);
+
+      expect(useAnalysisStore.getState().analysis).toBeNull();
+    });
+
+    it('should import analysis data', () => {
+      const data = createValidProjectData();
+      data.analysis = createTestAnalysis();
+
+      importProject(data);
+
+      const analysis = useAnalysisStore.getState().analysis;
+      expect(analysis).not.toBeNull();
+      expect(analysis?.meta.lineCount).toBe(2);
+      expect(analysis?.emotion.dominantEmotions).toContain('joy');
+    });
+
+    it('should skip analysis import when includeAnalysis is false', () => {
+      const data = createValidProjectData();
+      data.analysis = createTestAnalysis();
+
+      importProject(data, { includeAnalysis: false });
+
+      expect(useAnalysisStore.getState().analysis).toBeNull();
+    });
+  });
+
+  describe('melody import', () => {
+    it('should import null melody', () => {
+      const data = createValidProjectData();
+      data.melody = { data: null, abcNotation: null };
+
+      importProject(data);
+
+      expect(useMelodyStore.getState().melody).toBeNull();
+      expect(useMelodyStore.getState().abcNotation).toBeNull();
+    });
+
+    it('should import ABC notation only', () => {
+      const data = createValidProjectData();
+      data.melody = { data: null, abcNotation: 'X:1\nT:Test\nK:C\nCDEF|' };
+
+      importProject(data);
+
+      expect(useMelodyStore.getState().abcNotation).toBe('X:1\nT:Test\nK:C\nCDEF|');
+    });
+
+    it('should import full melody data', () => {
+      const data = createValidProjectData();
+      const melody = {
+        params: {
+          title: 'Test',
+          timeSignature: '4/4' as const,
+          defaultNoteLength: '1/8' as const,
+          tempo: 100,
+          key: 'C' as const,
+        },
+        measures: [[{ pitch: 'C', octave: 0, duration: 1 }]],
+        lyrics: [['la']],
+      };
+      data.melody = { data: melody, abcNotation: 'X:1\nK:C\nC|' };
+
+      importProject(data);
+
+      const state = useMelodyStore.getState();
+      expect(state.melody).toEqual(melody);
+      expect(state.abcNotation).toBe('X:1\nK:C\nC|');
+    });
+
+    it('should skip melody import when includeMelody is false', () => {
+      const data = createValidProjectData();
+      data.melody = { data: null, abcNotation: 'X:1\nK:C\nC|' };
+
+      importProject(data, { includeMelody: false });
+
+      expect(useMelodyStore.getState().abcNotation).toBeNull();
+    });
+  });
+
+  describe('recordings import', () => {
+    it('should import empty recordings array', () => {
+      const data = createValidProjectData();
+      data.recordings = [];
+
+      importProject(data);
+
+      expect(useRecordingStore.getState().takes).toHaveLength(0);
+    });
+
+    it('should import recording metadata', () => {
+      const data = createValidProjectData();
+      data.recordings = [
+        {
+          id: 'rec-1',
+          duration: 30.5,
+          timestamp: 1704067200000,
+          name: 'Take 1',
+        },
+        {
+          id: 'rec-2',
+          duration: 45,
+          timestamp: 1704067300000,
+          melodyVersionId: 'melody-v1',
+          lyricVersionId: 'lyric-v1',
+        },
+      ];
+
+      importProject(data);
+
+      const takes = useRecordingStore.getState().takes;
+      expect(takes).toHaveLength(2);
+      expect(takes[0].id).toBe('rec-1');
+      expect(takes[0].duration).toBe(30.5);
+      expect(takes[0].name).toBe('Take 1');
+      expect(takes[0].blobUrl).toBe(''); // Blob URL should be empty
+      expect(takes[1].melodyVersionId).toBe('melody-v1');
+    });
+
+    it('should skip recordings import when includeRecordings is false', () => {
+      const data = createValidProjectData();
+      data.recordings = [{ id: 'rec-1', duration: 30, timestamp: 1000 }];
+
+      importProject(data, { includeRecordings: false });
+
+      expect(useRecordingStore.getState().takes).toHaveLength(0);
+    });
+  });
+
+  describe('round-trip export/import', () => {
+    it('should preserve poem data through export/import cycle', () => {
+      // Set up initial data
+      usePoemStore.getState().setPoem('Original poem text');
+      usePoemStore.getState().addVersion('Modified poem', 'First edit');
+
+      // Export
+      const exported = exportProject();
+
+      // Reset stores
+      usePoemStore.getState().reset();
+
+      // Import
+      importProject(exported);
+
+      // Verify
+      const state = usePoemStore.getState();
+      expect(state.original).toBe('Original poem text');
+      expect(state.versions[0].lyrics).toBe('Modified poem');
+      expect(state.versions[0].description).toBe('First edit');
+    });
+
+    it('should preserve settings through export/import cycle', () => {
+      // Set up settings
+      useMelodyStore.getState().setTempo(140);
+      useMelodyStore.getState().setVolume(0.6);
+      useMelodyStore.getState().toggleLoop();
+
+      // Export
+      const exported = exportProject();
+
+      // Reset
+      useMelodyStore.getState().reset();
+
+      // Import
+      importProject(exported);
+
+      // Verify
+      const state = useMelodyStore.getState();
+      expect(state.tempo).toBe(140);
+      expect(state.volume).toBe(0.6);
+      expect(state.loop).toBe(true);
+    });
+  });
+});
+
+describe('importProjectFromJson', () => {
+  beforeEach(() => {
+    usePoemStore.getState().reset();
+    useAnalysisStore.getState().reset();
+    useMelodyStore.getState().reset();
+    useRecordingStore.getState().reset();
+
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    }
+  });
+
+  it('should import valid JSON string', () => {
+    const data = createValidProjectData();
+    const json = JSON.stringify(data);
+
+    expect(() => importProjectFromJson(json)).not.toThrow();
+
+    expect(usePoemStore.getState().original).toBe(data.poem.original);
+  });
+
+  it('should throw for invalid JSON', () => {
+    expect(() => importProjectFromJson('not valid json')).toThrow(ProjectImportError);
+  });
+
+  it('should throw for valid JSON but invalid project structure', () => {
+    expect(() => importProjectFromJson('{"foo": "bar"}')).toThrow(ProjectImportError);
+  });
+
+  it('should include parse errors in exception', () => {
+    try {
+      importProjectFromJson('invalid json {');
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProjectImportError);
+      expect((error as ProjectImportError).errors.length).toBeGreaterThan(0);
+      expect((error as ProjectImportError).errors.some((e) => e.includes('Invalid JSON'))).toBe(
+        true
+      );
+    }
+  });
+
+  it('should pass options to importProject', () => {
+    const data = createValidProjectData();
+    data.analysis = createTestAnalysis();
+    const json = JSON.stringify(data);
+
+    importProjectFromJson(json, { includeAnalysis: false });
+
+    expect(useAnalysisStore.getState().analysis).toBeNull();
+  });
+});

--- a/web/src/lib/project/import.ts
+++ b/web/src/lib/project/import.ts
@@ -1,0 +1,308 @@
+/**
+ * Ghost Note - Project Import
+ *
+ * Functions for importing project data from JSON.
+ *
+ * @module lib/project/import
+ */
+
+import { usePoemStore } from '../../stores/usePoemStore';
+import { useAnalysisStore } from '../../stores/useAnalysisStore';
+import { useMelodyStore } from '../../stores/useMelodyStore';
+import { useRecordingStore } from '../../stores/useRecordingStore';
+import type { ProjectData } from './types';
+import { ProjectImportError, metadataToTake, CURRENT_SCHEMA_VERSION } from './types';
+import { parseAndValidate, validateProjectData } from './validate';
+import type { KeySignature, TimeSignature } from '../melody/types';
+
+// =============================================================================
+// Import Options
+// =============================================================================
+
+/**
+ * Options for importing a project.
+ */
+export interface ImportOptions {
+  /** Whether to clear existing data before importing (default: true) */
+  clearExisting?: boolean;
+  /** Whether to import recordings metadata (default: true) */
+  includeRecordings?: boolean;
+  /** Whether to import melody data (default: true) */
+  includeMelody?: boolean;
+  /** Whether to import analysis data (default: true) */
+  includeAnalysis?: boolean;
+}
+
+const defaultOptions: Required<ImportOptions> = {
+  clearExisting: true,
+  includeRecordings: true,
+  includeMelody: true,
+  includeAnalysis: true,
+};
+
+// =============================================================================
+// Import Functions
+// =============================================================================
+
+/**
+ * Imports project data into the application stores.
+ *
+ * @param data - Validated ProjectData object
+ * @param options - Import options
+ * @throws ProjectImportError if import fails
+ */
+export function importProject(data: ProjectData, options: ImportOptions = {}): void {
+  const opts = { ...defaultOptions, ...options };
+
+  console.log('[Project] Importing project...', {
+    version: data.version,
+    exportedAt: data.exportedAt,
+    options: opts,
+  });
+
+  // Validate the data before importing
+  const validation = validateProjectData(data);
+  if (!validation.valid) {
+    throw new ProjectImportError('Invalid project data', validation.errors);
+  }
+
+  // Log warnings if any
+  if (validation.warnings.length > 0) {
+    console.warn('[Project] Import warnings:', validation.warnings);
+  }
+
+  // Migrate data if needed
+  const migratedData = migrateProjectData(data);
+
+  // Clear existing data if requested
+  if (opts.clearExisting) {
+    console.log('[Project] Clearing existing data...');
+    usePoemStore.getState().reset();
+    useAnalysisStore.getState().reset();
+    useMelodyStore.getState().reset();
+    useRecordingStore.getState().reset();
+  }
+
+  // Import poem data
+  importPoemData(migratedData);
+
+  // Import analysis data
+  if (opts.includeAnalysis && migratedData.analysis) {
+    importAnalysisData(migratedData);
+  }
+
+  // Import melody data
+  if (opts.includeMelody) {
+    importMelodyData(migratedData);
+  }
+
+  // Import recording metadata
+  if (opts.includeRecordings) {
+    importRecordingData(migratedData);
+  }
+
+  console.log('[Project] Import complete');
+}
+
+/**
+ * Imports project data from a JSON string.
+ *
+ * @param jsonString - JSON string containing project data
+ * @param options - Import options
+ * @throws ProjectImportError if parsing or validation fails
+ */
+export function importProjectFromJson(jsonString: string, options: ImportOptions = {}): void {
+  console.log('[Project] Parsing JSON...');
+
+  const result = parseAndValidate(jsonString);
+
+  if (!result.valid || !result.data) {
+    throw new ProjectImportError('Failed to parse project JSON', result.errors);
+  }
+
+  importProject(result.data, options);
+}
+
+/**
+ * Imports project data from a File object.
+ *
+ * @param file - File object (from file input or drag-and-drop)
+ * @param options - Import options
+ * @returns Promise that resolves when import is complete
+ * @throws ProjectImportError if reading, parsing, or validation fails
+ */
+export async function importProjectFromFile(
+  file: File,
+  options: ImportOptions = {}
+): Promise<void> {
+  console.log('[Project] Reading file:', file.name);
+
+  // Validate file type
+  if (!file.name.endsWith('.json') && file.type !== 'application/json') {
+    throw new ProjectImportError('Invalid file type', ['File must be a JSON file (.json)']);
+  }
+
+  // Read file contents
+  let jsonString: string;
+  try {
+    jsonString = await file.text();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    throw new ProjectImportError('Failed to read file', [message]);
+  }
+
+  // Import from JSON string
+  importProjectFromJson(jsonString, options);
+}
+
+// =============================================================================
+// Data Import Helpers
+// =============================================================================
+
+/**
+ * Imports poem data into the poem store.
+ */
+function importPoemData(data: ProjectData): void {
+  console.log('[Project] Importing poem data...');
+
+  const poemStore = usePoemStore.getState();
+
+  // Set the original poem
+  poemStore.setPoem(data.poem.original);
+
+  // Import all versions
+  // We need to directly set the state since addVersion computes changes
+  usePoemStore.setState({
+    versions: data.poem.versions,
+    currentVersionIndex: data.poem.currentVersionIndex,
+  });
+
+  console.log('[Project] Poem imported:', {
+    hasOriginal: data.poem.original.length > 0,
+    versionCount: data.poem.versions.length,
+    currentVersion: data.poem.currentVersionIndex,
+  });
+}
+
+/**
+ * Imports analysis data into the analysis store.
+ */
+function importAnalysisData(data: ProjectData): void {
+  if (!data.analysis) {
+    console.log('[Project] No analysis data to import');
+    return;
+  }
+
+  console.log('[Project] Importing analysis data...');
+
+  const analysisStore = useAnalysisStore.getState();
+
+  // Find the version ID that was analyzed
+  // If currentVersionIndex is -1, no specific version was analyzed
+  let analyzedVersionId: string | undefined;
+  if (
+    data.poem.currentVersionIndex >= 0 &&
+    data.poem.versions[data.poem.currentVersionIndex]
+  ) {
+    analyzedVersionId = data.poem.versions[data.poem.currentVersionIndex].id;
+  }
+
+  analysisStore.setAnalysis(data.analysis, analyzedVersionId);
+
+  console.log('[Project] Analysis imported');
+}
+
+/**
+ * Imports melody data and settings into the melody store.
+ */
+function importMelodyData(data: ProjectData): void {
+  console.log('[Project] Importing melody data...');
+
+  const melodyStore = useMelodyStore.getState();
+
+  // Import settings
+  melodyStore.setTempo(data.settings.tempo);
+  melodyStore.setVolume(data.settings.volume);
+  if (data.settings.loop) {
+    // Only toggle if we need to enable loop (store defaults to false)
+    if (!melodyStore.loop) {
+      melodyStore.toggleLoop();
+    }
+  }
+
+  // Type-safe key setting
+  const validKeys: KeySignature[] = ['C', 'G', 'D', 'F', 'Am', 'Em', 'Dm'];
+  if (validKeys.includes(data.settings.key as KeySignature)) {
+    melodyStore.setKey(data.settings.key as KeySignature);
+  }
+
+  // Type-safe time signature setting
+  const validTimeSignatures: TimeSignature[] = ['4/4', '3/4', '6/8', '2/4'];
+  if (validTimeSignatures.includes(data.settings.timeSignature as TimeSignature)) {
+    melodyStore.setTimeSignature(data.settings.timeSignature as TimeSignature);
+  }
+
+  // Import melody if present
+  if (data.melody.data && data.melody.abcNotation) {
+    melodyStore.setMelody(data.melody.data, data.melody.abcNotation);
+    console.log('[Project] Melody data imported');
+  } else if (data.melody.abcNotation) {
+    melodyStore.setAbcNotation(data.melody.abcNotation);
+    console.log('[Project] ABC notation imported (no melody data)');
+  } else {
+    console.log('[Project] No melody data to import');
+  }
+}
+
+/**
+ * Imports recording metadata into the recording store.
+ */
+function importRecordingData(data: ProjectData): void {
+  if (!data.recordings || data.recordings.length === 0) {
+    console.log('[Project] No recording data to import');
+    return;
+  }
+
+  console.log('[Project] Importing recording metadata...');
+
+  const recordingStore = useRecordingStore.getState();
+
+  // Convert metadata back to takes (with empty blobUrl)
+  for (const metadata of data.recordings) {
+    const take = metadataToTake(metadata);
+    recordingStore.addTake(take);
+  }
+
+  console.log('[Project] Recordings imported:', data.recordings.length);
+}
+
+// =============================================================================
+// Migration
+// =============================================================================
+
+/**
+ * Migrates project data from older schema versions to the current version.
+ *
+ * @param data - Project data to migrate
+ * @returns Migrated project data
+ */
+function migrateProjectData(data: ProjectData): ProjectData {
+  // Currently only version 1.0.0 exists, so no migration needed
+  if (data.version === CURRENT_SCHEMA_VERSION) {
+    return data;
+  }
+
+  console.log('[Project] Migrating from version', data.version, 'to', CURRENT_SCHEMA_VERSION);
+
+  // Future migrations would go here
+  // Example:
+  // if (compareVersions(data.version, '1.1.0') < 0) {
+  //   data = migrateFrom100To110(data);
+  // }
+
+  // Update version to current
+  return {
+    ...data,
+    version: CURRENT_SCHEMA_VERSION,
+  };
+}

--- a/web/src/lib/project/index.ts
+++ b/web/src/lib/project/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Ghost Note - Project Import/Export
+ *
+ * Central export point for project serialization functionality.
+ *
+ * @module lib/project
+ */
+
+// Types
+export type {
+  ProjectData,
+  UserSettings,
+  RecordingMetadata,
+  ValidationResult,
+} from './types';
+
+export {
+  CURRENT_SCHEMA_VERSION,
+  MIN_SUPPORTED_VERSION,
+  ProjectImportError,
+  takeToMetadata,
+  metadataToTake,
+} from './types';
+
+// Export functions
+export { exportProject, serializeProject, downloadProjectFile } from './export';
+
+// Import functions
+export type { ImportOptions } from './import';
+export {
+  importProject,
+  importProjectFromJson,
+  importProjectFromFile,
+} from './import';
+
+// Validation functions
+export { validateProjectData, parseAndValidate } from './validate';

--- a/web/src/lib/project/types.test.ts
+++ b/web/src/lib/project/types.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for project types
+ *
+ * @module lib/project/types.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CURRENT_SCHEMA_VERSION,
+  MIN_SUPPORTED_VERSION,
+  takeToMetadata,
+  metadataToTake,
+  ProjectImportError,
+} from './types';
+import type { RecordingTake } from '../../stores/types';
+import type { RecordingMetadata } from './types';
+
+describe('project types', () => {
+  describe('schema versions', () => {
+    it('should have valid current schema version', () => {
+      expect(CURRENT_SCHEMA_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it('should have valid minimum supported version', () => {
+      expect(MIN_SUPPORTED_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it('should have min version less than or equal to current', () => {
+      const [minMajor, minMinor, minPatch] = MIN_SUPPORTED_VERSION.split('.').map(Number);
+      const [curMajor, curMinor, curPatch] = CURRENT_SCHEMA_VERSION.split('.').map(Number);
+
+      const minNum = minMajor * 10000 + minMinor * 100 + minPatch;
+      const curNum = curMajor * 10000 + curMinor * 100 + curPatch;
+
+      expect(minNum).toBeLessThanOrEqual(curNum);
+    });
+  });
+
+  describe('takeToMetadata', () => {
+    it('should convert RecordingTake to RecordingMetadata', () => {
+      const take: RecordingTake = {
+        id: 'take-123',
+        blobUrl: 'blob:http://localhost/abc123',
+        duration: 30.5,
+        timestamp: 1704067200000,
+        melodyVersionId: 'melody-v1',
+        lyricVersionId: 'lyric-v1',
+        name: 'My Recording',
+      };
+
+      const metadata = takeToMetadata(take);
+
+      expect(metadata).toEqual({
+        id: 'take-123',
+        duration: 30.5,
+        timestamp: 1704067200000,
+        melodyVersionId: 'melody-v1',
+        lyricVersionId: 'lyric-v1',
+        name: 'My Recording',
+      });
+
+      // Should not include blobUrl
+      expect('blobUrl' in metadata).toBe(false);
+    });
+
+    it('should handle take without optional fields', () => {
+      const take: RecordingTake = {
+        id: 'take-456',
+        blobUrl: 'blob:http://localhost/def456',
+        duration: 15.0,
+        timestamp: 1704067300000,
+      };
+
+      const metadata = takeToMetadata(take);
+
+      expect(metadata).toEqual({
+        id: 'take-456',
+        duration: 15.0,
+        timestamp: 1704067300000,
+        melodyVersionId: undefined,
+        lyricVersionId: undefined,
+        name: undefined,
+      });
+    });
+  });
+
+  describe('metadataToTake', () => {
+    it('should convert RecordingMetadata to RecordingTake', () => {
+      const metadata: RecordingMetadata = {
+        id: 'take-789',
+        duration: 45.0,
+        timestamp: 1704067400000,
+        melodyVersionId: 'melody-v2',
+        lyricVersionId: 'lyric-v2',
+        name: 'Another Recording',
+      };
+
+      const take = metadataToTake(metadata);
+
+      expect(take).toEqual({
+        id: 'take-789',
+        blobUrl: '', // Empty blob URL since audio is not preserved
+        duration: 45.0,
+        timestamp: 1704067400000,
+        melodyVersionId: 'melody-v2',
+        lyricVersionId: 'lyric-v2',
+        name: 'Another Recording',
+      });
+    });
+
+    it('should set empty blobUrl for restored take', () => {
+      const metadata: RecordingMetadata = {
+        id: 'take-abc',
+        duration: 20.0,
+        timestamp: 1704067500000,
+      };
+
+      const take = metadataToTake(metadata);
+
+      expect(take.blobUrl).toBe('');
+    });
+  });
+
+  describe('ProjectImportError', () => {
+    it('should create error with message and errors array', () => {
+      const error = new ProjectImportError('Import failed', ['Error 1', 'Error 2']);
+
+      expect(error.message).toBe('Import failed');
+      expect(error.errors).toEqual(['Error 1', 'Error 2']);
+      expect(error.name).toBe('ProjectImportError');
+    });
+
+    it('should be an instance of Error', () => {
+      const error = new ProjectImportError('Test', []);
+
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/web/src/lib/project/types.ts
+++ b/web/src/lib/project/types.ts
@@ -1,0 +1,168 @@
+/**
+ * Ghost Note - Project Import/Export Types
+ *
+ * Type definitions for project serialization and deserialization.
+ *
+ * @module lib/project/types
+ */
+
+import type { LyricVersion, RecordingTake } from '../../stores/types';
+import type { PoemAnalysis } from '../../types';
+import type { Melody } from '../melody/types';
+
+// =============================================================================
+// Schema Version
+// =============================================================================
+
+/**
+ * Current project schema version.
+ * Increment when making breaking changes to ProjectData structure.
+ */
+export const CURRENT_SCHEMA_VERSION = '1.0.0';
+
+/**
+ * Minimum supported schema version for migration.
+ */
+export const MIN_SUPPORTED_VERSION = '1.0.0';
+
+// =============================================================================
+// User Settings
+// =============================================================================
+
+/**
+ * User settings that are part of the project export.
+ * Does not include UI preferences (theme, panel visibility, etc.)
+ */
+export interface UserSettings {
+  /** Melody playback tempo in BPM */
+  tempo: number;
+  /** Melody playback volume (0-1) */
+  volume: number;
+  /** Whether to loop melody playback */
+  loop: boolean;
+  /** Selected key signature */
+  key: string;
+  /** Selected time signature */
+  timeSignature: string;
+}
+
+// =============================================================================
+// Recording Metadata
+// =============================================================================
+
+/**
+ * Recording take metadata for export.
+ * Excludes audio blob data (blobUrl) since it can't be serialized to JSON.
+ */
+export interface RecordingMetadata {
+  /** Unique identifier */
+  id: string;
+  /** Duration in seconds */
+  duration: number;
+  /** When this was recorded */
+  timestamp: number;
+  /** ID of the melody version used during recording */
+  melodyVersionId?: string;
+  /** ID of the lyric version used during recording */
+  lyricVersionId?: string;
+  /** Optional user-provided name */
+  name?: string;
+}
+
+// =============================================================================
+// Project Data
+// =============================================================================
+
+/**
+ * Complete project data structure for import/export.
+ */
+export interface ProjectData {
+  /** Schema version for migration support */
+  version: string;
+  /** ISO timestamp when project was exported */
+  exportedAt: string;
+  /** Poem data including original and all versions */
+  poem: {
+    /** Original poem text as entered by user */
+    original: string;
+    /** All lyric versions with their metadata */
+    versions: LyricVersion[];
+    /** Index of currently active version (-1 means original) */
+    currentVersionIndex: number;
+  };
+  /** Analysis results (null if not analyzed) */
+  analysis: PoemAnalysis | null;
+  /** Generated melody (null if not generated) */
+  melody: {
+    /** The melody data structure */
+    data: Melody | null;
+    /** ABC notation string */
+    abcNotation: string | null;
+  };
+  /** User settings for playback */
+  settings: UserSettings;
+  /** Recording metadata (excludes audio blobs) */
+  recordings: RecordingMetadata[];
+}
+
+// =============================================================================
+// Validation Types
+// =============================================================================
+
+/**
+ * Result of project validation.
+ */
+export interface ValidationResult {
+  /** Whether the project data is valid */
+  valid: boolean;
+  /** List of validation errors (empty if valid) */
+  errors: string[];
+  /** List of validation warnings (non-fatal issues) */
+  warnings: string[];
+}
+
+/**
+ * Error thrown when project import fails.
+ */
+export class ProjectImportError extends Error {
+  readonly errors: string[];
+
+  constructor(message: string, errors: string[]) {
+    super(message);
+    this.name = 'ProjectImportError';
+    this.errors = errors;
+  }
+}
+
+// =============================================================================
+// Utility Types
+// =============================================================================
+
+/**
+ * Converts a RecordingTake to RecordingMetadata (strips blobUrl).
+ */
+export function takeToMetadata(take: RecordingTake): RecordingMetadata {
+  return {
+    id: take.id,
+    duration: take.duration,
+    timestamp: take.timestamp,
+    melodyVersionId: take.melodyVersionId,
+    lyricVersionId: take.lyricVersionId,
+    name: take.name,
+  };
+}
+
+/**
+ * Converts RecordingMetadata back to RecordingTake (with empty blobUrl).
+ */
+export function metadataToTake(metadata: RecordingMetadata): RecordingTake {
+  return {
+    id: metadata.id,
+    blobUrl: '', // Audio blob is not preserved in export
+    duration: metadata.duration,
+    timestamp: metadata.timestamp,
+    melodyVersionId: metadata.melodyVersionId,
+    lyricVersionId: metadata.lyricVersionId,
+    name: metadata.name,
+  };
+}

--- a/web/src/lib/project/validate.test.ts
+++ b/web/src/lib/project/validate.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Tests for project validation
+ *
+ * @module lib/project/validate.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateProjectData, parseAndValidate } from './validate';
+import { CURRENT_SCHEMA_VERSION } from './types';
+import type { ProjectData } from './types';
+
+// Helper to create a valid project data object
+function createValidProjectData(): ProjectData {
+  return {
+    version: CURRENT_SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    poem: {
+      original: 'Roses are red\nViolets are blue',
+      versions: [
+        {
+          id: 'v_123456789_abc1234',
+          lyrics: 'Roses are red\nViolets are blue\nSugar is sweet',
+          timestamp: Date.now(),
+          changes: [
+            {
+              type: 'modify',
+              start: 0,
+              end: 28,
+              oldText: 'Roses are red\nViolets are blue',
+              newText: 'Roses are red\nViolets are blue\nSugar is sweet',
+            },
+          ],
+          description: 'Added third line',
+        },
+      ],
+      currentVersionIndex: 0,
+    },
+    analysis: null,
+    melody: {
+      data: null,
+      abcNotation: null,
+    },
+    settings: {
+      tempo: 100,
+      volume: 0.8,
+      loop: false,
+      key: 'C',
+      timeSignature: '4/4',
+    },
+    recordings: [],
+  };
+}
+
+describe('validateProjectData', () => {
+  describe('valid data', () => {
+    it('should accept valid project data', () => {
+      const data = createValidProjectData();
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should accept project with empty poem', () => {
+      const data = createValidProjectData();
+      data.poem.original = '';
+      data.poem.versions = [];
+      data.poem.currentVersionIndex = -1;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should accept project with analysis data', () => {
+      const data = createValidProjectData();
+      data.analysis = {
+        meta: { lineCount: 2, stanzaCount: 1, wordCount: 6, syllableCount: 8 },
+        structure: { stanzas: [] },
+        prosody: {
+          meter: {
+            pattern: '0101',
+            detectedMeter: 'iambic',
+            footType: 'iamb',
+            feetPerLine: 2,
+            confidence: 0.8,
+            deviations: [],
+          },
+          rhyme: { scheme: 'AA', rhymeGroups: {}, internalRhymes: [] },
+          regularity: 0.9,
+        },
+        emotion: {
+          overallSentiment: 0.5,
+          arousal: 0.5,
+          dominantEmotions: [],
+          emotionalArc: [],
+          suggestedMusicParams: { mode: 'major', tempoRange: [80, 120], register: 'middle' },
+        },
+        problems: [],
+        melodySuggestions: {
+          timeSignature: '4/4',
+          tempo: 100,
+          key: 'C',
+          mode: 'major',
+          phraseBreaks: [],
+        },
+      };
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should accept project with recordings', () => {
+      const data = createValidProjectData();
+      data.recordings = [
+        {
+          id: 'rec-1',
+          duration: 30.5,
+          timestamp: Date.now(),
+          name: 'Take 1',
+        },
+        {
+          id: 'rec-2',
+          duration: 45.0,
+          timestamp: Date.now(),
+          melodyVersionId: 'melody-v1',
+          lyricVersionId: 'lyric-v1',
+        },
+      ];
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('invalid version', () => {
+    it('should reject missing version', () => {
+      const data = createValidProjectData();
+      delete (data as unknown as Record<string, unknown>).version;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing required field: version');
+    });
+
+    it('should reject non-string version', () => {
+      const data = createValidProjectData() as unknown as Record<string, unknown>;
+      data.version = 123;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Field "version" must be a string');
+    });
+
+    it('should reject unsupported version', () => {
+      const data = createValidProjectData();
+      data.version = '99.99.99';
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Unsupported schema version'))).toBe(true);
+    });
+  });
+
+  describe('invalid exportedAt', () => {
+    it('should reject missing exportedAt', () => {
+      const data = createValidProjectData();
+      delete (data as unknown as Record<string, unknown>).exportedAt;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing required field: exportedAt');
+    });
+
+    it('should reject invalid date string', () => {
+      const data = createValidProjectData();
+      data.exportedAt = 'not-a-date';
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Field "exportedAt" must be a valid ISO date string');
+    });
+  });
+
+  describe('invalid poem', () => {
+    it('should reject missing poem', () => {
+      const data = createValidProjectData();
+      delete (data as unknown as Record<string, unknown>).poem;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing required field: poem');
+    });
+
+    it('should reject non-object poem', () => {
+      const data = createValidProjectData() as unknown as Record<string, unknown>;
+      data.poem = 'not an object';
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Field "poem" must be an object');
+    });
+
+    it('should reject missing poem.original', () => {
+      const data = createValidProjectData();
+      delete (data.poem as Record<string, unknown>).original;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing required field: poem.original');
+    });
+
+    it('should reject non-array poem.versions', () => {
+      const data = createValidProjectData();
+      (data.poem as Record<string, unknown>).versions = 'not an array';
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Field "poem.versions" must be an array');
+    });
+
+    it('should reject invalid version in versions array', () => {
+      const data = createValidProjectData();
+      data.poem.versions = [
+        {
+          id: '', // Empty ID should fail
+          lyrics: 'Test',
+          timestamp: Date.now(),
+          changes: [],
+        },
+      ];
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('poem.versions[0].id must be a non-empty string');
+    });
+
+    it('should reject non-integer currentVersionIndex', () => {
+      const data = createValidProjectData();
+      data.poem.currentVersionIndex = 1.5;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Field "poem.currentVersionIndex" must be an integer');
+    });
+  });
+
+  describe('invalid settings', () => {
+    it('should reject missing settings', () => {
+      const data = createValidProjectData();
+      delete (data as unknown as Record<string, unknown>).settings;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Missing required field: settings');
+    });
+
+    it('should reject tempo out of range', () => {
+      const data = createValidProjectData();
+      data.settings.tempo = 500;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Field "settings.tempo" must be a number between 20 and 300');
+    });
+
+    it('should reject volume out of range', () => {
+      const data = createValidProjectData();
+      data.settings.volume = 1.5;
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Field "settings.volume" must be a number between 0 and 1');
+    });
+
+    it('should reject non-boolean loop', () => {
+      const data = createValidProjectData() as unknown as Record<string, unknown>;
+      (data.settings as Record<string, unknown>).loop = 'true';
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Field "settings.loop" must be a boolean');
+    });
+  });
+
+  describe('warnings for optional fields', () => {
+    it('should warn about invalid analysis structure', () => {
+      const data = createValidProjectData();
+      data.analysis = { invalid: 'structure' } as unknown as typeof data.analysis;
+
+      const result = validateProjectData(data);
+
+      // Should still be valid, but with warnings
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some((w) => w.includes('Analysis data'))).toBe(true);
+    });
+
+    it('should warn about invalid recording entries', () => {
+      const data = createValidProjectData();
+      data.recordings = [
+        { invalid: 'recording' } as unknown as (typeof data.recordings)[0],
+      ];
+
+      const result = validateProjectData(data);
+
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some((w) => w.includes('recordings[0]'))).toBe(true);
+    });
+  });
+
+  describe('non-object data', () => {
+    it('should reject null data', () => {
+      const result = validateProjectData(null);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Project data must be a non-null object');
+    });
+
+    it('should reject non-object data', () => {
+      const result = validateProjectData('not an object');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Project data must be a non-null object');
+    });
+
+    it('should reject array data', () => {
+      const result = validateProjectData([]);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Project data must be a non-null object');
+    });
+  });
+});
+
+describe('parseAndValidate', () => {
+  it('should parse and validate valid JSON', () => {
+    const data = createValidProjectData();
+    const json = JSON.stringify(data);
+
+    const result = parseAndValidate(json);
+
+    expect(result.valid).toBe(true);
+    expect(result.data).toEqual(data);
+  });
+
+  it('should return errors for invalid JSON', () => {
+    const result = parseAndValidate('not valid json');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('Invalid JSON'))).toBe(true);
+    expect(result.data).toBeUndefined();
+  });
+
+  it('should return errors for valid JSON but invalid project data', () => {
+    const result = parseAndValidate('{"foo": "bar"}');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.data).toBeUndefined();
+  });
+
+  it('should handle empty object', () => {
+    const result = parseAndValidate('{}');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/lib/project/validate.ts
+++ b/web/src/lib/project/validate.ts
@@ -1,0 +1,354 @@
+/**
+ * Ghost Note - Project Validation
+ *
+ * Functions for validating project data before import.
+ *
+ * @module lib/project/validate
+ */
+
+import type { ProjectData, ValidationResult } from './types';
+import { CURRENT_SCHEMA_VERSION, MIN_SUPPORTED_VERSION } from './types';
+import { isPoemAnalysis } from '../../types/analysis';
+
+// =============================================================================
+// Version Comparison
+// =============================================================================
+
+/**
+ * Compares two semantic version strings.
+ *
+ * @param a - First version
+ * @param b - Second version
+ * @returns -1 if a < b, 0 if a === b, 1 if a > b
+ */
+function compareVersions(a: string, b: string): number {
+  const partsA = a.split('.').map(Number);
+  const partsB = b.split('.').map(Number);
+
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+    const numA = partsA[i] ?? 0;
+    const numB = partsB[i] ?? 0;
+
+    if (numA < numB) return -1;
+    if (numA > numB) return 1;
+  }
+
+  return 0;
+}
+
+/**
+ * Checks if a version is supported for import.
+ *
+ * @param version - Version string to check
+ * @returns True if version is supported
+ */
+function isVersionSupported(version: string): boolean {
+  return (
+    compareVersions(version, MIN_SUPPORTED_VERSION) >= 0 &&
+    compareVersions(version, CURRENT_SCHEMA_VERSION) <= 0
+  );
+}
+
+// =============================================================================
+// Validation Functions
+// =============================================================================
+
+/**
+ * Validates a raw JSON object as ProjectData.
+ *
+ * @param data - Raw parsed JSON object
+ * @returns Validation result with errors and warnings
+ */
+export function validateProjectData(data: unknown): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Check if data is an object (not null, not array)
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    errors.push('Project data must be a non-null object');
+    return { valid: false, errors, warnings };
+  }
+
+  const project = data as Record<string, unknown>;
+
+  // ==========================================================================
+  // Required Fields
+  // ==========================================================================
+
+  // Version
+  if (!('version' in project)) {
+    errors.push('Missing required field: version');
+  } else if (typeof project.version !== 'string') {
+    errors.push('Field "version" must be a string');
+  } else if (!isVersionSupported(project.version)) {
+    errors.push(
+      `Unsupported schema version: ${project.version}. ` +
+        `Supported range: ${MIN_SUPPORTED_VERSION} to ${CURRENT_SCHEMA_VERSION}`
+    );
+  }
+
+  // ExportedAt
+  if (!('exportedAt' in project)) {
+    errors.push('Missing required field: exportedAt');
+  } else if (typeof project.exportedAt !== 'string') {
+    errors.push('Field "exportedAt" must be a string');
+  } else {
+    const date = new Date(project.exportedAt);
+    if (isNaN(date.getTime())) {
+      errors.push('Field "exportedAt" must be a valid ISO date string');
+    }
+  }
+
+  // Poem
+  if (!('poem' in project)) {
+    errors.push('Missing required field: poem');
+  } else {
+    const poemErrors = validatePoem(project.poem);
+    errors.push(...poemErrors);
+  }
+
+  // Settings
+  if (!('settings' in project)) {
+    errors.push('Missing required field: settings');
+  } else {
+    const settingsErrors = validateSettings(project.settings);
+    errors.push(...settingsErrors);
+  }
+
+  // ==========================================================================
+  // Optional Fields with Validation
+  // ==========================================================================
+
+  // Analysis (can be null)
+  if ('analysis' in project && project.analysis !== null) {
+    if (!isPoemAnalysis(project.analysis)) {
+      warnings.push('Analysis data does not match expected structure; it may be corrupted');
+    }
+  }
+
+  // Melody (can be null or have null fields)
+  if ('melody' in project && project.melody !== null) {
+    const melodyWarnings = validateMelody(project.melody);
+    warnings.push(...melodyWarnings);
+  }
+
+  // Recordings (can be empty array)
+  if ('recordings' in project) {
+    if (!Array.isArray(project.recordings)) {
+      errors.push('Field "recordings" must be an array');
+    } else {
+      const recordingWarnings = validateRecordings(project.recordings);
+      warnings.push(...recordingWarnings);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Validates the poem section of project data.
+ */
+function validatePoem(poem: unknown): string[] {
+  const errors: string[] = [];
+
+  if (typeof poem !== 'object' || poem === null) {
+    errors.push('Field "poem" must be an object');
+    return errors;
+  }
+
+  const poemObj = poem as Record<string, unknown>;
+
+  // Original
+  if (!('original' in poemObj)) {
+    errors.push('Missing required field: poem.original');
+  } else if (typeof poemObj.original !== 'string') {
+    errors.push('Field "poem.original" must be a string');
+  }
+
+  // Versions
+  if (!('versions' in poemObj)) {
+    errors.push('Missing required field: poem.versions');
+  } else if (!Array.isArray(poemObj.versions)) {
+    errors.push('Field "poem.versions" must be an array');
+  } else {
+    // Validate each version
+    for (let i = 0; i < poemObj.versions.length; i++) {
+      const versionErrors = validateLyricVersion(poemObj.versions[i], i);
+      errors.push(...versionErrors);
+    }
+  }
+
+  // CurrentVersionIndex
+  if (!('currentVersionIndex' in poemObj)) {
+    errors.push('Missing required field: poem.currentVersionIndex');
+  } else if (typeof poemObj.currentVersionIndex !== 'number') {
+    errors.push('Field "poem.currentVersionIndex" must be a number');
+  } else if (!Number.isInteger(poemObj.currentVersionIndex)) {
+    errors.push('Field "poem.currentVersionIndex" must be an integer');
+  }
+
+  return errors;
+}
+
+/**
+ * Validates a single lyric version.
+ */
+function validateLyricVersion(version: unknown, index: number): string[] {
+  const errors: string[] = [];
+
+  if (typeof version !== 'object' || version === null) {
+    errors.push(`poem.versions[${index}] must be an object`);
+    return errors;
+  }
+
+  const v = version as Record<string, unknown>;
+
+  if (typeof v.id !== 'string' || v.id.length === 0) {
+    errors.push(`poem.versions[${index}].id must be a non-empty string`);
+  }
+
+  if (typeof v.lyrics !== 'string') {
+    errors.push(`poem.versions[${index}].lyrics must be a string`);
+  }
+
+  if (typeof v.timestamp !== 'number') {
+    errors.push(`poem.versions[${index}].timestamp must be a number`);
+  }
+
+  if (!Array.isArray(v.changes)) {
+    errors.push(`poem.versions[${index}].changes must be an array`);
+  }
+
+  return errors;
+}
+
+/**
+ * Validates the settings section of project data.
+ */
+function validateSettings(settings: unknown): string[] {
+  const errors: string[] = [];
+
+  if (typeof settings !== 'object' || settings === null) {
+    errors.push('Field "settings" must be an object');
+    return errors;
+  }
+
+  const s = settings as Record<string, unknown>;
+
+  if (typeof s.tempo !== 'number' || s.tempo < 20 || s.tempo > 300) {
+    errors.push('Field "settings.tempo" must be a number between 20 and 300');
+  }
+
+  if (typeof s.volume !== 'number' || s.volume < 0 || s.volume > 1) {
+    errors.push('Field "settings.volume" must be a number between 0 and 1');
+  }
+
+  if (typeof s.loop !== 'boolean') {
+    errors.push('Field "settings.loop" must be a boolean');
+  }
+
+  if (typeof s.key !== 'string') {
+    errors.push('Field "settings.key" must be a string');
+  }
+
+  if (typeof s.timeSignature !== 'string') {
+    errors.push('Field "settings.timeSignature" must be a string');
+  }
+
+  return errors;
+}
+
+/**
+ * Validates the melody section of project data.
+ */
+function validateMelody(melody: unknown): string[] {
+  const warnings: string[] = [];
+
+  if (typeof melody !== 'object' || melody === null) {
+    warnings.push('Melody data is not a valid object');
+    return warnings;
+  }
+
+  const m = melody as Record<string, unknown>;
+
+  // data can be null or a Melody object
+  if (m.data !== null && typeof m.data !== 'object') {
+    warnings.push('Melody data structure may be corrupted');
+  }
+
+  // abcNotation can be null or a string
+  if (m.abcNotation !== null && typeof m.abcNotation !== 'string') {
+    warnings.push('ABC notation may be corrupted');
+  }
+
+  return warnings;
+}
+
+/**
+ * Validates the recordings array.
+ */
+function validateRecordings(recordings: unknown[]): string[] {
+  const warnings: string[] = [];
+
+  for (let i = 0; i < recordings.length; i++) {
+    const recording = recordings[i];
+
+    if (typeof recording !== 'object' || recording === null) {
+      warnings.push(`recordings[${i}] is not a valid object`);
+      continue;
+    }
+
+    const r = recording as Record<string, unknown>;
+
+    if (typeof r.id !== 'string') {
+      warnings.push(`recordings[${i}].id is missing or invalid`);
+    }
+
+    if (typeof r.duration !== 'number' || r.duration < 0) {
+      warnings.push(`recordings[${i}].duration is missing or invalid`);
+    }
+
+    if (typeof r.timestamp !== 'number') {
+      warnings.push(`recordings[${i}].timestamp is missing or invalid`);
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Parses and validates a JSON string as ProjectData.
+ *
+ * @param jsonString - JSON string to parse
+ * @returns Validation result
+ */
+export function parseAndValidate(jsonString: string): ValidationResult & { data?: ProjectData } {
+  // Try to parse JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonString);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown parse error';
+    return {
+      valid: false,
+      errors: [`Invalid JSON: ${message}`],
+      warnings: [],
+    };
+  }
+
+  // Validate the parsed data
+  const result = validateProjectData(parsed);
+
+  if (result.valid) {
+    return {
+      ...result,
+      data: parsed as ProjectData,
+    };
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Adds complete project import/export functionality for saving and loading Ghost Note projects as JSON files
- Includes all project data: poem, lyric versions, analysis, melody, settings, and recording metadata
- Implements robust validation and version migration framework

## Changes
- `web/src/lib/project/types.ts` - Type definitions for ProjectData, validation types, and utility functions
- `web/src/lib/project/export.ts` - Export functions: exportProject(), serializeProject(), downloadProjectFile()
- `web/src/lib/project/import.ts` - Import functions with store restoration and migration support
- `web/src/lib/project/validate.ts` - Comprehensive validation for schema version and data integrity
- `web/src/lib/project/index.ts` - Central export point for all project functionality
- `web/src/lib/project/*.test.ts` - Comprehensive test suite with 60+ tests

## Testing
- [x] Unit tests pass (`npm test`) - 4366 tests passing
- [x] Check passes (`npm run check`) - lint and typecheck pass
- [x] Validation tests cover: valid data, invalid versions, missing fields, type errors, warnings

## Notes
- Recording metadata is exported (id, duration, timestamp, name) but audio blobs are not included since they cannot be serialized to JSON
- Schema version 1.0.0 is the initial version with migration framework ready for future changes
- Import includes options to selectively include/exclude analysis, melody, and recordings

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)