### PR TITLE
feat(GH-58): Create version comparison modal

### DIFF
--- a/web/src/components/LyricEditor/VersionCompareModal.css
+++ b/web/src/components/LyricEditor/VersionCompareModal.css
@@ -1,0 +1,577 @@
+/**
+ * VersionCompareModal Styles
+ *
+ * Styles for the version comparison modal dialog.
+ */
+
+/* Overlay */
+.version-compare-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+  animation: version-compare-modal-fade-in 0.15s ease-out;
+}
+
+@keyframes version-compare-modal-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Modal container */
+.version-compare-modal {
+  background-color: var(--color-surface, white);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  max-width: 1200px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  animation: version-compare-modal-slide-in 0.2s ease-out;
+  overflow: hidden;
+}
+
+@keyframes version-compare-modal-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Header */
+.version-compare-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.version-compare-modal__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #111827);
+}
+
+.version-compare-modal__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-text-secondary, #6b7280);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.version-compare-modal__close:hover {
+  background-color: var(--color-hover, #f3f4f6);
+  color: var(--color-text-primary, #111827);
+}
+
+.version-compare-modal__close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+/* Version selectors */
+.version-compare-modal__selectors {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background-color: var(--color-surface-secondary, #f9fafb);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.version-compare-modal__selector {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.version-compare-modal__selector-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.version-compare-modal__select {
+  width: 100%;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.875rem;
+  color: var(--color-text-primary, #374151);
+  background-color: var(--color-surface, white);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  padding-right: 2.5rem;
+}
+
+.version-compare-modal__select:hover {
+  border-color: var(--color-border-hover, #9ca3af);
+}
+
+.version-compare-modal__select:focus {
+  outline: none;
+  border-color: var(--color-primary, #3b82f6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.version-compare-modal__swap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  margin-bottom: 0;
+  font-size: 1.25rem;
+  color: var(--color-text-secondary, #6b7280);
+  background-color: var(--color-surface, white);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.version-compare-modal__swap:hover {
+  background-color: var(--color-hover, #f3f4f6);
+  border-color: var(--color-border-hover, #9ca3af);
+  color: var(--color-text-primary, #374151);
+}
+
+.version-compare-modal__swap:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+/* Toolbar */
+.version-compare-modal__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.version-compare-modal__toolbar-btn {
+  padding: 0.5rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #6b7280);
+  background-color: var(--color-surface, white);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.version-compare-modal__toolbar-btn:hover {
+  background-color: var(--color-hover, #f3f4f6);
+  border-color: var(--color-border-hover, #9ca3af);
+}
+
+.version-compare-modal__toolbar-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+/* Change navigation */
+.version-compare-modal__nav {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.version-compare-modal__nav-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  color: var(--color-text-secondary, #6b7280);
+  background-color: var(--color-surface, white);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.version-compare-modal__nav-btn:hover:not(:disabled) {
+  background-color: var(--color-hover, #f3f4f6);
+  border-color: var(--color-border-hover, #9ca3af);
+  color: var(--color-text-primary, #374151);
+}
+
+.version-compare-modal__nav-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.version-compare-modal__nav-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+.version-compare-modal__nav-counter {
+  min-width: 80px;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+/* Copy buttons */
+.version-compare-modal__copy-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.version-compare-modal__copy-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #6b7280);
+  background-color: var(--color-surface, white);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.version-compare-modal__copy-btn:hover {
+  background-color: var(--color-hover, #f3f4f6);
+  border-color: var(--color-border-hover, #9ca3af);
+  color: var(--color-text-primary, #374151);
+}
+
+.version-compare-modal__copy-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+.version-compare-modal__copy-btn--copied {
+  color: #10b981;
+  border-color: #10b981;
+}
+
+.version-compare-modal__copy-btn--copied:hover {
+  color: #10b981;
+  border-color: #10b981;
+  background-color: rgba(16, 185, 129, 0.05);
+}
+
+/* Diff view container */
+.version-compare-modal__diff {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 1rem 1.5rem;
+  background-color: var(--color-surface, white);
+}
+
+/* Same version message */
+.version-compare-modal__same-version {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  text-align: center;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.version-compare-modal__same-version p {
+  margin: 0.25rem 0;
+}
+
+.version-compare-modal__same-version p:first-child {
+  font-weight: 500;
+  color: var(--color-text-primary, #374151);
+}
+
+/* Footer */
+.version-compare-modal__footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 0.75rem 1.5rem;
+  background-color: var(--color-surface-secondary, #f9fafb);
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+.version-compare-modal__footer-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.version-compare-modal__footer-label {
+  font-weight: 600;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.version-compare-modal__footer-value {
+  color: var(--color-text-primary, #374151);
+}
+
+.version-compare-modal__footer-time {
+  color: var(--color-text-tertiary, #9ca3af);
+}
+
+/* Keyboard hints */
+.version-compare-modal__hints {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 0.5rem 1.5rem;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+  background-color: var(--color-surface-secondary, #f9fafb);
+}
+
+.version-compare-modal__hint {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.6875rem;
+  color: var(--color-text-tertiary, #9ca3af);
+}
+
+.version-compare-modal__hint kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  padding: 0.125rem 0.375rem;
+  font-family: inherit;
+  font-size: 0.625rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #6b7280);
+  background-color: var(--color-surface, white);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 4px;
+  box-shadow: 0 1px 0 var(--color-border, #d1d5db);
+}
+
+/* Dark mode support */
+.dark .version-compare-modal {
+  background-color: var(--color-surface-dark, #1f2937);
+}
+
+.dark .version-compare-modal__header {
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .version-compare-modal__title {
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .version-compare-modal__close {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .version-compare-modal__close:hover {
+  background-color: var(--color-hover-dark, #374151);
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .version-compare-modal__selectors {
+  background-color: var(--color-surface-secondary-dark, #111827);
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .version-compare-modal__selector-label {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .version-compare-modal__select {
+  color: var(--color-text-primary-dark, #e5e7eb);
+  background-color: var(--color-surface-dark, #1f2937);
+  border-color: var(--color-border-dark, #4b5563);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+}
+
+.dark .version-compare-modal__select:hover {
+  border-color: var(--color-border-hover-dark, #6b7280);
+}
+
+.dark .version-compare-modal__swap {
+  color: var(--color-text-secondary-dark, #9ca3af);
+  background-color: var(--color-surface-dark, #1f2937);
+  border-color: var(--color-border-dark, #4b5563);
+}
+
+.dark .version-compare-modal__swap:hover {
+  background-color: var(--color-hover-dark, #374151);
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .version-compare-modal__toolbar {
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .version-compare-modal__toolbar-btn,
+.dark .version-compare-modal__nav-btn,
+.dark .version-compare-modal__copy-btn {
+  color: var(--color-text-secondary-dark, #9ca3af);
+  background-color: var(--color-surface-dark, #1f2937);
+  border-color: var(--color-border-dark, #4b5563);
+}
+
+.dark .version-compare-modal__toolbar-btn:hover,
+.dark .version-compare-modal__nav-btn:hover:not(:disabled),
+.dark .version-compare-modal__copy-btn:hover {
+  background-color: var(--color-hover-dark, #374151);
+  border-color: var(--color-border-hover-dark, #6b7280);
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .version-compare-modal__nav-counter {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .version-compare-modal__diff {
+  background-color: var(--color-surface-dark, #1f2937);
+}
+
+.dark .version-compare-modal__same-version {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .version-compare-modal__same-version p:first-child {
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .version-compare-modal__footer {
+  background-color: var(--color-surface-secondary-dark, #111827);
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .version-compare-modal__footer-label {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .version-compare-modal__footer-value {
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .version-compare-modal__footer-time {
+  color: var(--color-text-tertiary-dark, #6b7280);
+}
+
+.dark .version-compare-modal__hints {
+  border-color: var(--color-border-dark, #374151);
+  background-color: var(--color-surface-secondary-dark, #111827);
+}
+
+.dark .version-compare-modal__hint {
+  color: var(--color-text-tertiary-dark, #6b7280);
+}
+
+.dark .version-compare-modal__hint kbd {
+  color: var(--color-text-secondary-dark, #9ca3af);
+  background-color: var(--color-surface-dark, #1f2937);
+  border-color: var(--color-border-dark, #4b5563);
+  box-shadow: 0 1px 0 var(--color-border-dark, #4b5563);
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .version-compare-modal__overlay,
+  .version-compare-modal {
+    animation: none;
+  }
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .version-compare-modal {
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .version-compare-modal__overlay {
+    padding: 0;
+  }
+
+  .version-compare-modal__selectors {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .version-compare-modal__swap {
+    align-self: center;
+    transform: rotate(90deg);
+  }
+
+  .version-compare-modal__toolbar {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+  }
+
+  .version-compare-modal__footer {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .version-compare-modal__hints {
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .version-compare-modal__copy-btn span {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .version-compare-modal__header,
+  .version-compare-modal__selectors,
+  .version-compare-modal__toolbar,
+  .version-compare-modal__diff,
+  .version-compare-modal__footer,
+  .version-compare-modal__hints {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .version-compare-modal__copy-actions {
+    display: none;
+  }
+}

--- a/web/src/components/LyricEditor/VersionCompareModal.test.tsx
+++ b/web/src/components/LyricEditor/VersionCompareModal.test.tsx
@@ -1,0 +1,684 @@
+/**
+ * Tests for VersionCompareModal Component
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VersionCompareModal } from './VersionCompareModal';
+import type { VersionCompareModalProps } from './types';
+import type { LyricVersion } from './types';
+
+describe('VersionCompareModal', () => {
+  const mockVersions: LyricVersion[] = [
+    {
+      id: 'v1',
+      lyrics: 'First version of lyrics\nWith two lines',
+      timestamp: Date.now() - 60000, // 1 minute ago
+      changes: [{ type: 'modify', start: 0, end: 10, oldText: 'original', newText: 'First' }],
+      description: 'Initial edit',
+    },
+    {
+      id: 'v2',
+      lyrics: 'Second version\nWith changes\nAnd more lines',
+      timestamp: Date.now() - 30000, // 30 seconds ago
+      changes: [
+        { type: 'add', start: 0, end: 5 },
+        { type: 'remove', start: 10, end: 15, oldText: 'text' },
+      ],
+      description: 'Added more content',
+    },
+    {
+      id: 'v3',
+      lyrics: 'Third version\nCompletely different',
+      timestamp: Date.now() - 10000, // 10 seconds ago
+      changes: [{ type: 'modify', start: 0, end: 20, oldText: 'Second', newText: 'Third' }],
+      description: 'Complete rewrite',
+    },
+  ];
+
+  const defaultProps: VersionCompareModalProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    versions: mockVersions,
+    originalText: 'Original poem text\nSecond line of original',
+  };
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders the modal when isOpen is true', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByTestId('version-compare-modal')).toBeInTheDocument();
+    });
+
+    it('does not render when isOpen is false', () => {
+      render(<VersionCompareModal {...defaultProps} isOpen={false} />);
+
+      expect(screen.queryByTestId('version-compare-modal')).not.toBeInTheDocument();
+    });
+
+    it('uses custom testId', () => {
+      render(<VersionCompareModal {...defaultProps} testId="custom-modal" />);
+
+      expect(screen.getByTestId('custom-modal')).toBeInTheDocument();
+    });
+
+    it('applies custom className', () => {
+      render(<VersionCompareModal {...defaultProps} className="custom-class" />);
+
+      const content = screen.getByTestId('version-compare-modal-content');
+      expect(content).toHaveClass('custom-class');
+    });
+
+    it('renders the title', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByText('Compare Versions')).toBeInTheDocument();
+    });
+
+    it('renders close button', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByTestId('version-compare-modal-close')).toBeInTheDocument();
+    });
+  });
+
+  describe('version selectors', () => {
+    it('renders both version selectors', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByTestId('version-compare-modal-left-select')).toBeInTheDocument();
+      expect(screen.getByTestId('version-compare-modal-right-select')).toBeInTheDocument();
+    });
+
+    it('includes original in version options', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const leftSelect = screen.getByTestId('version-compare-modal-left-select');
+      expect(leftSelect).toContainHTML('Original');
+    });
+
+    it('includes all versions in options', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const leftSelect = screen.getByTestId('version-compare-modal-left-select');
+      expect(leftSelect).toContainHTML('Initial edit');
+      expect(leftSelect).toContainHTML('Added more content');
+      expect(leftSelect).toContainHTML('Complete rewrite');
+    });
+
+    it('defaults left selector to original', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const leftSelect = screen.getByTestId('version-compare-modal-left-select') as HTMLSelectElement;
+      expect(leftSelect.value).toBe('original');
+    });
+
+    it('defaults right selector to latest version', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select') as HTMLSelectElement;
+      expect(rightSelect.value).toBe('v3');
+    });
+
+    it('uses initialLeftVersionId when provided', () => {
+      render(<VersionCompareModal {...defaultProps} initialLeftVersionId="v1" />);
+
+      const leftSelect = screen.getByTestId('version-compare-modal-left-select') as HTMLSelectElement;
+      expect(leftSelect.value).toBe('v1');
+    });
+
+    it('uses initialRightVersionId when provided', () => {
+      render(<VersionCompareModal {...defaultProps} initialRightVersionId="v2" />);
+
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select') as HTMLSelectElement;
+      expect(rightSelect.value).toBe('v2');
+    });
+
+    it('changes left version when selector changes', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const leftSelect = screen.getByTestId('version-compare-modal-left-select');
+      await user.selectOptions(leftSelect, 'v1');
+
+      expect((leftSelect as HTMLSelectElement).value).toBe('v1');
+    });
+
+    it('changes right version when selector changes', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select');
+      await user.selectOptions(rightSelect, 'v1');
+
+      expect((rightSelect as HTMLSelectElement).value).toBe('v1');
+    });
+  });
+
+  describe('swap functionality', () => {
+    it('renders swap button', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByTestId('version-compare-modal-swap')).toBeInTheDocument();
+    });
+
+    it('swaps versions when swap button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} initialLeftVersionId="v1" initialRightVersionId="v2" />);
+
+      const swapButton = screen.getByTestId('version-compare-modal-swap');
+      await user.click(swapButton);
+
+      const leftSelect = screen.getByTestId('version-compare-modal-left-select') as HTMLSelectElement;
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select') as HTMLSelectElement;
+
+      expect(leftSelect.value).toBe('v2');
+      expect(rightSelect.value).toBe('v1');
+    });
+  });
+
+  describe('diff view modes', () => {
+    it('defaults to side-by-side view', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByTestId('version-compare-modal-diff-view')).toBeInTheDocument();
+    });
+
+    it('renders toggle button', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByTestId('version-compare-modal-toggle-mode')).toBeInTheDocument();
+    });
+
+    it('switches to inline view when toggle is clicked', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const toggleButton = screen.getByTestId('version-compare-modal-toggle-mode');
+      await user.click(toggleButton);
+
+      expect(screen.getByTestId('version-compare-modal-inline-diff')).toBeInTheDocument();
+    });
+
+    it('switches back to side-by-side view', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const toggleButton = screen.getByTestId('version-compare-modal-toggle-mode');
+      await user.click(toggleButton);
+      await user.click(toggleButton);
+
+      expect(screen.getByTestId('version-compare-modal-diff-view')).toBeInTheDocument();
+    });
+  });
+
+  describe('same version warning', () => {
+    it('shows warning when both selectors have same version', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select');
+      await user.selectOptions(rightSelect, 'original');
+
+      expect(screen.getByTestId('version-compare-modal-same-version')).toBeInTheDocument();
+    });
+
+    it('hides diff view when same version selected', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select');
+      await user.selectOptions(rightSelect, 'original');
+
+      // Wait for state update and verify diff view is hidden
+      await waitFor(() => {
+        expect(screen.queryByTestId('version-compare-modal-diff-view')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('change navigation', () => {
+    it('renders navigation buttons', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByTestId('version-compare-modal-prev-change')).toBeInTheDocument();
+      expect(screen.getByTestId('version-compare-modal-next-change')).toBeInTheDocument();
+    });
+
+    it('renders change counter', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByTestId('version-compare-modal-change-counter')).toBeInTheDocument();
+    });
+
+    it('disables navigation when no changes', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      // Select same version on both sides
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select');
+      await user.selectOptions(rightSelect, 'original');
+
+      await waitFor(() => {
+        const prevButton = screen.getByTestId('version-compare-modal-prev-change');
+        const nextButton = screen.getByTestId('version-compare-modal-next-change');
+
+        expect(prevButton).toBeDisabled();
+        expect(nextButton).toBeDisabled();
+      });
+    });
+
+    it('shows "No changes" when identical', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select');
+      await user.selectOptions(rightSelect, 'original');
+
+      // First verify the same-version message appears (confirming both are now same)
+      await waitFor(() => {
+        expect(screen.getByTestId('version-compare-modal-same-version')).toBeInTheDocument();
+      });
+
+      // Then verify change counter shows no changes
+      const counter = screen.getByTestId('version-compare-modal-change-counter');
+      expect(counter).toHaveTextContent('No changes');
+    });
+
+    it('navigates to next change when next button clicked', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const nextButton = screen.getByTestId('version-compare-modal-next-change');
+      const counter = screen.getByTestId('version-compare-modal-change-counter');
+
+      await user.click(nextButton);
+
+      // Counter should update
+      expect(counter.textContent).not.toBe('No changes');
+    });
+
+    it('navigates to previous change when prev button clicked', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const nextButton = screen.getByTestId('version-compare-modal-next-change');
+      const prevButton = screen.getByTestId('version-compare-modal-prev-change');
+
+      // Navigate forward first
+      await user.click(nextButton);
+      await user.click(nextButton);
+
+      // Then back
+      await user.click(prevButton);
+
+      // Should have navigated
+      expect(screen.getByTestId('version-compare-modal-change-counter')).toBeInTheDocument();
+    });
+  });
+
+  describe('copy functionality', () => {
+    it('renders copy buttons', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByTestId('version-compare-modal-copy-left')).toBeInTheDocument();
+      expect(screen.getByTestId('version-compare-modal-copy-right')).toBeInTheDocument();
+    });
+
+    it('copy left button can be clicked', async () => {
+      const user = userEvent.setup();
+
+      // Mock clipboard for this test
+      const writeTextMock = vi.fn(() => Promise.resolve());
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: writeTextMock },
+        writable: true,
+        configurable: true,
+      });
+
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const copyLeftButton = screen.getByTestId('version-compare-modal-copy-left');
+
+      // Button should be clickable and have correct aria-label
+      expect(copyLeftButton).toBeInTheDocument();
+      expect(copyLeftButton).toHaveAttribute('aria-label');
+
+      await user.click(copyLeftButton);
+
+      // Verify the clipboard API was called
+      await waitFor(() => {
+        expect(writeTextMock).toHaveBeenCalled();
+      });
+    });
+
+    it('copy right button can be clicked', async () => {
+      const user = userEvent.setup();
+
+      // Mock clipboard for this test
+      const writeTextMock = vi.fn(() => Promise.resolve());
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: writeTextMock },
+        writable: true,
+        configurable: true,
+      });
+
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const copyRightButton = screen.getByTestId('version-compare-modal-copy-right');
+
+      expect(copyRightButton).toBeInTheDocument();
+      expect(copyRightButton).toHaveAttribute('aria-label');
+
+      await user.click(copyRightButton);
+
+      // Verify the clipboard API was called
+      await waitFor(() => {
+        expect(writeTextMock).toHaveBeenCalled();
+      });
+    });
+
+    it('copy buttons have correct labels', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const copyLeftButton = screen.getByTestId('version-compare-modal-copy-left');
+      const copyRightButton = screen.getByTestId('version-compare-modal-copy-right');
+
+      expect(copyLeftButton).toHaveTextContent('Copy Left');
+      expect(copyRightButton).toHaveTextContent('Copy Right');
+    });
+  });
+
+  describe('closing modal', () => {
+    it('calls onClose when close button clicked', async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} onClose={onClose} />);
+
+      const closeButton = screen.getByTestId('version-compare-modal-close');
+      await user.click(closeButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onClose when overlay clicked', async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} onClose={onClose} />);
+
+      const overlay = screen.getByTestId('version-compare-modal');
+      await user.click(overlay);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('does not close when modal content clicked', async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} onClose={onClose} />);
+
+      const content = screen.getByTestId('version-compare-modal-content');
+      await user.click(content);
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('calls onClose when Escape key pressed', () => {
+      const onClose = vi.fn();
+      render(<VersionCompareModal {...defaultProps} onClose={onClose} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('navigates to next change with Ctrl+ArrowDown', async () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const counter = screen.getByTestId('version-compare-modal-change-counter');
+
+      fireEvent.keyDown(document, { key: 'ArrowDown', ctrlKey: true });
+
+      // Should update navigation state
+      await waitFor(() => {
+        expect(counter).toBeInTheDocument();
+      });
+    });
+
+    it('navigates to previous change with Ctrl+ArrowUp', async () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      // Navigate forward first
+      fireEvent.keyDown(document, { key: 'ArrowDown', ctrlKey: true });
+      fireEvent.keyDown(document, { key: 'ArrowDown', ctrlKey: true });
+
+      // Then back
+      fireEvent.keyDown(document, { key: 'ArrowUp', ctrlKey: true });
+
+      expect(screen.getByTestId('version-compare-modal-change-counter')).toBeInTheDocument();
+    });
+
+    it('navigates with Ctrl+J', async () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      fireEvent.keyDown(document, { key: 'j', ctrlKey: true });
+
+      expect(screen.getByTestId('version-compare-modal-change-counter')).toBeInTheDocument();
+    });
+
+    it('navigates with Ctrl+K', async () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+
+      expect(screen.getByTestId('version-compare-modal-change-counter')).toBeInTheDocument();
+    });
+  });
+
+  describe('focus management', () => {
+    it('traps focus within modal', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+    });
+
+    it('has aria-modal attribute', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has role="dialog"', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('has aria-labelledby pointing to title', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'version-compare-modal-title');
+    });
+
+    it('left select has aria-label', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const leftSelect = screen.getByTestId('version-compare-modal-left-select');
+      expect(leftSelect).toHaveAttribute('aria-label', 'Select left version to compare');
+    });
+
+    it('right select has aria-label', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select');
+      expect(rightSelect).toHaveAttribute('aria-label', 'Select right version to compare');
+    });
+
+    it('swap button has aria-label', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const swapButton = screen.getByTestId('version-compare-modal-swap');
+      expect(swapButton).toHaveAttribute('aria-label', 'Swap left and right versions');
+    });
+
+    it('close button has aria-label', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const closeButton = screen.getByTestId('version-compare-modal-close');
+      expect(closeButton).toHaveAttribute('aria-label', 'Close comparison modal');
+    });
+
+    it('navigation buttons have aria-labels', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const prevButton = screen.getByTestId('version-compare-modal-prev-change');
+      const nextButton = screen.getByTestId('version-compare-modal-next-change');
+
+      expect(prevButton).toHaveAttribute('aria-label', 'Go to previous change');
+      expect(nextButton).toHaveAttribute('aria-label', 'Go to next change');
+    });
+
+    it('copy buttons have aria-labels', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const copyLeftButton = screen.getByTestId('version-compare-modal-copy-left');
+      const copyRightButton = screen.getByTestId('version-compare-modal-copy-right');
+
+      expect(copyLeftButton).toHaveAttribute('aria-label');
+      expect(copyRightButton).toHaveAttribute('aria-label');
+    });
+
+    it('change counter has aria-live for screen readers', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const counter = screen.getByTestId('version-compare-modal-change-counter');
+      expect(counter).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('navigation area has role="navigation"', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      const nav = screen.getByRole('navigation');
+      expect(nav).toHaveAttribute('aria-label', 'Navigate between changes');
+    });
+  });
+
+  describe('footer information', () => {
+    it('displays left version info', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByText('Left:')).toBeInTheDocument();
+    });
+
+    it('displays right version info', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByText('Right:')).toBeInTheDocument();
+    });
+  });
+
+  describe('keyboard hints', () => {
+    it('displays keyboard hints', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(screen.getByText('Close')).toBeInTheDocument();
+      // Use regex to match partial text since it contains keyboard elements
+      expect(screen.getByText(/Navigate changes/)).toBeInTheDocument();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty versions array', () => {
+      render(<VersionCompareModal {...defaultProps} versions={[]} />);
+
+      // Should still render with just original
+      expect(screen.getByTestId('version-compare-modal')).toBeInTheDocument();
+
+      const leftSelect = screen.getByTestId('version-compare-modal-left-select') as HTMLSelectElement;
+      expect(leftSelect.value).toBe('original');
+    });
+
+    it('handles empty original text', () => {
+      render(<VersionCompareModal {...defaultProps} originalText="" />);
+
+      expect(screen.getByTestId('version-compare-modal')).toBeInTheDocument();
+    });
+
+    it('updates when modal reopens with different initial versions', async () => {
+      const { rerender } = render(
+        <VersionCompareModal
+          {...defaultProps}
+          isOpen={false}
+          initialLeftVersionId="v1"
+          initialRightVersionId="v2"
+        />
+      );
+
+      rerender(
+        <VersionCompareModal
+          {...defaultProps}
+          isOpen={true}
+          initialLeftVersionId="v2"
+          initialRightVersionId="v3"
+        />
+      );
+
+      // Wait for requestAnimationFrame to complete
+      await waitFor(() => {
+        const leftSelect = screen.getByTestId('version-compare-modal-left-select') as HTMLSelectElement;
+        expect(leftSelect.value).toBe('v2');
+      });
+
+      const rightSelect = screen.getByTestId('version-compare-modal-right-select') as HTMLSelectElement;
+      expect(rightSelect.value).toBe('v3');
+    });
+
+    it('resets change index when version changes', async () => {
+      const user = userEvent.setup();
+      render(<VersionCompareModal {...defaultProps} />);
+
+      // Navigate to some change
+      const nextButton = screen.getByTestId('version-compare-modal-next-change');
+      await user.click(nextButton);
+      await user.click(nextButton);
+
+      // Change version
+      const leftSelect = screen.getByTestId('version-compare-modal-left-select');
+      await user.selectOptions(leftSelect, 'v1');
+
+      // Counter should reset
+      const counter = screen.getByTestId('version-compare-modal-change-counter');
+      expect(counter.textContent).toMatch(/1 \/ \d+|No changes/);
+    });
+  });
+
+  describe('scrolling behavior', () => {
+    it('prevents body scroll when modal is open', () => {
+      render(<VersionCompareModal {...defaultProps} />);
+
+      expect(document.body.style.overflow).toBe('hidden');
+    });
+
+    it('restores body scroll when modal closes', () => {
+      const { rerender } = render(<VersionCompareModal {...defaultProps} />);
+
+      rerender(<VersionCompareModal {...defaultProps} isOpen={false} />);
+
+      // Body scroll should be restored (empty string means default behavior)
+      expect(document.body.style.overflow).not.toBe('hidden');
+    });
+  });
+});

--- a/web/src/components/LyricEditor/VersionCompareModal.tsx
+++ b/web/src/components/LyricEditor/VersionCompareModal.tsx
@@ -1,0 +1,833 @@
+/**
+ * VersionCompareModal Component
+ *
+ * A modal dialog for comparing any two lyric versions side-by-side.
+ * Features version selection dropdowns, diff visualization, copy functionality,
+ * and keyboard navigation between changes.
+ *
+ * @module components/LyricEditor/VersionCompareModal
+ */
+
+import type { ReactElement } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { DiffView } from './DiffView';
+import { InlineDiff } from './InlineDiff';
+import { computeLineDiff } from './diffUtils';
+import type { VersionCompareModalProps, DiffViewMode } from './types';
+import './VersionCompareModal.css';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[VersionCompareModal] ${message}`, ...args);
+  }
+};
+
+/**
+ * Represents a selectable version option
+ */
+interface VersionOption {
+  id: string;
+  label: string;
+  description: string;
+  lyrics: string;
+  timestamp: number | null;
+}
+
+/**
+ * Format timestamp to human-readable string
+ */
+function formatTimestamp(timestamp: number): string {
+  return new Date(timestamp).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Get relative time string
+ */
+function getRelativeTime(timestamp: number): string {
+  const now = Date.now();
+  const diff = now - timestamp;
+
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `${days}d ago`;
+  } else if (hours > 0) {
+    return `${hours}h ago`;
+  } else if (minutes > 0) {
+    return `${minutes}m ago`;
+  } else if (seconds > 10) {
+    return `${seconds}s ago`;
+  } else {
+    return 'Just now';
+  }
+}
+
+/**
+ * Copy icon SVG component
+ */
+function CopyIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+/**
+ * Check icon SVG component
+ */
+function CheckIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+/**
+ * Arrow up icon for navigating to previous change
+ */
+function ArrowUpIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="12" y1="19" x2="12" y2="5" />
+      <polyline points="5 12 12 5 19 12" />
+    </svg>
+  );
+}
+
+/**
+ * Arrow down icon for navigating to next change
+ */
+function ArrowDownIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <polyline points="19 12 12 19 5 12" />
+    </svg>
+  );
+}
+
+/**
+ * Close icon SVG component
+ */
+function CloseIcon(): ReactElement {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+/**
+ * VersionCompareModal provides a full-featured version comparison interface.
+ *
+ * Features:
+ * - Select any two versions to compare (including original)
+ * - Side-by-side or inline diff visualization
+ * - Highlight differences with clear visual indicators
+ * - Copy either version to clipboard
+ * - Navigate between changes with keyboard shortcuts
+ * - Fully accessible with ARIA labels and keyboard support
+ *
+ * @example
+ * ```tsx
+ * <VersionCompareModal
+ *   isOpen={showCompare}
+ *   onClose={() => setShowCompare(false)}
+ *   versions={versions}
+ *   originalText={originalPoem}
+ * />
+ * ```
+ */
+export function VersionCompareModal({
+  isOpen,
+  onClose,
+  versions,
+  originalText,
+  initialLeftVersionId,
+  initialRightVersionId,
+  className = '',
+  testId = 'version-compare-modal',
+}: VersionCompareModalProps): ReactElement | null {
+  // Local state
+  const [leftVersionId, setLeftVersionId] = useState<string>(
+    initialLeftVersionId ?? 'original'
+  );
+  const [rightVersionId, setRightVersionId] = useState<string>(
+    initialRightVersionId ?? (versions.length > 0 ? versions[versions.length - 1].id : 'original')
+  );
+  const [diffViewMode, setDiffViewMode] = useState<DiffViewMode>('side-by-side');
+  const [copiedSide, setCopiedSide] = useState<'left' | 'right' | null>(null);
+  const [currentChangeIndex, setCurrentChangeIndex] = useState<number>(0);
+
+  // Refs
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const leftSelectRef = useRef<HTMLSelectElement>(null);
+  const previousActiveElementRef = useRef<Element | null>(null);
+  const diffContainerRef = useRef<HTMLDivElement>(null);
+
+  log('Rendering VersionCompareModal', {
+    isOpen,
+    leftVersionId,
+    rightVersionId,
+    versionCount: versions.length,
+  });
+
+  // Build version options array
+  const versionOptions: VersionOption[] = useMemo(() => {
+    const options: VersionOption[] = [
+      {
+        id: 'original',
+        label: 'Original',
+        description: 'Original poem',
+        lyrics: originalText,
+        timestamp: null,
+      },
+    ];
+
+    // Sort versions by timestamp (newest first) for display
+    const sortedVersions = [...versions].sort((a, b) => b.timestamp - a.timestamp);
+
+    sortedVersions.forEach((version) => {
+      const originalIndex = versions.findIndex((v) => v.id === version.id);
+      options.push({
+        id: version.id,
+        label: version.description ?? `Version ${originalIndex + 1}`,
+        description: version.timestamp ? getRelativeTime(version.timestamp) : '',
+        lyrics: version.lyrics,
+        timestamp: version.timestamp,
+      });
+    });
+
+    return options;
+  }, [versions, originalText]);
+
+  // Get selected versions
+  const leftVersion = useMemo(
+    () => versionOptions.find((v) => v.id === leftVersionId) ?? versionOptions[0],
+    [versionOptions, leftVersionId]
+  );
+
+  const rightVersion = useMemo(
+    () => versionOptions.find((v) => v.id === rightVersionId) ?? versionOptions[0],
+    [versionOptions, rightVersionId]
+  );
+
+  // Compute diff result for change navigation
+  const diffResult = useMemo(() => {
+    return computeLineDiff(leftVersion.lyrics, rightVersion.lyrics);
+  }, [leftVersion.lyrics, rightVersion.lyrics]);
+
+  // Count actual changes (non-equal)
+  const changeCount = useMemo(() => {
+    return diffResult.changes.filter((c) => c.type !== 'equal').length;
+  }, [diffResult.changes]);
+
+  // Track the previous isOpen state to detect open/close transitions
+  const wasOpenRef = useRef(false);
+
+  // Reset selections when modal opens (transition from closed to open)
+  useEffect(() => {
+    const wasOpen = wasOpenRef.current;
+    wasOpenRef.current = isOpen;
+
+    // Only reset when transitioning from closed to open
+    if (isOpen && !wasOpen) {
+      log('Modal opened, resetting state');
+      // We defer the state reset to avoid synchronous setState in effect
+      // by using requestAnimationFrame which runs outside the effect cycle
+      requestAnimationFrame(() => {
+        const newLeftId = initialLeftVersionId ?? 'original';
+        const newRightId =
+          initialRightVersionId ?? (versions.length > 0 ? versions[versions.length - 1].id : 'original');
+
+        setLeftVersionId(newLeftId);
+        setRightVersionId(newRightId);
+        setCurrentChangeIndex(0);
+        setCopiedSide(null);
+
+        log('Modal state reset:', { newLeftId, newRightId });
+      });
+    }
+  }, [isOpen, initialLeftVersionId, initialRightVersionId, versions]);
+
+  // Store previously focused element when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      previousActiveElementRef.current = document.activeElement;
+      log('Stored previous active element:', previousActiveElementRef.current);
+    }
+  }, [isOpen]);
+
+  // Focus management - focus left select when dialog opens
+  useEffect(() => {
+    if (isOpen && leftSelectRef.current) {
+      const timeoutId = setTimeout(() => {
+        leftSelectRef.current?.focus();
+        log('Focused left select');
+      }, 10);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [isOpen]);
+
+  // Restore focus when dialog closes
+  useEffect(() => {
+    if (!isOpen && previousActiveElementRef.current) {
+      const elementToFocus = previousActiveElementRef.current as HTMLElement;
+      if (elementToFocus && typeof elementToFocus.focus === 'function') {
+        const timeoutId = setTimeout(() => {
+          elementToFocus.focus();
+          log('Restored focus to previous element');
+        }, 10);
+        return () => clearTimeout(timeoutId);
+      }
+    }
+  }, [isOpen]);
+
+  // Scroll to a specific change
+  const scrollToChange = useCallback(
+    (index: number): void => {
+      if (!diffContainerRef.current) return;
+
+      // Find changed rows in the diff view
+      const changedRows = diffContainerRef.current.querySelectorAll(
+        '.diff-view__line-content--add, .diff-view__line-content--remove, ' +
+          '.inline-diff__change--add, .inline-diff__change--remove'
+      );
+
+      const element = changedRows[index] as HTMLElement | undefined;
+      if (element && typeof element.scrollIntoView === 'function') {
+        element.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+        });
+        log('Scrolled to change:', index);
+      }
+    },
+    []
+  );
+
+  // Navigate to next change
+  const handleNextChange = useCallback((): void => {
+    if (changeCount === 0) return;
+    const nextIndex = (currentChangeIndex + 1) % changeCount;
+    log('Navigating to next change:', nextIndex);
+    setCurrentChangeIndex(nextIndex);
+
+    // Scroll to the change
+    scrollToChange(nextIndex);
+  }, [changeCount, currentChangeIndex, scrollToChange]);
+
+  // Navigate to previous change
+  const handlePrevChange = useCallback((): void => {
+    if (changeCount === 0) return;
+    const prevIndex = currentChangeIndex === 0 ? changeCount - 1 : currentChangeIndex - 1;
+    log('Navigating to previous change:', prevIndex);
+    setCurrentChangeIndex(prevIndex);
+
+    // Scroll to the change
+    scrollToChange(prevIndex);
+  }, [changeCount, currentChangeIndex, scrollToChange]);
+
+  // Keyboard handling
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent): void => {
+      if (!isOpen) return;
+
+      log('Key pressed:', event.key);
+
+      // Escape to close
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        log('Escape pressed, closing modal');
+        onClose();
+        return;
+      }
+
+      // Navigate changes with J/K or arrow keys (when not in select)
+      const activeElement = document.activeElement;
+      const isInSelect = activeElement?.tagName === 'SELECT';
+
+      if (!isInSelect) {
+        if (event.key === 'j' || event.key === 'ArrowDown') {
+          if (event.ctrlKey || event.metaKey) {
+            event.preventDefault();
+            handleNextChange();
+          }
+        } else if (event.key === 'k' || event.key === 'ArrowUp') {
+          if (event.ctrlKey || event.metaKey) {
+            event.preventDefault();
+            handlePrevChange();
+          }
+        }
+      }
+
+      // Tab focus trap
+      if (event.key === 'Tab') {
+        const focusableElements = dialogRef.current?.querySelectorAll(
+          'button:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+
+        if (!focusableElements || focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0] as HTMLElement;
+        const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+            log('Focus wrapped to last element');
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+            log('Focus wrapped to first element');
+          }
+        }
+      }
+    },
+    [isOpen, onClose, handleNextChange, handlePrevChange]
+  );
+
+  // Add keyboard listeners
+  useEffect(() => {
+    if (!isOpen) return;
+
+    log('Adding keyboard listeners');
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      log('Removing keyboard listeners');
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, handleKeyDown]);
+
+  // Prevent body scroll when dialog is open
+  useEffect(() => {
+    if (isOpen) {
+      const previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      log('Prevented body scroll');
+
+      return () => {
+        document.body.style.overflow = previousOverflow;
+        log('Restored body scroll');
+      };
+    }
+  }, [isOpen]);
+
+  // Handle overlay click
+  const handleOverlayClick = useCallback(
+    (event: React.MouseEvent): void => {
+      if (event.target === event.currentTarget) {
+        log('Overlay clicked, closing modal');
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  // Handle close button click
+  const handleClose = useCallback((): void => {
+    log('Close button clicked');
+    onClose();
+  }, [onClose]);
+
+  // Handle left version change
+  const handleLeftVersionChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      const newId = event.target.value;
+      log('Left version changed to:', newId);
+      setLeftVersionId(newId);
+      setCurrentChangeIndex(0);
+    },
+    []
+  );
+
+  // Handle right version change
+  const handleRightVersionChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      const newId = event.target.value;
+      log('Right version changed to:', newId);
+      setRightVersionId(newId);
+      setCurrentChangeIndex(0);
+    },
+    []
+  );
+
+  // Swap versions
+  const handleSwapVersions = useCallback((): void => {
+    log('Swapping versions');
+    const temp = leftVersionId;
+    setLeftVersionId(rightVersionId);
+    setRightVersionId(temp);
+    setCurrentChangeIndex(0);
+  }, [leftVersionId, rightVersionId]);
+
+  // Toggle diff view mode
+  const handleToggleDiffMode = useCallback((): void => {
+    const newMode = diffViewMode === 'side-by-side' ? 'inline' : 'side-by-side';
+    log('Toggling diff mode to:', newMode);
+    setDiffViewMode(newMode);
+  }, [diffViewMode]);
+
+  // Copy left version to clipboard
+  const handleCopyLeft = useCallback(async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(leftVersion.lyrics);
+      log('Copied left version to clipboard');
+      setCopiedSide('left');
+      setTimeout(() => setCopiedSide(null), 2000);
+    } catch (error) {
+      log('Failed to copy left version:', error);
+    }
+  }, [leftVersion.lyrics]);
+
+  // Copy right version to clipboard
+  const handleCopyRight = useCallback(async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(rightVersion.lyrics);
+      log('Copied right version to clipboard');
+      setCopiedSide('right');
+      setTimeout(() => setCopiedSide(null), 2000);
+    } catch (error) {
+      log('Failed to copy right version:', error);
+    }
+  }, [rightVersion.lyrics]);
+
+  // Don't render if not open
+  if (!isOpen) {
+    return null;
+  }
+
+  const containerClass = [
+    'version-compare-modal',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  return (
+    <div
+      className="version-compare-modal__overlay"
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="version-compare-modal-title"
+      data-testid={testId}
+    >
+      <div
+        ref={dialogRef}
+        className={containerClass}
+        data-testid={`${testId}-content`}
+      >
+        {/* Header */}
+        <header className="version-compare-modal__header">
+          <h2
+            id="version-compare-modal-title"
+            className="version-compare-modal__title"
+          >
+            Compare Versions
+          </h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="version-compare-modal__close"
+            onClick={handleClose}
+            aria-label="Close comparison modal"
+            data-testid={`${testId}-close`}
+          >
+            <CloseIcon />
+          </button>
+        </header>
+
+        {/* Version selectors */}
+        <div className="version-compare-modal__selectors">
+          {/* Left version selector */}
+          <div className="version-compare-modal__selector">
+            <label
+              htmlFor="left-version-select"
+              className="version-compare-modal__selector-label"
+            >
+              Left (Base)
+            </label>
+            <select
+              ref={leftSelectRef}
+              id="left-version-select"
+              className="version-compare-modal__select"
+              value={leftVersionId}
+              onChange={handleLeftVersionChange}
+              aria-label="Select left version to compare"
+              data-testid={`${testId}-left-select`}
+            >
+              {versionOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                  {option.timestamp ? ` (${option.description})` : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Swap button */}
+          <button
+            type="button"
+            className="version-compare-modal__swap"
+            onClick={handleSwapVersions}
+            aria-label="Swap left and right versions"
+            title="Swap versions"
+            data-testid={`${testId}-swap`}
+          >
+            ⇄
+          </button>
+
+          {/* Right version selector */}
+          <div className="version-compare-modal__selector">
+            <label
+              htmlFor="right-version-select"
+              className="version-compare-modal__selector-label"
+            >
+              Right (Compare)
+            </label>
+            <select
+              id="right-version-select"
+              className="version-compare-modal__select"
+              value={rightVersionId}
+              onChange={handleRightVersionChange}
+              aria-label="Select right version to compare"
+              data-testid={`${testId}-right-select`}
+            >
+              {versionOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                  {option.timestamp ? ` (${option.description})` : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Toolbar */}
+        <div className="version-compare-modal__toolbar">
+          {/* View mode toggle */}
+          <button
+            type="button"
+            className="version-compare-modal__toolbar-btn"
+            onClick={handleToggleDiffMode}
+            aria-label={`Switch to ${diffViewMode === 'side-by-side' ? 'inline' : 'side-by-side'} view`}
+            data-testid={`${testId}-toggle-mode`}
+          >
+            {diffViewMode === 'side-by-side' ? 'Inline View' : 'Side-by-Side'}
+          </button>
+
+          {/* Change navigation */}
+          <div
+            className="version-compare-modal__nav"
+            role="navigation"
+            aria-label="Navigate between changes"
+          >
+            <button
+              type="button"
+              className="version-compare-modal__nav-btn"
+              onClick={handlePrevChange}
+              disabled={changeCount === 0}
+              aria-label="Go to previous change"
+              title="Previous change (Ctrl+K)"
+              data-testid={`${testId}-prev-change`}
+            >
+              <ArrowUpIcon />
+            </button>
+            <span
+              className="version-compare-modal__nav-counter"
+              aria-live="polite"
+              data-testid={`${testId}-change-counter`}
+            >
+              {changeCount > 0 ? `${currentChangeIndex + 1} / ${changeCount}` : 'No changes'}
+            </span>
+            <button
+              type="button"
+              className="version-compare-modal__nav-btn"
+              onClick={handleNextChange}
+              disabled={changeCount === 0}
+              aria-label="Go to next change"
+              title="Next change (Ctrl+J)"
+              data-testid={`${testId}-next-change`}
+            >
+              <ArrowDownIcon />
+            </button>
+          </div>
+
+          {/* Copy buttons */}
+          <div className="version-compare-modal__copy-actions">
+            <button
+              type="button"
+              className={`version-compare-modal__copy-btn ${copiedSide === 'left' ? 'version-compare-modal__copy-btn--copied' : ''}`}
+              onClick={handleCopyLeft}
+              aria-label={`Copy ${leftVersion.label} to clipboard`}
+              title={`Copy ${leftVersion.label}`}
+              data-testid={`${testId}-copy-left`}
+            >
+              {copiedSide === 'left' ? <CheckIcon /> : <CopyIcon />}
+              <span>Copy Left</span>
+            </button>
+            <button
+              type="button"
+              className={`version-compare-modal__copy-btn ${copiedSide === 'right' ? 'version-compare-modal__copy-btn--copied' : ''}`}
+              onClick={handleCopyRight}
+              aria-label={`Copy ${rightVersion.label} to clipboard`}
+              title={`Copy ${rightVersion.label}`}
+              data-testid={`${testId}-copy-right`}
+            >
+              {copiedSide === 'right' ? <CheckIcon /> : <CopyIcon />}
+              <span>Copy Right</span>
+            </button>
+          </div>
+        </div>
+
+        {/* Diff view */}
+        <div
+          ref={diffContainerRef}
+          className="version-compare-modal__diff"
+          data-testid={`${testId}-diff`}
+        >
+          {leftVersionId === rightVersionId ? (
+            <div
+              className="version-compare-modal__same-version"
+              data-testid={`${testId}-same-version`}
+            >
+              <p>Both sides are showing the same version.</p>
+              <p>Select different versions to compare.</p>
+            </div>
+          ) : diffViewMode === 'side-by-side' ? (
+            <DiffView
+              originalText={leftVersion.lyrics}
+              modifiedText={rightVersion.lyrics}
+              testId={`${testId}-diff-view`}
+            />
+          ) : (
+            <InlineDiff
+              originalText={leftVersion.lyrics}
+              modifiedText={rightVersion.lyrics}
+              showLineNumbers
+              testId={`${testId}-inline-diff`}
+            />
+          )}
+        </div>
+
+        {/* Footer with version info */}
+        <footer className="version-compare-modal__footer">
+          <div className="version-compare-modal__footer-info">
+            <span className="version-compare-modal__footer-label">Left:</span>
+            <span className="version-compare-modal__footer-value">
+              {leftVersion.label}
+              {leftVersion.timestamp && (
+                <span
+                  className="version-compare-modal__footer-time"
+                  title={formatTimestamp(leftVersion.timestamp)}
+                >
+                  {' '}
+                  ({leftVersion.description})
+                </span>
+              )}
+            </span>
+          </div>
+          <div className="version-compare-modal__footer-info">
+            <span className="version-compare-modal__footer-label">Right:</span>
+            <span className="version-compare-modal__footer-value">
+              {rightVersion.label}
+              {rightVersion.timestamp && (
+                <span
+                  className="version-compare-modal__footer-time"
+                  title={formatTimestamp(rightVersion.timestamp)}
+                >
+                  {' '}
+                  ({rightVersion.description})
+                </span>
+              )}
+            </span>
+          </div>
+        </footer>
+
+        {/* Keyboard shortcuts hint */}
+        <div className="version-compare-modal__hints" aria-hidden="true">
+          <span className="version-compare-modal__hint">
+            <kbd>Esc</kbd> Close
+          </span>
+          <span className="version-compare-modal__hint">
+            <kbd>Ctrl</kbd>+<kbd>↑</kbd>/<kbd>↓</kbd> Navigate changes
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default VersionCompareModal;

--- a/web/src/components/LyricEditor/index.ts
+++ b/web/src/components/LyricEditor/index.ts
@@ -14,6 +14,7 @@ export { DiffView } from './DiffView';
 export { InlineDiff } from './InlineDiff';
 export { SuggestionCard } from './SuggestionCard';
 export { VersionList } from './VersionList';
+export { VersionCompareModal } from './VersionCompareModal';
 
 // Types (all props and utility types from types.ts)
 export type {
@@ -28,6 +29,7 @@ export type {
   LyricVersion,
   SuggestionCardProps,
   SuggestionStatus,
+  VersionCompareModalProps,
   VersionListProps,
 } from './types';
 

--- a/web/src/components/LyricEditor/types.ts
+++ b/web/src/components/LyricEditor/types.ts
@@ -177,6 +177,28 @@ export interface LyricEditorProps {
   testId?: string;
 }
 
+/**
+ * Props for VersionCompareModal component
+ */
+export interface VersionCompareModalProps {
+  /** Whether the modal is open */
+  isOpen: boolean;
+  /** Callback when the modal should close */
+  onClose: () => void;
+  /** List of versions to compare */
+  versions: LyricVersion[];
+  /** The original text (for version comparison) */
+  originalText: string;
+  /** Optional initial left version ID (defaults to 'original') */
+  initialLeftVersionId?: string;
+  /** Optional initial right version ID (defaults to latest version) */
+  initialRightVersionId?: string;
+  /** Optional CSS class name */
+  className?: string;
+  /** Test ID for testing */
+  testId?: string;
+}
+
 // =============================================================================
 // Re-export LyricVersion for convenience
 // =============================================================================


### PR DESCRIPTION
## Summary
- Created `VersionCompareModal` component for comparing any two lyric versions
- Side-by-side diff view with highlighted differences
- Keyboard navigation and copy functionality
- Full accessibility support

## Changes
- `web/src/components/LyricEditor/VersionCompareModal.tsx` - Main modal component with version selection, diff display, and navigation
- `web/src/components/LyricEditor/VersionCompareModal.css` - Styling with dark mode support
- `web/src/components/LyricEditor/VersionCompareModal.test.tsx` - Comprehensive test suite (62 tests)
- `web/src/components/LyricEditor/types.ts` - Added `VersionCompareModalProps` interface
- `web/src/components/LyricEditor/index.ts` - Updated exports

## Features
- Select any two versions to compare (including original)
- Toggle between side-by-side and inline diff views
- Navigate between changes with up/down arrows or Ctrl+J/K
- Copy either version to clipboard
- Swap versions with one click
- Full keyboard navigation and focus management
- ARIA labels for screen reader support

## Testing
- [x] Unit tests pass (`npm test`)
- [x] Check passes (`npm run check`)
- [x] Manual testing performed

## Notes
This component reuses existing `DiffView` and `InlineDiff` components for consistent diff rendering.

Closes #58