### PR TITLE
feat(GH-53): Add privacy-respecting analytics and error tracking

### DIFF
--- a/web/src/components/Privacy/PrivacySettings.css
+++ b/web/src/components/Privacy/PrivacySettings.css
@@ -1,0 +1,339 @@
+/**
+ * PrivacySettings Component Styles
+ */
+
+.privacy-settings {
+  max-width: 640px;
+  padding: 1.5rem;
+  background: var(--color-surface, #fff);
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.privacy-settings__title {
+  margin: 0 0 1.5rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+/* DNT Banner */
+.privacy-settings__banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.privacy-settings__banner--dnt {
+  background: var(--color-info-bg, #eff6ff);
+  border: 1px solid var(--color-info-border, #bfdbfe);
+  color: var(--color-info-text, #1e40af);
+}
+
+.privacy-settings__banner-icon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* Sections */
+.privacy-settings__section {
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--color-border, #e5e5e5);
+}
+
+.privacy-settings__section:last-child {
+  border-bottom: none;
+}
+
+.privacy-settings__section-title {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+/* Toggle Row */
+.privacy-settings__toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.privacy-settings__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.privacy-settings__label-text {
+  font-weight: 500;
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+.privacy-settings__label-description {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #666);
+}
+
+/* Toggle Switch */
+.privacy-settings__toggle {
+  position: relative;
+  width: 48px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 13px;
+  background: var(--color-neutral-300, #d1d5db);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.privacy-settings__toggle:hover:not(:disabled) {
+  background: var(--color-neutral-400, #9ca3af);
+}
+
+.privacy-settings__toggle--on {
+  background: var(--color-primary, #3b82f6);
+}
+
+.privacy-settings__toggle--on:hover:not(:disabled) {
+  background: var(--color-primary-dark, #2563eb);
+}
+
+.privacy-settings__toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.privacy-settings__toggle:focus-visible {
+  outline: 2px solid var(--color-primary, #3b82f6);
+  outline-offset: 2px;
+}
+
+.privacy-settings__toggle-slider {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.privacy-settings__toggle--on .privacy-settings__toggle-slider {
+  transform: translateX(22px);
+}
+
+/* Status */
+.privacy-settings__status {
+  margin: 0.75rem 0 0;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #666);
+}
+
+.privacy-settings__status-value {
+  font-weight: 500;
+  color: var(--color-text-muted, #999);
+}
+
+.privacy-settings__status-value--active {
+  color: var(--color-success, #22c55e);
+}
+
+/* Stats */
+.privacy-settings__stats {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 1rem;
+}
+
+.privacy-settings__stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.privacy-settings__stat-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+.privacy-settings__stat-label {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #666);
+}
+
+/* Actions */
+.privacy-settings__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.privacy-settings__button {
+  padding: 0.5rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.privacy-settings__button:focus-visible {
+  outline: 2px solid var(--color-primary, #3b82f6);
+  outline-offset: 2px;
+}
+
+.privacy-settings__button--secondary {
+  background: var(--color-surface, #fff);
+  border-color: var(--color-border, #d1d5db);
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+.privacy-settings__button--secondary:hover {
+  background: var(--color-neutral-50, #f9fafb);
+  border-color: var(--color-neutral-400, #9ca3af);
+}
+
+.privacy-settings__button--danger {
+  background: var(--color-danger-bg, #fef2f2);
+  border-color: var(--color-danger-border, #fecaca);
+  color: var(--color-danger, #dc2626);
+}
+
+.privacy-settings__button--danger:hover {
+  background: var(--color-danger-bg-hover, #fee2e2);
+  border-color: var(--color-danger, #dc2626);
+}
+
+/* Policy */
+.privacy-settings__policy {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--color-text-secondary, #374151);
+}
+
+.privacy-settings__policy-heading {
+  margin: 1rem 0 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+.privacy-settings__policy-heading:first-child {
+  margin-top: 0;
+}
+
+.privacy-settings__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  list-style-type: disc;
+}
+
+.privacy-settings__list li {
+  margin-bottom: 0.25rem;
+}
+
+.privacy-settings__list--negative li::marker {
+  color: var(--color-danger, #dc2626);
+}
+
+.privacy-settings__policy-note {
+  margin: 1rem 0 0;
+  padding: 0.75rem;
+  background: var(--color-neutral-50, #f9fafb);
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #666);
+}
+
+/* Screen reader only */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .privacy-settings {
+    background: var(--color-surface-dark, #1f2937);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  }
+
+  .privacy-settings__title,
+  .privacy-settings__section-title,
+  .privacy-settings__label-text,
+  .privacy-settings__stat-value,
+  .privacy-settings__policy-heading {
+    color: var(--color-text-primary-dark, #f9fafb);
+  }
+
+  .privacy-settings__label-description,
+  .privacy-settings__status,
+  .privacy-settings__stat-label,
+  .privacy-settings__policy {
+    color: var(--color-text-secondary-dark, #9ca3af);
+  }
+
+  .privacy-settings__section {
+    border-color: var(--color-border-dark, #374151);
+  }
+
+  .privacy-settings__toggle {
+    background: var(--color-neutral-600, #4b5563);
+  }
+
+  .privacy-settings__button--secondary {
+    background: var(--color-surface-dark, #1f2937);
+    border-color: var(--color-border-dark, #374151);
+    color: var(--color-text-primary-dark, #f9fafb);
+  }
+
+  .privacy-settings__button--secondary:hover {
+    background: var(--color-neutral-700, #374151);
+  }
+
+  .privacy-settings__policy-note {
+    background: var(--color-neutral-800, #1f2937);
+  }
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .privacy-settings {
+    padding: 1rem;
+  }
+
+  .privacy-settings__stats {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .privacy-settings__actions {
+    flex-direction: column;
+  }
+
+  .privacy-settings__button {
+    width: 100%;
+  }
+}

--- a/web/src/components/Privacy/PrivacySettings.test.tsx
+++ b/web/src/components/Privacy/PrivacySettings.test.tsx
@@ -1,0 +1,370 @@
+/**
+ * PrivacySettings Component Tests
+ *
+ * Tests for the privacy settings component.
+ *
+ * @module components/Privacy/PrivacySettings.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { PrivacySettings } from './PrivacySettings';
+import { useAnalyticsStore } from '@/stores/useAnalyticsStore';
+import { renderHook } from '@testing-library/react';
+
+// Mock localStorage and sessionStorage
+const mockStorage: Record<string, string> = {};
+const mockSessionStorage: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => mockStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockStorage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete mockStorage[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
+  }),
+};
+
+const sessionStorageMock = {
+  getItem: vi.fn((key: string) => mockSessionStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockSessionStorage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete mockSessionStorage[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(mockSessionStorage).forEach((key) => delete mockSessionStorage[key]);
+  }),
+};
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessionStorageMock,
+  writable: true,
+});
+
+// Mock URL.createObjectURL
+global.URL.createObjectURL = vi.fn(() => 'blob:test');
+global.URL.revokeObjectURL = vi.fn();
+
+describe('PrivacySettings', () => {
+  beforeEach(() => {
+    // Clear mocks and storage
+    vi.clearAllMocks();
+    localStorageMock.clear();
+    sessionStorageMock.clear();
+
+    // Reset navigator.doNotTrack
+    Object.defineProperty(navigator, 'doNotTrack', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    // Reset the analytics store
+    const { result } = renderHook(() => useAnalyticsStore());
+    act(() => {
+      result.current.reset();
+      result.current.initialize();
+    });
+  });
+
+  afterEach(() => {
+    const { result } = renderHook(() => useAnalyticsStore());
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  describe('rendering', () => {
+    it('should render the privacy settings component', () => {
+      render(<PrivacySettings />);
+
+      expect(screen.getByText('Privacy Settings')).toBeInTheDocument();
+    });
+
+    it('should render the analytics toggle', () => {
+      render(<PrivacySettings />);
+
+      expect(screen.getByText('Enable anonymous analytics')).toBeInTheDocument();
+      expect(screen.getByRole('switch')).toBeInTheDocument();
+    });
+
+    it('should render data export button', () => {
+      render(<PrivacySettings />);
+
+      expect(screen.getByText('Export My Data')).toBeInTheDocument();
+    });
+
+    it('should render clear data button', () => {
+      render(<PrivacySettings />);
+
+      expect(screen.getByText('Clear All Data')).toBeInTheDocument();
+    });
+
+    it('should render privacy policy when showPolicy is true', () => {
+      render(<PrivacySettings showPolicy={true} />);
+
+      expect(screen.getByText('What We Collect')).toBeInTheDocument();
+      expect(screen.getByText('We DO collect:')).toBeInTheDocument();
+      expect(screen.getByText('We DO NOT collect:')).toBeInTheDocument();
+    });
+
+    it('should not render privacy policy when showPolicy is false', () => {
+      render(<PrivacySettings showPolicy={false} />);
+
+      expect(screen.queryByText('What We Collect')).not.toBeInTheDocument();
+    });
+
+    it('should apply custom className', () => {
+      render(<PrivacySettings className="custom-class" />);
+
+      const container = screen.getByTestId('privacy-settings');
+      expect(container).toHaveClass('custom-class');
+    });
+
+    it('should use custom testId', () => {
+      render(<PrivacySettings testId="custom-privacy" />);
+
+      expect(screen.getByTestId('custom-privacy')).toBeInTheDocument();
+    });
+  });
+
+  describe('analytics toggle', () => {
+    it('should show toggle as on when analytics is enabled', () => {
+      render(<PrivacySettings />);
+
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should toggle analytics off when clicked', async () => {
+      const onSettingsChange = vi.fn();
+      render(<PrivacySettings onSettingsChange={onSettingsChange} />);
+
+      const toggle = screen.getByRole('switch');
+      fireEvent.click(toggle);
+
+      expect(onSettingsChange).toHaveBeenCalledWith(false);
+    });
+
+    it('should toggle analytics on when clicked while disabled', async () => {
+      const onSettingsChange = vi.fn();
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.disable();
+      });
+
+      render(<PrivacySettings onSettingsChange={onSettingsChange} />);
+
+      const toggle = screen.getByRole('switch');
+      fireEvent.click(toggle);
+
+      expect(onSettingsChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('DNT banner', () => {
+    it('should show DNT banner when Do Not Track is enabled', () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: '1',
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useAnalyticsStore());
+      act(() => {
+        result.current.reset();
+        result.current.initialize();
+      });
+
+      render(<PrivacySettings />);
+
+      expect(screen.getByText(/Do Not Track detected/)).toBeInTheDocument();
+    });
+
+    it('should not show DNT banner when Do Not Track is not enabled', () => {
+      render(<PrivacySettings />);
+
+      expect(screen.queryByText(/Do Not Track detected/)).not.toBeInTheDocument();
+    });
+
+    it('should disable toggle when DNT is enabled', () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: '1',
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useAnalyticsStore());
+      act(() => {
+        result.current.reset();
+        result.current.initialize();
+      });
+
+      render(<PrivacySettings />);
+
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toBeDisabled();
+    });
+  });
+
+  describe('data export', () => {
+    it('should export data when export button is clicked', () => {
+      render(<PrivacySettings />);
+
+      const exportButton = screen.getByText('Export My Data');
+      fireEvent.click(exportButton);
+
+      expect(global.URL.createObjectURL).toHaveBeenCalled();
+      expect(global.URL.revokeObjectURL).toHaveBeenCalled();
+    });
+  });
+
+  describe('data clearing', () => {
+    it('should show confirmation before clearing data', () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+      render(<PrivacySettings />);
+
+      const clearButton = screen.getByText('Clear All Data');
+      fireEvent.click(clearButton);
+
+      expect(confirmSpy).toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it('should clear data when confirmed', () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+      render(<PrivacySettings />);
+
+      const clearButton = screen.getByText('Clear All Data');
+      fireEvent.click(clearButton);
+
+      // Check that confirmation was shown
+      expect(confirmSpy).toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it('should not clear data when not confirmed', () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+      render(<PrivacySettings />);
+
+      const clearButton = screen.getByText('Clear All Data');
+      fireEvent.click(clearButton);
+
+      expect(confirmSpy).toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+  });
+
+  describe('status display', () => {
+    it('should show Active status when analytics is enabled', () => {
+      render(<PrivacySettings />);
+
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
+    it('should show Disabled status when analytics is disabled', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      act(() => {
+        result.current.disable();
+      });
+
+      render(<PrivacySettings />);
+
+      // Find the status value element which should contain "Disabled"
+      const statusValue = screen.getByText((content, element) => {
+        return element?.classList?.contains('privacy-settings__status-value') === true &&
+               content === 'Disabled';
+      });
+      expect(statusValue).toBeInTheDocument();
+    });
+
+    it('should show Disabled (DNT) status when DNT is enabled', () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: '1',
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useAnalyticsStore());
+      act(() => {
+        result.current.reset();
+        result.current.initialize();
+      });
+
+      render(<PrivacySettings />);
+
+      expect(screen.getByText('Disabled (DNT)')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have accessible toggle button', () => {
+      render(<PrivacySettings />);
+
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-checked');
+      expect(toggle).toHaveAttribute('aria-labelledby');
+    });
+
+    it('should have role="status" on DNT banner', () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: '1',
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useAnalyticsStore());
+      act(() => {
+        result.current.reset();
+        result.current.initialize();
+      });
+
+      render(<PrivacySettings />);
+
+      const banner = screen.getByTestId('privacy-settings-dnt-banner');
+      expect(banner).toHaveAttribute('role', 'status');
+    });
+  });
+
+  describe('privacy policy content', () => {
+    it('should list what data is collected', () => {
+      render(<PrivacySettings showPolicy={true} />);
+
+      expect(screen.getByText(/Anonymous page views/)).toBeInTheDocument();
+      expect(screen.getByText(/Feature usage counts/)).toBeInTheDocument();
+      expect(screen.getByText(/Error reports/)).toBeInTheDocument();
+      expect(screen.getByText(/Performance metrics/)).toBeInTheDocument();
+    });
+
+    it('should list what data is NOT collected', () => {
+      render(<PrivacySettings showPolicy={true} />);
+
+      expect(screen.getByText(/Your poems or lyrics/)).toBeInTheDocument();
+      expect(screen.getByText(/Personal information/)).toBeInTheDocument();
+      expect(screen.getByText(/IP addresses or location/)).toBeInTheDocument();
+    });
+
+    it('should list user rights', () => {
+      render(<PrivacySettings showPolicy={true} />);
+
+      expect(screen.getByText(/Opt-out anytime/)).toBeInTheDocument();
+      expect(screen.getByText(/Export your data/)).toBeInTheDocument();
+      expect(screen.getByText(/Delete your data/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/Privacy/PrivacySettings.tsx
+++ b/web/src/components/Privacy/PrivacySettings.tsx
@@ -1,0 +1,258 @@
+/**
+ * PrivacySettings Component
+ *
+ * Provides user interface for managing privacy settings and analytics preferences.
+ * Displays current analytics status and allows users to opt-out.
+ *
+ * @module components/Privacy/PrivacySettings
+ */
+
+import { useCallback } from 'react';
+import { useAnalyticsStore } from '@/stores/useAnalyticsStore';
+import './PrivacySettings.css';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[PrivacySettings] ${message}`, ...args);
+  }
+};
+
+/**
+ * Props for the PrivacySettings component
+ */
+export interface PrivacySettingsProps {
+  /** Additional CSS class name */
+  className?: string;
+  /** Data test ID for testing */
+  testId?: string;
+  /** Whether to show the full policy or just settings */
+  showPolicy?: boolean;
+  /** Callback when settings change */
+  onSettingsChange?: (enabled: boolean) => void;
+}
+
+/**
+ * PrivacySettings component allows users to view and control their privacy preferences.
+ *
+ * Features:
+ * - Toggle analytics on/off
+ * - See Do Not Track status
+ * - View what data is collected
+ * - Export/clear personal data
+ *
+ * @example
+ * ```tsx
+ * <PrivacySettings
+ *   showPolicy
+ *   onSettingsChange={(enabled) => console.log('Analytics:', enabled)}
+ * />
+ * ```
+ */
+export function PrivacySettings({
+  className = '',
+  testId = 'privacy-settings',
+  showPolicy = true,
+  onSettingsChange,
+}: PrivacySettingsProps): React.ReactElement {
+  // Analytics store
+  const enabled = useAnalyticsStore((state) => state.enabled);
+  const doNotTrackDetected = useAnalyticsStore((state) => state.doNotTrackDetected);
+  const aggregate = useAnalyticsStore((state) => state.aggregate);
+  const enable = useAnalyticsStore((state) => state.enable);
+  const disable = useAnalyticsStore((state) => state.disable);
+  const exportData = useAnalyticsStore((state) => state.exportData);
+  const clearData = useAnalyticsStore((state) => state.clearData);
+  const refreshAggregate = useAnalyticsStore((state) => state.refreshAggregate);
+
+  // Toggle analytics
+  const handleToggle = useCallback(() => {
+    if (enabled) {
+      log('Disabling analytics');
+      disable();
+      onSettingsChange?.(false);
+    } else {
+      log('Enabling analytics');
+      enable();
+      onSettingsChange?.(true);
+    }
+  }, [enabled, enable, disable, onSettingsChange]);
+
+  // Export data
+  const handleExport = useCallback(() => {
+    log('Exporting analytics data');
+    refreshAggregate();
+    const data = exportData();
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `ghost-note-analytics-${new Date().toISOString().split('T')[0]}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [exportData, refreshAggregate]);
+
+  // Clear data
+  const handleClear = useCallback(() => {
+    if (window.confirm('Are you sure you want to clear all analytics data? This cannot be undone.')) {
+      log('Clearing analytics data');
+      clearData();
+    }
+  }, [clearData]);
+
+  const containerClass = ['privacy-settings', className].filter(Boolean).join(' ').trim();
+
+  // Calculate totals from aggregate
+  const totalEvents = aggregate
+    ? Object.values(aggregate.pageViews).reduce((sum, count) => sum + count, 0) +
+      Object.values(aggregate.featureUsage).reduce((sum, count) => sum + count, 0) +
+      Object.values(aggregate.errors).reduce((sum, count) => sum + count, 0)
+    : 0;
+
+  return (
+    <div className={containerClass} data-testid={testId}>
+      <h2 className="privacy-settings__title">Privacy Settings</h2>
+
+      {/* DNT Status Banner */}
+      {doNotTrackDetected && (
+        <div
+          className="privacy-settings__banner privacy-settings__banner--dnt"
+          role="status"
+          data-testid={`${testId}-dnt-banner`}
+        >
+          <span className="privacy-settings__banner-icon" aria-hidden="true">
+            🛡️
+          </span>
+          <span>
+            <strong>Do Not Track detected.</strong> Analytics are automatically disabled because your
+            browser has requested not to be tracked.
+          </span>
+        </div>
+      )}
+
+      {/* Analytics Toggle */}
+      <div className="privacy-settings__section">
+        <h3 className="privacy-settings__section-title">Analytics</h3>
+        <div className="privacy-settings__toggle-row">
+          <label
+            htmlFor="analytics-toggle"
+            className="privacy-settings__label"
+            id="analytics-toggle-label"
+          >
+            <span className="privacy-settings__label-text">Enable anonymous analytics</span>
+            <span className="privacy-settings__label-description">
+              Help improve Ghost Note by sharing anonymous usage data
+            </span>
+          </label>
+          <button
+            type="button"
+            id="analytics-toggle"
+            role="switch"
+            aria-checked={enabled && !doNotTrackDetected}
+            aria-labelledby="analytics-toggle-label"
+            className={`privacy-settings__toggle ${enabled && !doNotTrackDetected ? 'privacy-settings__toggle--on' : ''}`}
+            onClick={handleToggle}
+            disabled={doNotTrackDetected}
+            data-testid={`${testId}-toggle`}
+          >
+            <span className="privacy-settings__toggle-slider" />
+            <span className="sr-only">{enabled ? 'Enabled' : 'Disabled'}</span>
+          </button>
+        </div>
+        <p className="privacy-settings__status">
+          Status:{' '}
+          <span
+            className={`privacy-settings__status-value ${enabled && !doNotTrackDetected ? 'privacy-settings__status-value--active' : ''}`}
+          >
+            {doNotTrackDetected ? 'Disabled (DNT)' : enabled ? 'Active' : 'Disabled'}
+          </span>
+        </p>
+      </div>
+
+      {/* Data Summary */}
+      <div className="privacy-settings__section">
+        <h3 className="privacy-settings__section-title">Your Data</h3>
+        <div className="privacy-settings__stats">
+          <div className="privacy-settings__stat">
+            <span className="privacy-settings__stat-value">{totalEvents}</span>
+            <span className="privacy-settings__stat-label">Events stored locally</span>
+          </div>
+          <div className="privacy-settings__stat">
+            <span className="privacy-settings__stat-value">{aggregate?.uniqueSessions || 0}</span>
+            <span className="privacy-settings__stat-label">Sessions</span>
+          </div>
+        </div>
+        <div className="privacy-settings__actions">
+          <button
+            type="button"
+            className="privacy-settings__button privacy-settings__button--secondary"
+            onClick={handleExport}
+            data-testid={`${testId}-export`}
+          >
+            Export My Data
+          </button>
+          <button
+            type="button"
+            className="privacy-settings__button privacy-settings__button--danger"
+            onClick={handleClear}
+            data-testid={`${testId}-clear`}
+          >
+            Clear All Data
+          </button>
+        </div>
+      </div>
+
+      {/* Privacy Policy */}
+      {showPolicy && (
+        <div className="privacy-settings__section">
+          <h3 className="privacy-settings__section-title">What We Collect</h3>
+          <div className="privacy-settings__policy">
+            <h4 className="privacy-settings__policy-heading">We DO collect:</h4>
+            <ul className="privacy-settings__list">
+              <li>Anonymous page views (which features you use)</li>
+              <li>Feature usage counts (how often features are used)</li>
+              <li>Error reports (to fix bugs)</li>
+              <li>Performance metrics (to improve speed)</li>
+            </ul>
+
+            <h4 className="privacy-settings__policy-heading">We DO NOT collect:</h4>
+            <ul className="privacy-settings__list privacy-settings__list--negative">
+              <li>Your poems or lyrics</li>
+              <li>Personal information (name, email, etc.)</li>
+              <li>IP addresses or location</li>
+              <li>Device identifiers</li>
+              <li>Cookies for tracking</li>
+              <li>Any data that could identify you</li>
+            </ul>
+
+            <h4 className="privacy-settings__policy-heading">Your Rights:</h4>
+            <ul className="privacy-settings__list">
+              <li>
+                <strong>Opt-out anytime:</strong> Toggle analytics off above
+              </li>
+              <li>
+                <strong>Export your data:</strong> Download all stored analytics data
+              </li>
+              <li>
+                <strong>Delete your data:</strong> Clear all analytics data permanently
+              </li>
+              <li>
+                <strong>Do Not Track:</strong> We automatically respect your browser's DNT setting
+              </li>
+            </ul>
+
+            <p className="privacy-settings__policy-note">
+              All analytics data is stored locally on your device. We do not send any data to
+              external servers. This tool is designed to be privacy-respecting and GDPR compliant.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PrivacySettings;

--- a/web/src/components/Privacy/index.ts
+++ b/web/src/components/Privacy/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Privacy Components
+ *
+ * Components for privacy settings and policy display.
+ *
+ * @module components/Privacy
+ */
+
+export { PrivacySettings, type PrivacySettingsProps } from './PrivacySettings';

--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -38,3 +38,12 @@ export {
   type FocusTrapOptions,
   type FocusTrapReturn,
 } from './useFocusTrap';
+
+export {
+  useAnalytics,
+  usePageView,
+  useFeatureTracker,
+  useErrorTracker,
+  type UseAnalyticsOptions,
+  type UseAnalyticsReturn,
+} from './useAnalytics';

--- a/web/src/hooks/useAnalytics.test.ts
+++ b/web/src/hooks/useAnalytics.test.ts
@@ -1,0 +1,274 @@
+/**
+ * useAnalytics Hook Tests
+ *
+ * Tests for the analytics hooks.
+ *
+ * @module hooks/useAnalytics.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAnalytics, usePageView, useFeatureTracker, useErrorTracker } from './useAnalytics';
+import { useAnalyticsStore } from '@/stores/useAnalyticsStore';
+
+// Mock localStorage and sessionStorage
+const mockStorage: Record<string, string> = {};
+const mockSessionStorage: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => mockStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockStorage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete mockStorage[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
+  }),
+};
+
+const sessionStorageMock = {
+  getItem: vi.fn((key: string) => mockSessionStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockSessionStorage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete mockSessionStorage[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(mockSessionStorage).forEach((key) => delete mockSessionStorage[key]);
+  }),
+};
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessionStorageMock,
+  writable: true,
+});
+
+describe('useAnalytics', () => {
+  beforeEach(() => {
+    // Clear mocks and storage
+    vi.clearAllMocks();
+    localStorageMock.clear();
+    sessionStorageMock.clear();
+
+    // Reset navigator.doNotTrack
+    Object.defineProperty(navigator, 'doNotTrack', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    // Reset the analytics store
+    const { result } = renderHook(() => useAnalyticsStore());
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  afterEach(() => {
+    const { result } = renderHook(() => useAnalyticsStore());
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  describe('useAnalytics hook', () => {
+    it('should return tracking functions', () => {
+      const { result } = renderHook(() => useAnalytics());
+
+      expect(result.current.trackFeature).toBeDefined();
+      expect(result.current.trackError).toBeDefined();
+      expect(result.current.trackPerformance).toBeDefined();
+      expect(result.current.trackPageView).toBeDefined();
+    });
+
+    it('should return isActive status', () => {
+      const { result } = renderHook(() => useAnalytics());
+      expect(typeof result.current.isActive).toBe('boolean');
+    });
+
+    it('should return doNotTrackEnabled status', () => {
+      const { result } = renderHook(() => useAnalytics());
+      expect(typeof result.current.doNotTrackEnabled).toBe('boolean');
+    });
+
+    it('should initialize analytics on first use', async () => {
+      renderHook(() => useAnalytics());
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+
+      // Wait for initialization
+      await vi.waitFor(() => {
+        expect(storeResult.current.initialized).toBe(true);
+      });
+    });
+
+    it('should track page view on mount when page is provided', async () => {
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+
+      renderHook(() => useAnalytics({ page: 'poem-input', trackPageViewOnMount: true }));
+
+      // Wait for initialization and page view
+      await vi.waitFor(() => {
+        expect(storeResult.current.initialized).toBe(true);
+      });
+    });
+
+    it('should not track page view when trackPageViewOnMount is false', async () => {
+      const trackPageViewSpy = vi.fn();
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+
+      // Override trackPageView
+      act(() => {
+        storeResult.current.trackPageView = trackPageViewSpy;
+      });
+
+      renderHook(() => useAnalytics({ page: 'poem-input', trackPageViewOnMount: false }));
+
+      // Give some time for potential tracking
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // trackPageView should not have been called
+      expect(trackPageViewSpy).not.toHaveBeenCalled();
+    });
+
+    it('trackFeature should call store trackFeature', async () => {
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+      const { result: hookResult } = renderHook(() => useAnalytics());
+
+      // Wait for initialization
+      await vi.waitFor(() => {
+        expect(storeResult.current.initialized).toBe(true);
+      });
+
+      act(() => {
+        hookResult.current.trackFeature('melody_generate');
+        storeResult.current.refreshAggregate();
+      });
+
+      // Should have tracked the feature
+      expect(storeResult.current.aggregate).not.toBeNull();
+    });
+
+    it('trackError should call store trackError', async () => {
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+      const { result: hookResult } = renderHook(() => useAnalytics());
+
+      // Wait for initialization
+      await vi.waitFor(() => {
+        expect(storeResult.current.initialized).toBe(true);
+      });
+
+      act(() => {
+        hookResult.current.trackError(new Error('Test error'));
+        storeResult.current.refreshAggregate();
+      });
+
+      expect(storeResult.current.aggregate).not.toBeNull();
+    });
+
+    it('trackPerformance should call store trackPerformance', async () => {
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+      const { result: hookResult } = renderHook(() => useAnalytics());
+
+      // Wait for initialization
+      await vi.waitFor(() => {
+        expect(storeResult.current.initialized).toBe(true);
+      });
+
+      act(() => {
+        hookResult.current.trackPerformance('LCP', 2500, 'good');
+        storeResult.current.refreshAggregate();
+      });
+
+      expect(storeResult.current.aggregate).not.toBeNull();
+    });
+  });
+
+  describe('usePageView hook', () => {
+    it('should track page view on mount', async () => {
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+
+      renderHook(() => usePageView('analysis'));
+
+      // Wait for initialization
+      await vi.waitFor(() => {
+        expect(storeResult.current.initialized).toBe(true);
+      });
+    });
+  });
+
+  describe('useFeatureTracker hook', () => {
+    it('should return a trackFeature function', () => {
+      const { result } = renderHook(() => useFeatureTracker());
+      expect(typeof result.current).toBe('function');
+    });
+
+    it('should track features when called', async () => {
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+      const { result: trackerResult } = renderHook(() => useFeatureTracker());
+
+      // Wait for initialization
+      await vi.waitFor(() => {
+        expect(storeResult.current.initialized).toBe(true);
+      });
+
+      act(() => {
+        trackerResult.current('poem_input');
+        storeResult.current.refreshAggregate();
+      });
+
+      expect(storeResult.current.aggregate).not.toBeNull();
+    });
+  });
+
+  describe('useErrorTracker hook', () => {
+    it('should return a trackError function', () => {
+      const { result } = renderHook(() => useErrorTracker());
+      expect(typeof result.current).toBe('function');
+    });
+
+    it('should track errors when called', async () => {
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+      const { result: trackerResult } = renderHook(() => useErrorTracker());
+
+      // Wait for initialization
+      await vi.waitFor(() => {
+        expect(storeResult.current.initialized).toBe(true);
+      });
+
+      act(() => {
+        trackerResult.current(new Error('Test'), { component: 'TestComponent' });
+        storeResult.current.refreshAggregate();
+      });
+
+      expect(storeResult.current.aggregate).not.toBeNull();
+    });
+  });
+
+  describe('DNT detection', () => {
+    it('should return doNotTrackEnabled as true when DNT is set', async () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: '1',
+        writable: true,
+        configurable: true,
+      });
+
+      const { result: hookResult } = renderHook(() => useAnalytics());
+      const { result: storeResult } = renderHook(() => useAnalyticsStore());
+
+      // Wait for initialization
+      await vi.waitFor(() => {
+        expect(storeResult.current.initialized).toBe(true);
+      });
+
+      expect(hookResult.current.doNotTrackEnabled).toBe(true);
+    });
+  });
+});

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -1,0 +1,220 @@
+/**
+ * useAnalytics Hook
+ *
+ * Provides easy access to analytics tracking from React components.
+ * Handles initialization, page view tracking, and feature usage tracking.
+ *
+ * @module hooks/useAnalytics
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useAnalyticsStore } from '@/stores/useAnalyticsStore';
+import type { FeatureName, PageName } from '@/lib/analytics';
+
+// Logging helper
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[useAnalytics] ${message}`, ...args);
+  }
+};
+
+/**
+ * Options for useAnalytics hook
+ */
+export interface UseAnalyticsOptions {
+  /** Current page name (for automatic page view tracking) */
+  page?: PageName;
+  /** Whether to track page view on mount */
+  trackPageViewOnMount?: boolean;
+}
+
+/**
+ * Return type for useAnalytics hook
+ */
+export interface UseAnalyticsReturn {
+  /** Track a feature usage event */
+  trackFeature: (feature: FeatureName, metadata?: Record<string, string | number | boolean>) => void;
+  /** Track an error */
+  trackError: (error: Error | string, options?: { component?: string; caught?: boolean; isReactError?: boolean }) => void;
+  /** Track a performance metric */
+  trackPerformance: (metric: string, value: number, rating?: 'good' | 'needs-improvement' | 'poor') => void;
+  /** Track a page view manually */
+  trackPageView: (page: PageName, previousPage?: PageName) => void;
+  /** Whether analytics is active */
+  isActive: boolean;
+  /** Whether Do Not Track is enabled */
+  doNotTrackEnabled: boolean;
+}
+
+/**
+ * Hook for tracking analytics events from React components
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { trackFeature, isActive } = useAnalytics({ page: 'poem-input' });
+ *
+ *   const handleSubmit = () => {
+ *     trackFeature('poem_input', { wordCount: 100 });
+ *     // ... submit logic
+ *   };
+ *
+ *   return <form onSubmit={handleSubmit}>...</form>;
+ * }
+ * ```
+ */
+export function useAnalytics(options: UseAnalyticsOptions = {}): UseAnalyticsReturn {
+  const { page, trackPageViewOnMount = true } = options;
+
+  const previousPageRef = useRef<PageName | undefined>(undefined);
+  const hasTrackedInitialPageView = useRef(false);
+
+  // Get store state and actions
+  const enabled = useAnalyticsStore((state) => state.enabled);
+  const doNotTrackDetected = useAnalyticsStore((state) => state.doNotTrackDetected);
+  const initialized = useAnalyticsStore((state) => state.initialized);
+  const initialize = useAnalyticsStore((state) => state.initialize);
+  const storeTrackPageView = useAnalyticsStore((state) => state.trackPageView);
+  const storeTrackFeature = useAnalyticsStore((state) => state.trackFeature);
+  const storeTrackError = useAnalyticsStore((state) => state.trackError);
+  const storeTrackPerformance = useAnalyticsStore((state) => state.trackPerformance);
+
+  const isActive = enabled && !doNotTrackDetected;
+
+  // Initialize analytics on first use
+  useEffect(() => {
+    if (!initialized) {
+      log('Initializing analytics');
+      initialize();
+    }
+  }, [initialized, initialize]);
+
+  // Track page view when page changes
+  useEffect(() => {
+    if (!trackPageViewOnMount || !page || !initialized) {
+      return;
+    }
+
+    // Only track if page actually changed or this is first view
+    if (page !== previousPageRef.current || !hasTrackedInitialPageView.current) {
+      log('Tracking page view', { page, previousPage: previousPageRef.current });
+      storeTrackPageView(page, previousPageRef.current);
+      previousPageRef.current = page;
+      hasTrackedInitialPageView.current = true;
+    }
+  }, [page, initialized, trackPageViewOnMount, storeTrackPageView]);
+
+  // Memoized tracking functions
+  const trackFeature = useCallback(
+    (feature: FeatureName, metadata?: Record<string, string | number | boolean>) => {
+      log('Tracking feature', { feature, metadata });
+      storeTrackFeature(feature, metadata);
+    },
+    [storeTrackFeature]
+  );
+
+  const trackError = useCallback(
+    (
+      error: Error | string,
+      errorOptions?: { component?: string; caught?: boolean; isReactError?: boolean }
+    ) => {
+      log('Tracking error', { error, options: errorOptions });
+      storeTrackError(error, errorOptions);
+    },
+    [storeTrackError]
+  );
+
+  const trackPerformance = useCallback(
+    (metric: string, value: number, rating?: 'good' | 'needs-improvement' | 'poor') => {
+      log('Tracking performance', { metric, value, rating });
+      storeTrackPerformance(metric, value, rating);
+    },
+    [storeTrackPerformance]
+  );
+
+  const trackPageView = useCallback(
+    (pageName: PageName, previousPage?: PageName) => {
+      log('Tracking page view (manual)', { page: pageName, previousPage });
+      storeTrackPageView(pageName, previousPage);
+    },
+    [storeTrackPageView]
+  );
+
+  return {
+    trackFeature,
+    trackError,
+    trackPerformance,
+    trackPageView,
+    isActive,
+    doNotTrackEnabled: doNotTrackDetected,
+  };
+}
+
+/**
+ * Hook for tracking page views
+ * Simplified version that just tracks page views on mount/change
+ *
+ * @example
+ * ```tsx
+ * function AnalysisPage() {
+ *   usePageView('analysis');
+ *   return <div>...</div>;
+ * }
+ * ```
+ */
+export function usePageView(page: PageName): void {
+  useAnalytics({ page, trackPageViewOnMount: true });
+}
+
+/**
+ * Hook for creating a feature tracker function
+ * Returns a stable function that can be used to track feature usage
+ *
+ * @example
+ * ```tsx
+ * function MelodyControls() {
+ *   const track = useFeatureTracker();
+ *
+ *   return (
+ *     <button onClick={() => { play(); track('melody_play'); }}>
+ *       Play
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export function useFeatureTracker(): (
+  feature: FeatureName,
+  metadata?: Record<string, string | number | boolean>
+) => void {
+  const { trackFeature } = useAnalytics();
+  return trackFeature;
+}
+
+/**
+ * Hook for creating an error tracker function
+ * Returns a stable function that can be used to track errors
+ *
+ * @example
+ * ```tsx
+ * function ApiComponent() {
+ *   const trackError = useErrorTracker();
+ *
+ *   const fetchData = async () => {
+ *     try {
+ *       await api.getData();
+ *     } catch (error) {
+ *       trackError(error, { component: 'ApiComponent' });
+ *     }
+ *   };
+ * }
+ * ```
+ */
+export function useErrorTracker(): (
+  error: Error | string,
+  options?: { component?: string; caught?: boolean; isReactError?: boolean }
+) => void {
+  const { trackError } = useAnalytics();
+  return trackError;
+}

--- a/web/src/lib/analytics/analyticsService.test.ts
+++ b/web/src/lib/analytics/analyticsService.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Analytics Service Tests
+ *
+ * Tests for the privacy-respecting analytics service.
+ *
+ * @module lib/analytics/analyticsService.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AnalyticsService } from './analyticsService';
+
+// Mock localStorage and sessionStorage
+const mockStorage: Record<string, string> = {};
+const mockSessionStorage: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => mockStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockStorage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete mockStorage[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
+  }),
+};
+
+const sessionStorageMock = {
+  getItem: vi.fn((key: string) => mockSessionStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockSessionStorage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete mockSessionStorage[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(mockSessionStorage).forEach((key) => delete mockSessionStorage[key]);
+  }),
+};
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessionStorageMock,
+  writable: true,
+});
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+
+  beforeEach(() => {
+    // Clear mocks
+    vi.clearAllMocks();
+    localStorageMock.clear();
+    sessionStorageMock.clear();
+
+    // Reset navigator.doNotTrack
+    Object.defineProperty(navigator, 'doNotTrack', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    // Create fresh service instance
+    service = new AnalyticsService({
+      debug: false,
+      maxQueueSize: 100,
+    });
+  });
+
+  afterEach(() => {
+    service.shutdown();
+  });
+
+  describe('initialization', () => {
+    it('should initialize successfully', () => {
+      service.initialize();
+      expect(service.session).not.toBeNull();
+      expect(service.session?.id).toBeDefined();
+    });
+
+    it('should create a new session on initialization', () => {
+      service.initialize();
+      expect(service.session).toBeDefined();
+      expect(service.session?.id).toBeTruthy();
+      expect(service.session?.startTime).toBeGreaterThan(0);
+    });
+
+    it('should not initialize twice', () => {
+      service.initialize();
+      const sessionId = service.session?.id;
+      service.initialize();
+      expect(service.session?.id).toBe(sessionId);
+    });
+  });
+
+  describe('Do Not Track', () => {
+    it('should detect DNT when set to "1"', () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: '1',
+        writable: true,
+        configurable: true,
+      });
+
+      const dntService = new AnalyticsService({ respectDoNotTrack: true });
+      expect(dntService.doNotTrackEnabled).toBe(true);
+      expect(dntService.isActive).toBe(false);
+    });
+
+    it('should detect DNT when set to "yes"', () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: 'yes',
+        writable: true,
+        configurable: true,
+      });
+
+      const dntService = new AnalyticsService({ respectDoNotTrack: true });
+      expect(dntService.doNotTrackEnabled).toBe(true);
+    });
+
+    it('should be active when DNT is not set', () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: null,
+        writable: true,
+        configurable: true,
+      });
+
+      const dntService = new AnalyticsService({ respectDoNotTrack: true, enabled: true });
+      expect(dntService.doNotTrackEnabled).toBe(false);
+      expect(dntService.isActive).toBe(true);
+    });
+
+    it('should skip tracking when DNT is enabled', () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: '1',
+        writable: true,
+        configurable: true,
+      });
+
+      const dntService = new AnalyticsService({ respectDoNotTrack: true });
+      dntService.initialize();
+      dntService.trackPageView('poem-input');
+
+      expect(dntService.events).toHaveLength(0);
+      dntService.shutdown();
+    });
+  });
+
+  describe('page view tracking', () => {
+    beforeEach(() => {
+      service.initialize();
+    });
+
+    it('should track page views', () => {
+      service.trackPageView('poem-input');
+      expect(service.events).toHaveLength(1);
+      expect(service.events[0].type).toBe('page_view');
+    });
+
+    it('should include page name in page view event', () => {
+      service.trackPageView('analysis');
+      const event = service.events[0];
+      expect(event.type).toBe('page_view');
+      if (event.type === 'page_view') {
+        expect(event.page).toBe('analysis');
+      }
+    });
+
+    it('should track previous page', () => {
+      service.trackPageView('poem-input');
+      service.trackPageView('analysis', 'poem-input');
+
+      const event = service.events[1];
+      if (event.type === 'page_view') {
+        expect(event.previousPage).toBe('poem-input');
+      }
+    });
+
+    it('should not track when disabled', () => {
+      service.configure({ trackPageViews: false });
+      service.trackPageView('poem-input');
+      expect(service.events).toHaveLength(0);
+    });
+  });
+
+  describe('feature usage tracking', () => {
+    beforeEach(() => {
+      service.initialize();
+    });
+
+    it('should track feature usage', () => {
+      service.trackFeatureUsage('melody_generate');
+      expect(service.events).toHaveLength(1);
+      expect(service.events[0].type).toBe('feature_usage');
+    });
+
+    it('should include feature name in event', () => {
+      service.trackFeatureUsage('poem_analysis');
+      const event = service.events[0];
+      if (event.type === 'feature_usage') {
+        expect(event.feature).toBe('poem_analysis');
+      }
+    });
+
+    it('should include metadata in feature usage event', () => {
+      service.trackFeatureUsage('lyrics_edit', { lineCount: 5 });
+      const event = service.events[0];
+      if (event.type === 'feature_usage') {
+        expect(event.metadata).toEqual({ lineCount: 5 });
+      }
+    });
+
+    it('should not track when disabled', () => {
+      service.configure({ trackFeatureUsage: false });
+      service.trackFeatureUsage('melody_play');
+      expect(service.events).toHaveLength(0);
+    });
+  });
+
+  describe('error tracking', () => {
+    beforeEach(() => {
+      service.initialize();
+    });
+
+    it('should track errors', () => {
+      service.trackError(new Error('Test error'));
+      expect(service.events).toHaveLength(1);
+      expect(service.events[0].type).toBe('error');
+    });
+
+    it('should track string errors', () => {
+      service.trackError('Something went wrong');
+      const event = service.events[0];
+      if (event.type === 'error') {
+        expect(event.message).toBe('Something went wrong');
+        expect(event.errorType).toBe('Error');
+      }
+    });
+
+    it('should sanitize error messages with file paths', () => {
+      service.trackError(new Error('Failed at /Users/test/app/file.ts'));
+      const event = service.events[0];
+      if (event.type === 'error') {
+        expect(event.message).not.toContain('/Users/test');
+        expect(event.message).toContain('[FILE]');
+      }
+    });
+
+    it('should sanitize error messages with URLs', () => {
+      service.trackError(new Error('Failed at https://api.example.com/secret?token=123'));
+      const event = service.events[0];
+      if (event.type === 'error') {
+        expect(event.message).not.toContain('https://');
+        expect(event.message).toContain('[URL]');
+      }
+    });
+
+    it('should sanitize error messages with emails', () => {
+      service.trackError(new Error('User test@example.com not found'));
+      const event = service.events[0];
+      if (event.type === 'error') {
+        expect(event.message).not.toContain('@example.com');
+        expect(event.message).toContain('[EMAIL]');
+      }
+    });
+
+    it('should truncate long error messages', () => {
+      const longMessage = 'A'.repeat(300);
+      service.trackError(new Error(longMessage));
+      const event = service.events[0];
+      if (event.type === 'error') {
+        expect(event.message.length).toBeLessThanOrEqual(203); // 200 + "..."
+      }
+    });
+
+    it('should include component name in error event', () => {
+      service.trackError(new Error('Test'), { component: 'MyComponent' });
+      const event = service.events[0];
+      if (event.type === 'error') {
+        expect(event.component).toBe('MyComponent');
+      }
+    });
+
+    it('should mark caught errors correctly', () => {
+      service.trackError(new Error('Test'), { caught: true });
+      const event = service.events[0];
+      if (event.type === 'error') {
+        expect(event.caught).toBe(true);
+      }
+    });
+
+    it('should not track when disabled', () => {
+      service.configure({ trackErrors: false });
+      service.trackError(new Error('Test'));
+      expect(service.events).toHaveLength(0);
+    });
+  });
+
+  describe('performance tracking', () => {
+    beforeEach(() => {
+      service.initialize();
+    });
+
+    it('should track performance metrics', () => {
+      service.trackPerformance('LCP', 2500);
+      expect(service.events).toHaveLength(1);
+      expect(service.events[0].type).toBe('performance');
+    });
+
+    it('should include metric name and value', () => {
+      service.trackPerformance('FCP', 1200);
+      const event = service.events[0];
+      if (event.type === 'performance') {
+        expect(event.metric).toBe('FCP');
+        expect(event.value).toBe(1200);
+      }
+    });
+
+    it('should include rating when provided', () => {
+      service.trackPerformance('LCP', 4500, 'poor');
+      const event = service.events[0];
+      if (event.type === 'performance') {
+        expect(event.rating).toBe('poor');
+      }
+    });
+
+    it('should not track when disabled', () => {
+      service.configure({ trackPerformance: false });
+      service.trackPerformance('CLS', 0.1);
+      expect(service.events).toHaveLength(0);
+    });
+  });
+
+  describe('enable/disable', () => {
+    beforeEach(() => {
+      service.initialize();
+    });
+
+    it('should enable analytics', () => {
+      service.disable();
+      expect(service.isActive).toBe(false);
+
+      service.enable();
+      expect(service.isActive).toBe(true);
+    });
+
+    it('should disable analytics', () => {
+      service.disable();
+      expect(service.isActive).toBe(false);
+    });
+
+    it('should not track events when disabled', () => {
+      service.disable();
+      service.trackPageView('poem-input');
+      service.trackFeatureUsage('melody_play');
+      service.trackError(new Error('Test'));
+
+      expect(service.events).toHaveLength(0);
+    });
+
+    it('should track events after re-enabling', () => {
+      service.disable();
+      service.enable();
+      service.trackPageView('poem-input');
+
+      expect(service.events).toHaveLength(1);
+    });
+  });
+
+  describe('aggregation', () => {
+    beforeEach(() => {
+      service.initialize();
+    });
+
+    it('should return aggregate data', () => {
+      service.trackPageView('poem-input');
+      service.trackPageView('analysis');
+      service.trackFeatureUsage('melody_generate');
+      service.trackError(new Error('Test'));
+
+      const aggregate = service.getAggregate();
+
+      expect(aggregate.pageViews['poem-input']).toBe(1);
+      expect(aggregate.pageViews['analysis']).toBe(1);
+      expect(aggregate.featureUsage['melody_generate']).toBe(1);
+      expect(aggregate.errors['Error']).toBe(1);
+    });
+
+    it('should track unique sessions', () => {
+      service.trackPageView('poem-input');
+      const aggregate = service.getAggregate();
+
+      expect(aggregate.uniqueSessions).toBeGreaterThan(0);
+    });
+  });
+
+  describe('data export', () => {
+    beforeEach(() => {
+      service.initialize();
+    });
+
+    it('should export data as JSON', () => {
+      service.trackPageView('poem-input');
+      const exported = service.exportData();
+      const data = JSON.parse(exported);
+
+      expect(data.exportDate).toBeDefined();
+      expect(data.aggregate).toBeDefined();
+      expect(data.events).toHaveLength(1);
+    });
+  });
+
+  describe('data clearing', () => {
+    beforeEach(() => {
+      service.initialize();
+    });
+
+    it('should clear all events', () => {
+      service.trackPageView('poem-input');
+      service.trackFeatureUsage('melody_play');
+      expect(service.events).toHaveLength(2);
+
+      service.clearData();
+      expect(service.events).toHaveLength(0);
+    });
+  });
+
+  describe('session management', () => {
+    it('should create session on initialization', () => {
+      service.initialize();
+      expect(service.session).not.toBeNull();
+      expect(service.session?.id).toBeTruthy();
+    });
+
+    it('should include session ID in events', () => {
+      service.initialize();
+      service.trackPageView('poem-input');
+
+      expect(service.events[0].sessionId).toBe(service.session?.id);
+    });
+
+    it('should update session activity on events', () => {
+      service.initialize();
+
+      service.trackPageView('poem-input');
+
+      // Event count should update
+      expect(service.session?.eventCount).toBe(1);
+    });
+  });
+
+  describe('queue management', () => {
+    it('should flush when queue reaches max size', async () => {
+      const smallQueueService = new AnalyticsService({
+        debug: false,
+        maxQueueSize: 5,
+      });
+      smallQueueService.initialize();
+
+      // Track events up to max queue size
+      for (let i = 0; i < 5; i++) {
+        smallQueueService.trackPageView('poem-input');
+      }
+
+      // Events should be saved to storage
+      expect(localStorageMock.setItem).toHaveBeenCalled();
+      smallQueueService.shutdown();
+    });
+  });
+});

--- a/web/src/lib/analytics/analyticsService.ts
+++ b/web/src/lib/analytics/analyticsService.ts
@@ -1,0 +1,745 @@
+/**
+ * Privacy-Respecting Analytics Service
+ *
+ * A self-hosted, GDPR-compliant analytics service that:
+ * - Respects Do Not Track (DNT) browser setting
+ * - Collects no personal information
+ * - Uses anonymous session IDs
+ * - Stores data locally with optional server sync
+ * - Provides privacy controls
+ *
+ * @module lib/analytics/analyticsService
+ */
+
+import type {
+  AnalyticsConfig,
+  AnalyticsEvent,
+  AnalyticsAggregate,
+  BaseAnalyticsEvent,
+  PageViewEvent,
+  FeatureUsageEvent,
+  ErrorEvent,
+  PerformanceEvent,
+  UserActionEvent,
+  PageName,
+  FeatureName,
+  SessionData,
+  PrivacyConsent,
+} from './types';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const DEBUG = import.meta.env?.DEV ?? false;
+
+const DEFAULT_CONFIG: AnalyticsConfig = {
+  enabled: true,
+  respectDoNotTrack: true,
+  debug: DEBUG,
+  maxQueueSize: 100,
+  flushInterval: 0, // Manual flush only (no server in this implementation)
+  trackErrors: true,
+  trackPerformance: true,
+  trackPageViews: true,
+  trackFeatureUsage: true,
+  storageKey: 'ghost-note-analytics',
+  endpoint: undefined, // No server endpoint - local storage only
+};
+
+const CONSENT_STORAGE_KEY = 'ghost-note-analytics-consent';
+const SESSION_STORAGE_KEY = 'ghost-note-session';
+const CONSENT_VERSION = '1.0.0';
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Generate a unique ID for events
+ */
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+/**
+ * Generate an anonymous session ID
+ * Uses a simple hash of random values, no user-identifiable information
+ */
+function generateSessionId(): string {
+  const array = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(array);
+  } else {
+    // Fallback for environments without crypto
+    for (let i = 0; i < 16; i++) {
+      array[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  return Array.from(array, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Check if Do Not Track is enabled in browser
+ */
+function isDoNotTrackEnabled(): boolean {
+  if (typeof navigator === 'undefined') return false;
+
+  // Check various DNT implementations
+  const dnt =
+    navigator.doNotTrack ||
+    (window as unknown as { doNotTrack?: string }).doNotTrack ||
+    (navigator as unknown as { msDoNotTrack?: string }).msDoNotTrack;
+
+  return dnt === '1' || dnt === 'yes';
+}
+
+/**
+ * Sanitize error message to remove potentially sensitive information
+ */
+function sanitizeErrorMessage(message: string): string {
+  let sanitized = message;
+
+  // Remove URLs first (might contain tokens) - must come before file path removal
+  sanitized = sanitized.replace(/https?:\/\/[^\s]+/g, '[URL]');
+
+  // Remove file paths (Windows style)
+  sanitized = sanitized.replace(/[A-Za-z]:[\\/][^\s]+/g, '[PATH]');
+
+  // Remove file paths (Unix style with extensions)
+  sanitized = sanitized.replace(/\/[^\s]+\.(ts|tsx|js|jsx)/g, '[FILE]');
+
+  // Remove potential email addresses
+  sanitized = sanitized.replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, '[EMAIL]');
+
+  // Truncate to reasonable length
+  if (sanitized.length > 200) {
+    sanitized = sanitized.substring(0, 200) + '...';
+  }
+
+  return sanitized;
+}
+
+/**
+ * Logging helper
+ */
+function log(message: string, ...args: unknown[]): void {
+  if (analyticsService.config.debug) {
+    console.log(`[Analytics] ${message}`, ...args);
+  }
+}
+
+// =============================================================================
+// Analytics Service Class
+// =============================================================================
+
+class AnalyticsService {
+  private _config: AnalyticsConfig;
+  private _events: AnalyticsEvent[] = [];
+  private _session: SessionData | null = null;
+  private _consent: PrivacyConsent | null = null;
+  private _initialized = false;
+  private _pageEntryTime: number = 0;
+  private _flushIntervalId: ReturnType<typeof setInterval> | null = null;
+
+  constructor(config: Partial<AnalyticsConfig> = {}) {
+    this._config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Get current configuration
+   */
+  get config(): AnalyticsConfig {
+    return this._config;
+  }
+
+  /**
+   * Check if analytics is currently active (enabled, consented, and not DNT)
+   */
+  get isActive(): boolean {
+    if (!this._config.enabled) {
+      return false;
+    }
+
+    if (this._config.respectDoNotTrack && isDoNotTrackEnabled()) {
+      return false;
+    }
+
+    // If we require explicit consent and don't have it, return false
+    // For now, we use an opt-out model (active by default, user can disable)
+    return true;
+  }
+
+  /**
+   * Check if Do Not Track is enabled
+   */
+  get doNotTrackEnabled(): boolean {
+    return isDoNotTrackEnabled();
+  }
+
+  /**
+   * Get current session data
+   */
+  get session(): SessionData | null {
+    return this._session;
+  }
+
+  /**
+   * Get current consent state
+   */
+  get consent(): PrivacyConsent | null {
+    return this._consent;
+  }
+
+  /**
+   * Get all stored events
+   */
+  get events(): AnalyticsEvent[] {
+    return [...this._events];
+  }
+
+  /**
+   * Initialize the analytics service
+   */
+  initialize(): void {
+    if (this._initialized) {
+      log('Already initialized');
+      return;
+    }
+
+    log('Initializing analytics service');
+
+    // Load consent from storage
+    this.loadConsent();
+
+    // Load stored events
+    this.loadEvents();
+
+    // Initialize or resume session
+    this.initSession();
+
+    // Set up flush interval if configured
+    if (this._config.flushInterval > 0) {
+      this._flushIntervalId = setInterval(() => {
+        this.flush();
+      }, this._config.flushInterval);
+    }
+
+    // Set up visibility change handler for session tracking
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', this.handleVisibilityChange);
+    }
+
+    // Set up unload handler to save events
+    if (typeof window !== 'undefined') {
+      window.addEventListener('beforeunload', this.handleBeforeUnload);
+    }
+
+    this._initialized = true;
+    log('Analytics initialized', {
+      isActive: this.isActive,
+      dnt: this.doNotTrackEnabled,
+      sessionId: this._session?.id,
+    });
+  }
+
+  /**
+   * Cleanup and shutdown the analytics service
+   */
+  shutdown(): void {
+    log('Shutting down analytics service');
+
+    // Clear flush interval
+    if (this._flushIntervalId) {
+      clearInterval(this._flushIntervalId);
+      this._flushIntervalId = null;
+    }
+
+    // Remove event listeners
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('beforeunload', this.handleBeforeUnload);
+    }
+
+    // Save any pending events
+    this.saveEvents();
+
+    this._initialized = false;
+  }
+
+  /**
+   * Update configuration
+   */
+  configure(config: Partial<AnalyticsConfig>): void {
+    log('Updating configuration', config);
+    this._config = { ...this._config, ...config };
+
+    // Re-evaluate flush interval
+    if (this._flushIntervalId) {
+      clearInterval(this._flushIntervalId);
+      this._flushIntervalId = null;
+    }
+
+    if (this._config.flushInterval > 0 && this._initialized) {
+      this._flushIntervalId = setInterval(() => {
+        this.flush();
+      }, this._config.flushInterval);
+    }
+  }
+
+  /**
+   * Enable analytics
+   */
+  enable(): void {
+    log('Enabling analytics');
+    this._config.enabled = true;
+    this.updateConsent(true);
+  }
+
+  /**
+   * Disable analytics
+   */
+  disable(): void {
+    log('Disabling analytics');
+    this._config.enabled = false;
+    this.updateConsent(false);
+  }
+
+  /**
+   * Track a page view
+   */
+  trackPageView(page: PageName, previousPage?: PageName): void {
+    if (!this.isActive || !this._config.trackPageViews) {
+      log('Page view tracking skipped', { isActive: this.isActive, page });
+      return;
+    }
+
+    // Calculate time on previous page
+    let timeOnPreviousPage: number | undefined;
+    if (this._pageEntryTime > 0) {
+      timeOnPreviousPage = Date.now() - this._pageEntryTime;
+    }
+
+    const event: PageViewEvent = {
+      ...this.createBaseEvent('page_view'),
+      type: 'page_view',
+      page,
+      previousPage,
+      timeOnPreviousPage,
+    };
+
+    // Update page entry time
+    this._pageEntryTime = Date.now();
+
+    // Update session
+    if (this._session) {
+      this._session.currentPage = page;
+    }
+
+    this.recordEvent(event);
+    log('Page view tracked', { page, previousPage, timeOnPreviousPage });
+  }
+
+  /**
+   * Track feature usage
+   */
+  trackFeatureUsage(
+    feature: FeatureName,
+    metadata?: Record<string, string | number | boolean>
+  ): void {
+    if (!this.isActive || !this._config.trackFeatureUsage) {
+      log('Feature usage tracking skipped', { isActive: this.isActive, feature });
+      return;
+    }
+
+    const event: FeatureUsageEvent = {
+      ...this.createBaseEvent('feature_usage'),
+      type: 'feature_usage',
+      feature,
+      metadata,
+    };
+
+    this.recordEvent(event);
+    log('Feature usage tracked', { feature, metadata });
+  }
+
+  /**
+   * Track an error
+   */
+  trackError(
+    error: Error | string,
+    options: {
+      component?: string;
+      caught?: boolean;
+      isReactError?: boolean;
+    } = {}
+  ): void {
+    if (!this.isActive || !this._config.trackErrors) {
+      log('Error tracking skipped', { isActive: this.isActive });
+      return;
+    }
+
+    const message = typeof error === 'string' ? error : error.message;
+    const errorType = typeof error === 'string' ? 'Error' : error.name;
+
+    const event: ErrorEvent = {
+      ...this.createBaseEvent('error'),
+      type: 'error',
+      message: sanitizeErrorMessage(message),
+      errorType,
+      component: options.component,
+      caught: options.caught ?? true,
+      isReactError: options.isReactError ?? false,
+    };
+
+    this.recordEvent(event);
+    log('Error tracked', { errorType, message: event.message });
+  }
+
+  /**
+   * Track a performance metric
+   */
+  trackPerformance(
+    metric: string,
+    value: number,
+    rating?: 'good' | 'needs-improvement' | 'poor'
+  ): void {
+    if (!this.isActive || !this._config.trackPerformance) {
+      log('Performance tracking skipped', { isActive: this.isActive, metric });
+      return;
+    }
+
+    const event: PerformanceEvent = {
+      ...this.createBaseEvent('performance'),
+      type: 'performance',
+      metric,
+      value,
+      rating,
+    };
+
+    this.recordEvent(event);
+    log('Performance tracked', { metric, value, rating });
+  }
+
+  /**
+   * Track a user action
+   */
+  trackAction(action: string, category: string, label?: string, value?: number): void {
+    if (!this.isActive) {
+      log('Action tracking skipped', { isActive: this.isActive, action });
+      return;
+    }
+
+    const event: UserActionEvent = {
+      ...this.createBaseEvent('user_action'),
+      type: 'user_action',
+      action,
+      category,
+      label,
+      value,
+    };
+
+    this.recordEvent(event);
+    log('Action tracked', { action, category, label, value });
+  }
+
+  /**
+   * Flush events (send to server if configured, otherwise just save)
+   */
+  async flush(): Promise<void> {
+    if (this._events.length === 0) {
+      return;
+    }
+
+    log('Flushing events', { count: this._events.length });
+
+    if (this._config.endpoint) {
+      // If we have a server endpoint, send events there
+      try {
+        await this.sendToServer();
+      } catch (error) {
+        log('Failed to send events to server', error);
+        // Keep events in queue for retry
+      }
+    }
+
+    // Always save to local storage as backup
+    this.saveEvents();
+  }
+
+  /**
+   * Get aggregated analytics data
+   */
+  getAggregate(): AnalyticsAggregate {
+    const pageViews: Record<string, number> = {};
+    const featureUsage: Record<string, number> = {};
+    const errors: Record<string, number> = {};
+    const sessions = new Set<string>();
+    const sessionDurations: number[] = [];
+    let startDate = Date.now();
+    let endDate = 0;
+
+    for (const event of this._events) {
+      // Track date range
+      if (event.timestamp < startDate) startDate = event.timestamp;
+      if (event.timestamp > endDate) endDate = event.timestamp;
+
+      // Track sessions
+      sessions.add(event.sessionId);
+
+      // Aggregate by type
+      switch (event.type) {
+        case 'page_view':
+          pageViews[event.page] = (pageViews[event.page] || 0) + 1;
+          if (event.timeOnPreviousPage) {
+            sessionDurations.push(event.timeOnPreviousPage);
+          }
+          break;
+        case 'feature_usage':
+          featureUsage[event.feature] = (featureUsage[event.feature] || 0) + 1;
+          break;
+        case 'error':
+          errors[event.errorType] = (errors[event.errorType] || 0) + 1;
+          break;
+      }
+    }
+
+    const avgSessionDuration =
+      sessionDurations.length > 0
+        ? sessionDurations.reduce((a, b) => a + b, 0) / sessionDurations.length
+        : 0;
+
+    return {
+      pageViews: pageViews as Record<PageName, number>,
+      featureUsage: featureUsage as Record<FeatureName, number>,
+      errors,
+      uniqueSessions: sessions.size,
+      avgSessionDuration,
+      startDate,
+      endDate,
+    };
+  }
+
+  /**
+   * Export analytics data
+   */
+  exportData(): string {
+    const data = {
+      exportDate: new Date().toISOString(),
+      aggregate: this.getAggregate(),
+      events: this._events,
+      config: {
+        enabled: this._config.enabled,
+        dntEnabled: this.doNotTrackEnabled,
+        dntRespected: this._config.respectDoNotTrack,
+      },
+    };
+
+    return JSON.stringify(data, null, 2);
+  }
+
+  /**
+   * Clear all analytics data
+   */
+  clearData(): void {
+    log('Clearing all analytics data');
+    this._events = [];
+
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(this._config.storageKey);
+    }
+  }
+
+  /**
+   * Get event count by type
+   */
+  getEventCount(type?: string): number {
+    if (!type) {
+      return this._events.length;
+    }
+    return this._events.filter((e) => e.type === type).length;
+  }
+
+  // =============================================================================
+  // Private Methods
+  // =============================================================================
+
+  private createBaseEvent(type: string): BaseAnalyticsEvent {
+    return {
+      id: generateId(),
+      type: type as BaseAnalyticsEvent['type'],
+      timestamp: Date.now(),
+      sessionId: this._session?.id || generateSessionId(),
+      page: this._session?.currentPage,
+    };
+  }
+
+  private recordEvent(event: AnalyticsEvent): void {
+    this._events.push(event);
+
+    // Update session
+    if (this._session) {
+      this._session.lastActivityTime = Date.now();
+      this._session.eventCount++;
+    }
+
+    // Check queue size
+    if (this._events.length >= this._config.maxQueueSize) {
+      this.flush();
+    }
+  }
+
+  private initSession(): void {
+    // Try to load existing session from sessionStorage
+    if (typeof sessionStorage !== 'undefined') {
+      const stored = sessionStorage.getItem(SESSION_STORAGE_KEY);
+      if (stored) {
+        try {
+          const session = JSON.parse(stored) as SessionData;
+          // Check if session is still valid (not timed out)
+          if (Date.now() - session.lastActivityTime < SESSION_TIMEOUT_MS) {
+            this._session = session;
+            log('Resumed existing session', { sessionId: session.id });
+            return;
+          }
+        } catch {
+          // Ignore parse errors
+        }
+      }
+    }
+
+    // Create new session
+    this._session = {
+      id: generateSessionId(),
+      startTime: Date.now(),
+      lastActivityTime: Date.now(),
+      eventCount: 0,
+    };
+
+    this.saveSession();
+    log('Created new session', { sessionId: this._session.id });
+  }
+
+  private saveSession(): void {
+    if (typeof sessionStorage !== 'undefined' && this._session) {
+      sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(this._session));
+    }
+  }
+
+  private loadEvents(): void {
+    if (typeof localStorage === 'undefined') return;
+
+    try {
+      const stored = localStorage.getItem(this._config.storageKey);
+      if (stored) {
+        this._events = JSON.parse(stored) as AnalyticsEvent[];
+        log('Loaded stored events', { count: this._events.length });
+      }
+    } catch (error) {
+      log('Failed to load stored events', error);
+      this._events = [];
+    }
+  }
+
+  private saveEvents(): void {
+    if (typeof localStorage === 'undefined') return;
+
+    try {
+      localStorage.setItem(this._config.storageKey, JSON.stringify(this._events));
+      log('Saved events', { count: this._events.length });
+    } catch (error) {
+      log('Failed to save events', error);
+      // If storage is full, remove oldest events
+      if (this._events.length > 50) {
+        this._events = this._events.slice(-50);
+        try {
+          localStorage.setItem(this._config.storageKey, JSON.stringify(this._events));
+        } catch {
+          // Give up
+        }
+      }
+    }
+  }
+
+  private loadConsent(): void {
+    if (typeof localStorage === 'undefined') return;
+
+    try {
+      const stored = localStorage.getItem(CONSENT_STORAGE_KEY);
+      if (stored) {
+        this._consent = JSON.parse(stored) as PrivacyConsent;
+        log('Loaded consent', this._consent);
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  private updateConsent(analytics: boolean): void {
+    this._consent = {
+      analytics,
+      timestamp: Date.now(),
+      version: CONSENT_VERSION,
+    };
+
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(this._consent));
+    }
+
+    log('Updated consent', this._consent);
+  }
+
+  private async sendToServer(): Promise<void> {
+    if (!this._config.endpoint || this._events.length === 0) return;
+
+    const response = await fetch(this._config.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        events: this._events,
+        sessionId: this._session?.id,
+      }),
+    });
+
+    if (response.ok) {
+      // Clear sent events
+      this._events = [];
+      log('Events sent to server successfully');
+    } else {
+      throw new Error(`Server responded with ${response.status}`);
+    }
+  }
+
+  private handleVisibilityChange = (): void => {
+    if (document.visibilityState === 'hidden') {
+      // Save events when page becomes hidden
+      this.saveEvents();
+      this.saveSession();
+    } else if (document.visibilityState === 'visible') {
+      // Check if session has expired
+      if (this._session && Date.now() - this._session.lastActivityTime > SESSION_TIMEOUT_MS) {
+        log('Session expired, creating new session');
+        this.initSession();
+      }
+    }
+  };
+
+  private handleBeforeUnload = (): void => {
+    this.saveEvents();
+    this.saveSession();
+  };
+}
+
+// =============================================================================
+// Singleton Instance
+// =============================================================================
+
+export const analyticsService = new AnalyticsService();
+
+// Export class for testing
+export { AnalyticsService };

--- a/web/src/lib/analytics/index.ts
+++ b/web/src/lib/analytics/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Analytics Module
+ *
+ * Privacy-respecting analytics for Ghost Note.
+ * Provides anonymous usage tracking with full user control.
+ *
+ * @module lib/analytics
+ */
+
+// Service
+export { analyticsService, AnalyticsService } from './analyticsService';
+
+// Types
+export type {
+  AnalyticsEventType,
+  FeatureName,
+  PageName,
+  BaseAnalyticsEvent,
+  PageViewEvent,
+  FeatureUsageEvent,
+  ErrorEvent,
+  PerformanceEvent,
+  UserActionEvent,
+  AnalyticsEvent,
+  AnalyticsConfig,
+  AnalyticsAggregate,
+  PrivacyConsent,
+  SessionData,
+} from './types';

--- a/web/src/lib/analytics/types.ts
+++ b/web/src/lib/analytics/types.ts
@@ -1,0 +1,219 @@
+/**
+ * Analytics Types
+ *
+ * Type definitions for the privacy-respecting analytics system.
+ *
+ * @module lib/analytics/types
+ */
+
+/**
+ * Types of events that can be tracked
+ */
+export type AnalyticsEventType =
+  | 'page_view'
+  | 'feature_usage'
+  | 'error'
+  | 'performance'
+  | 'user_action';
+
+/**
+ * Feature names that can be tracked
+ */
+export type FeatureName =
+  | 'poem_input'
+  | 'poem_analysis'
+  | 'lyrics_edit'
+  | 'suggestion_apply'
+  | 'suggestion_reject'
+  | 'melody_generate'
+  | 'melody_play'
+  | 'melody_stop'
+  | 'melody_pause'
+  | 'recording_start'
+  | 'recording_stop'
+  | 'theme_change'
+  | 'export_project'
+  | 'import_project'
+  | 'undo'
+  | 'redo'
+  | 'keyboard_shortcut';
+
+/**
+ * Page/view names for page view tracking
+ */
+export type PageName =
+  | 'poem-input'
+  | 'analysis'
+  | 'lyrics-editor'
+  | 'melody'
+  | 'recording';
+
+/**
+ * Base analytics event (common fields)
+ */
+export interface BaseAnalyticsEvent {
+  /** Unique event ID */
+  id: string;
+  /** Event type */
+  type: AnalyticsEventType;
+  /** Timestamp when event occurred */
+  timestamp: number;
+  /** Session ID (anonymous, generated per browser session) */
+  sessionId: string;
+  /** Current page/view when event occurred */
+  page?: PageName;
+}
+
+/**
+ * Page view event
+ */
+export interface PageViewEvent extends BaseAnalyticsEvent {
+  type: 'page_view';
+  /** Page being viewed */
+  page: PageName;
+  /** Previous page (for navigation tracking) */
+  previousPage?: PageName;
+  /** Time spent on previous page in milliseconds */
+  timeOnPreviousPage?: number;
+}
+
+/**
+ * Feature usage event
+ */
+export interface FeatureUsageEvent extends BaseAnalyticsEvent {
+  type: 'feature_usage';
+  /** Feature that was used */
+  feature: FeatureName;
+  /** Optional metadata about the feature usage (no PII) */
+  metadata?: Record<string, string | number | boolean>;
+}
+
+/**
+ * Error event
+ */
+export interface ErrorEvent extends BaseAnalyticsEvent {
+  type: 'error';
+  /** Error message (sanitized, no stack traces with file paths) */
+  message: string;
+  /** Error category/name */
+  errorType: string;
+  /** Component where error occurred (if available) */
+  component?: string;
+  /** Whether error was caught by error boundary */
+  caught: boolean;
+  /** Whether this is a React error boundary error */
+  isReactError: boolean;
+}
+
+/**
+ * Performance event
+ */
+export interface PerformanceEvent extends BaseAnalyticsEvent {
+  type: 'performance';
+  /** Metric name */
+  metric: string;
+  /** Value in milliseconds */
+  value: number;
+  /** Optional rating (good, needs-improvement, poor) */
+  rating?: 'good' | 'needs-improvement' | 'poor';
+}
+
+/**
+ * User action event (for A/B testing, feature discovery)
+ */
+export interface UserActionEvent extends BaseAnalyticsEvent {
+  type: 'user_action';
+  /** Action name */
+  action: string;
+  /** Action category */
+  category: string;
+  /** Optional label for additional context */
+  label?: string;
+  /** Optional value */
+  value?: number;
+}
+
+/**
+ * Union type for all analytics events
+ */
+export type AnalyticsEvent =
+  | PageViewEvent
+  | FeatureUsageEvent
+  | ErrorEvent
+  | PerformanceEvent
+  | UserActionEvent;
+
+/**
+ * Analytics configuration
+ */
+export interface AnalyticsConfig {
+  /** Enable/disable analytics */
+  enabled: boolean;
+  /** Respect Do Not Track header */
+  respectDoNotTrack: boolean;
+  /** Enable debug logging */
+  debug: boolean;
+  /** Maximum events to store locally before flush */
+  maxQueueSize: number;
+  /** Flush interval in milliseconds (0 = manual only) */
+  flushInterval: number;
+  /** Enable error tracking */
+  trackErrors: boolean;
+  /** Enable performance tracking */
+  trackPerformance: boolean;
+  /** Enable page view tracking */
+  trackPageViews: boolean;
+  /** Enable feature usage tracking */
+  trackFeatureUsage: boolean;
+  /** Storage key for persisting events */
+  storageKey: string;
+  /** Endpoint for sending analytics (if using server) */
+  endpoint?: string;
+}
+
+/**
+ * Aggregated analytics data for dashboard display
+ */
+export interface AnalyticsAggregate {
+  /** Total page views by page */
+  pageViews: Record<PageName, number>;
+  /** Total feature usage by feature */
+  featureUsage: Record<FeatureName, number>;
+  /** Error count by error type */
+  errors: Record<string, number>;
+  /** Total unique sessions */
+  uniqueSessions: number;
+  /** Average session duration in ms */
+  avgSessionDuration: number;
+  /** Date range */
+  startDate: number;
+  endDate: number;
+}
+
+/**
+ * Privacy consent state
+ */
+export interface PrivacyConsent {
+  /** User has explicitly consented to analytics */
+  analytics: boolean;
+  /** Timestamp of consent */
+  timestamp: number;
+  /** Consent version (for future consent updates) */
+  version: string;
+}
+
+/**
+ * Session data
+ */
+export interface SessionData {
+  /** Anonymous session ID */
+  id: string;
+  /** Session start time */
+  startTime: number;
+  /** Last activity time */
+  lastActivityTime: number;
+  /** Current page */
+  currentPage?: PageName;
+  /** Number of events in session */
+  eventCount: number;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,32 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { analyticsService } from '@/lib/analytics'
+
+// Initialize analytics service early (before React renders)
+// This respects Do Not Track and provides privacy-first analytics
+analyticsService.initialize();
+
+// Set up global error handler to catch uncaught errors
+window.addEventListener('error', (event) => {
+  analyticsService.trackError(event.error || event.message, {
+    component: 'window',
+    caught: false,
+    isReactError: false,
+  });
+});
+
+// Set up unhandled promise rejection handler
+window.addEventListener('unhandledrejection', (event) => {
+  const message = event.reason instanceof Error
+    ? event.reason.message
+    : String(event.reason);
+  analyticsService.trackError(message, {
+    component: 'promise',
+    caught: false,
+    isReactError: false,
+  });
+});
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/web/src/stores/index.ts
+++ b/web/src/stores/index.ts
@@ -203,6 +203,24 @@ export {
   selectFutureDescriptions,
 } from './undoMiddleware';
 
+// Analytics Store
+export { useAnalyticsStore } from './useAnalyticsStore';
+export type {
+  AnalyticsState,
+  AnalyticsActions,
+  AnalyticsStore as AnalyticsStoreType,
+} from './useAnalyticsStore';
+export {
+  selectAnalyticsEnabled,
+  selectDoNotTrackDetected,
+  selectAnalyticsInitialized,
+  selectAnalyticsAggregate,
+  selectAnalyticsActive,
+  selectTotalPageViews,
+  selectTotalFeatureUsage,
+  selectTotalErrors,
+} from './useAnalyticsStore';
+
 // =============================================================================
 // Utility Functions
 // =============================================================================
@@ -217,6 +235,7 @@ import { useThemeStore as themeStore } from './useThemeStore';
 import { useSuggestionStore as suggestionStore } from './useSuggestionStore';
 import { useToastStore as toastStore } from './useToastStore';
 import { useUndoStore as undoStore } from './undoMiddleware';
+import { useAnalyticsStore as analyticsStore } from './useAnalyticsStore';
 
 /**
  * Reset all stores to their initial state
@@ -232,6 +251,7 @@ export function resetAllStores(): void {
   suggestionStore.getState().reset();
   toastStore.getState().reset();
   undoStore.getState().clearHistory();
+  analyticsStore.getState().reset();
 
   console.log('[Stores] All stores reset');
 }
@@ -246,6 +266,9 @@ export function clearPersistedData(): void {
     localStorage.removeItem('ghost-note-recording-store');
     localStorage.removeItem('ghost-note-ui-store');
     localStorage.removeItem('ghost-note-theme-store');
+    localStorage.removeItem('ghost-note-analytics');
+    localStorage.removeItem('ghost-note-analytics-preferences');
+    localStorage.removeItem('ghost-note-analytics-consent');
     console.log('[Stores] All persisted data cleared');
   }
 }

--- a/web/src/stores/useAnalyticsStore.test.ts
+++ b/web/src/stores/useAnalyticsStore.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Analytics Store Tests
+ *
+ * Tests for the analytics store and its integration with the analytics service.
+ *
+ * @module stores/useAnalyticsStore.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  useAnalyticsStore,
+  selectAnalyticsEnabled,
+  selectDoNotTrackDetected,
+  selectAnalyticsInitialized,
+  selectAnalyticsActive,
+  selectTotalPageViews,
+  selectTotalFeatureUsage,
+  selectTotalErrors,
+} from './useAnalyticsStore';
+
+// Mock localStorage and sessionStorage
+const mockStorage: Record<string, string> = {};
+const mockSessionStorage: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => mockStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockStorage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete mockStorage[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
+  }),
+};
+
+const sessionStorageMock = {
+  getItem: vi.fn((key: string) => mockSessionStorage[key] || null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockSessionStorage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete mockSessionStorage[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(mockSessionStorage).forEach((key) => delete mockSessionStorage[key]);
+  }),
+};
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessionStorageMock,
+  writable: true,
+});
+
+describe('useAnalyticsStore', () => {
+  beforeEach(() => {
+    // Clear mocks and storage
+    vi.clearAllMocks();
+    localStorageMock.clear();
+    sessionStorageMock.clear();
+
+    // Reset navigator.doNotTrack
+    Object.defineProperty(navigator, 'doNotTrack', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    // Reset the store
+    const { result } = renderHook(() => useAnalyticsStore());
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  afterEach(() => {
+    const { result } = renderHook(() => useAnalyticsStore());
+    act(() => {
+      result.current.reset();
+    });
+  });
+
+  describe('initial state', () => {
+    it('should have analytics enabled by default', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(result.current.enabled).toBe(true);
+    });
+
+    it('should not be initialized initially', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(result.current.initialized).toBe(false);
+    });
+
+    it('should not detect DNT initially', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(result.current.doNotTrackDetected).toBe(false);
+    });
+
+    it('should not have aggregate data initially', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(result.current.aggregate).toBeNull();
+    });
+  });
+
+  describe('initialization', () => {
+    it('should initialize the store', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.initialize();
+      });
+
+      expect(result.current.initialized).toBe(true);
+    });
+
+    it('should detect DNT on initialization when set', () => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        value: '1',
+        writable: true,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.initialize();
+      });
+
+      expect(result.current.doNotTrackDetected).toBe(true);
+    });
+  });
+
+  describe('enable/disable', () => {
+    it('should enable analytics', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.disable();
+      });
+      expect(result.current.enabled).toBe(false);
+
+      act(() => {
+        result.current.enable();
+      });
+      expect(result.current.enabled).toBe(true);
+    });
+
+    it('should disable analytics', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.disable();
+      });
+
+      expect(result.current.enabled).toBe(false);
+    });
+  });
+
+  describe('tracking', () => {
+    it('should track page views', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.initialize();
+        result.current.trackPageView('poem-input');
+        result.current.refreshAggregate();
+      });
+
+      // Should have some aggregate data now
+      expect(result.current.aggregate).not.toBeNull();
+    });
+
+    it('should track feature usage', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.initialize();
+        result.current.trackFeature('melody_generate');
+        result.current.refreshAggregate();
+      });
+
+      expect(result.current.aggregate).not.toBeNull();
+    });
+
+    it('should track errors', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.initialize();
+        result.current.trackError(new Error('Test error'));
+        result.current.refreshAggregate();
+      });
+
+      expect(result.current.aggregate).not.toBeNull();
+    });
+
+    it('should track performance', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.initialize();
+        result.current.trackPerformance('LCP', 2500);
+        result.current.refreshAggregate();
+      });
+
+      expect(result.current.aggregate).not.toBeNull();
+    });
+  });
+
+  describe('data export', () => {
+    it('should export data as JSON string', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.initialize();
+        result.current.trackPageView('poem-input');
+      });
+
+      let exported: string = '';
+      act(() => {
+        exported = result.current.exportData();
+      });
+
+      expect(exported).toBeTruthy();
+      const data = JSON.parse(exported);
+      expect(data.exportDate).toBeDefined();
+    });
+  });
+
+  describe('data clearing', () => {
+    it('should clear analytics data', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.initialize();
+        result.current.trackPageView('poem-input');
+        result.current.refreshAggregate();
+      });
+
+      act(() => {
+        result.current.clearData();
+      });
+
+      expect(result.current.aggregate).toBeNull();
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset the store to initial state', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.initialize();
+        result.current.disable();
+      });
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.enabled).toBe(true);
+      expect(result.current.initialized).toBe(false);
+    });
+  });
+
+  describe('selectors', () => {
+    it('selectAnalyticsEnabled should return enabled state', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(selectAnalyticsEnabled(result.current)).toBe(true);
+    });
+
+    it('selectDoNotTrackDetected should return DNT state', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(selectDoNotTrackDetected(result.current)).toBe(false);
+    });
+
+    it('selectAnalyticsInitialized should return initialized state', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(selectAnalyticsInitialized(result.current)).toBe(false);
+
+      act(() => {
+        result.current.initialize();
+      });
+
+      expect(selectAnalyticsInitialized(result.current)).toBe(true);
+    });
+
+    it('selectAnalyticsActive should return true when enabled and no DNT', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(selectAnalyticsActive(result.current)).toBe(true);
+    });
+
+    it('selectAnalyticsActive should return false when disabled', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+
+      act(() => {
+        result.current.disable();
+      });
+
+      expect(selectAnalyticsActive(result.current)).toBe(false);
+    });
+
+    it('selectTotalPageViews should return 0 when no aggregate', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(selectTotalPageViews(result.current)).toBe(0);
+    });
+
+    it('selectTotalFeatureUsage should return 0 when no aggregate', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(selectTotalFeatureUsage(result.current)).toBe(0);
+    });
+
+    it('selectTotalErrors should return 0 when no aggregate', () => {
+      const { result } = renderHook(() => useAnalyticsStore());
+      expect(selectTotalErrors(result.current)).toBe(0);
+    });
+  });
+});

--- a/web/src/stores/useAnalyticsStore.ts
+++ b/web/src/stores/useAnalyticsStore.ts
@@ -1,0 +1,248 @@
+/**
+ * Ghost Note - Analytics Store
+ *
+ * Manages analytics state and provides React integration for the
+ * privacy-respecting analytics service.
+ *
+ * @module stores/useAnalyticsStore
+ */
+
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+import {
+  analyticsService,
+  type AnalyticsAggregate,
+  type FeatureName,
+  type PageName,
+} from '@/lib/analytics';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface AnalyticsState {
+  /** Whether analytics is enabled */
+  enabled: boolean;
+  /** Whether Do Not Track is detected in browser */
+  doNotTrackDetected: boolean;
+  /** Whether service has been initialized */
+  initialized: boolean;
+  /** Current aggregate data (for dashboard) */
+  aggregate: AnalyticsAggregate | null;
+  /** Last update timestamp */
+  lastUpdated: number;
+}
+
+export interface AnalyticsActions {
+  /** Initialize analytics service */
+  initialize: () => void;
+  /** Enable analytics tracking */
+  enable: () => void;
+  /** Disable analytics tracking */
+  disable: () => void;
+  /** Track a page view */
+  trackPageView: (page: PageName, previousPage?: PageName) => void;
+  /** Track feature usage */
+  trackFeature: (feature: FeatureName, metadata?: Record<string, string | number | boolean>) => void;
+  /** Track an error */
+  trackError: (error: Error | string, options?: { component?: string; caught?: boolean; isReactError?: boolean }) => void;
+  /** Track performance metric */
+  trackPerformance: (metric: string, value: number, rating?: 'good' | 'needs-improvement' | 'poor') => void;
+  /** Refresh aggregate data */
+  refreshAggregate: () => void;
+  /** Export analytics data */
+  exportData: () => string;
+  /** Clear all analytics data */
+  clearData: () => void;
+  /** Reset store to initial state */
+  reset: () => void;
+}
+
+export type AnalyticsStore = AnalyticsState & AnalyticsActions;
+
+// =============================================================================
+// Initial State
+// =============================================================================
+
+const initialState: AnalyticsState = {
+  enabled: true,
+  doNotTrackDetected: false,
+  initialized: false,
+  aggregate: null,
+  lastUpdated: 0,
+};
+
+// =============================================================================
+// Store Implementation
+// =============================================================================
+
+export const useAnalyticsStore = create<AnalyticsStore>()(
+  devtools(
+    persist(
+      (set, get) => ({
+        // State
+        ...initialState,
+
+        // Actions
+        initialize: () => {
+          const state = get();
+          if (state.initialized) {
+            console.log('[AnalyticsStore] Already initialized');
+            return;
+          }
+
+          console.log('[AnalyticsStore] Initializing');
+
+          // Configure service based on stored preferences
+          analyticsService.configure({
+            enabled: state.enabled,
+          });
+
+          // Initialize the service
+          analyticsService.initialize();
+
+          // Check DNT status
+          const doNotTrackDetected = analyticsService.doNotTrackEnabled;
+
+          set(
+            {
+              initialized: true,
+              doNotTrackDetected,
+            },
+            false,
+            'initialize'
+          );
+
+          // Refresh aggregate
+          get().refreshAggregate();
+        },
+
+        enable: () => {
+          console.log('[AnalyticsStore] Enabling analytics');
+          analyticsService.enable();
+          set({ enabled: true }, false, 'enable');
+        },
+
+        disable: () => {
+          console.log('[AnalyticsStore] Disabling analytics');
+          analyticsService.disable();
+          set({ enabled: false }, false, 'disable');
+        },
+
+        trackPageView: (page, previousPage) => {
+          analyticsService.trackPageView(page, previousPage);
+          // Don't trigger state update for every event - too expensive
+        },
+
+        trackFeature: (feature, metadata) => {
+          analyticsService.trackFeatureUsage(feature, metadata);
+        },
+
+        trackError: (error, options) => {
+          analyticsService.trackError(error, options);
+        },
+
+        trackPerformance: (metric, value, rating) => {
+          analyticsService.trackPerformance(metric, value, rating);
+        },
+
+        refreshAggregate: () => {
+          const aggregate = analyticsService.getAggregate();
+          set(
+            {
+              aggregate,
+              lastUpdated: Date.now(),
+            },
+            false,
+            'refreshAggregate'
+          );
+        },
+
+        exportData: () => {
+          return analyticsService.exportData();
+        },
+
+        clearData: () => {
+          console.log('[AnalyticsStore] Clearing all analytics data');
+          analyticsService.clearData();
+          set(
+            {
+              aggregate: null,
+              lastUpdated: Date.now(),
+            },
+            false,
+            'clearData'
+          );
+        },
+
+        reset: () => {
+          console.log('[AnalyticsStore] Resetting store');
+          analyticsService.shutdown();
+          set(initialState, false, 'reset');
+        },
+      }),
+      {
+        name: 'ghost-note-analytics-preferences',
+        partialize: (state) => ({
+          enabled: state.enabled,
+        }),
+      }
+    ),
+    { name: 'AnalyticsStore' }
+  )
+);
+
+// =============================================================================
+// Selectors
+// =============================================================================
+
+/**
+ * Check if analytics is enabled
+ */
+export const selectAnalyticsEnabled = (state: AnalyticsStore): boolean => state.enabled;
+
+/**
+ * Check if Do Not Track is detected
+ */
+export const selectDoNotTrackDetected = (state: AnalyticsStore): boolean => state.doNotTrackDetected;
+
+/**
+ * Check if analytics is initialized
+ */
+export const selectAnalyticsInitialized = (state: AnalyticsStore): boolean => state.initialized;
+
+/**
+ * Get aggregate data
+ */
+export const selectAnalyticsAggregate = (state: AnalyticsStore): AnalyticsAggregate | null =>
+  state.aggregate;
+
+/**
+ * Check if analytics is active (enabled and not blocked by DNT)
+ */
+export const selectAnalyticsActive = (state: AnalyticsStore): boolean =>
+  state.enabled && !state.doNotTrackDetected;
+
+/**
+ * Get total page views from aggregate
+ */
+export const selectTotalPageViews = (state: AnalyticsStore): number => {
+  if (!state.aggregate) return 0;
+  return Object.values(state.aggregate.pageViews).reduce((sum, count) => sum + count, 0);
+};
+
+/**
+ * Get total feature usage from aggregate
+ */
+export const selectTotalFeatureUsage = (state: AnalyticsStore): number => {
+  if (!state.aggregate) return 0;
+  return Object.values(state.aggregate.featureUsage).reduce((sum, count) => sum + count, 0);
+};
+
+/**
+ * Get total error count from aggregate
+ */
+export const selectTotalErrors = (state: AnalyticsStore): number => {
+  if (!state.aggregate) return 0;
+  return Object.values(state.aggregate.errors).reduce((sum, count) => sum + count, 0);
+};


### PR DESCRIPTION
## Summary
- Implement self-hosted, privacy-respecting analytics system
- Respect Do Not Track (DNT) browser setting
- Track anonymous page views, feature usage, and errors
- No personal data collection - GDPR compliant
- Add user controls for privacy settings

## Changes
- `web/src/lib/analytics/` - Analytics service with local storage
  - `types.ts` - Type definitions for events and configuration
  - `analyticsService.ts` - Core analytics service class
  - `analyticsService.test.ts` - Comprehensive tests
  - `index.ts` - Public exports
- `web/src/stores/useAnalyticsStore.ts` - Zustand store for React integration
- `web/src/hooks/useAnalytics.ts` - React hooks for tracking
- `web/src/components/Privacy/` - Privacy settings UI component
  - `PrivacySettings.tsx` - Toggle, export, clear controls
  - `PrivacySettings.css` - Styles with dark mode support
  - `PrivacySettings.test.tsx` - Component tests
- `web/src/components/Common/ErrorBoundary.tsx` - Integrated error reporting
- `web/src/main.tsx` - Initialize analytics on app start

## Privacy Features
- **DNT Respected**: Automatically disabled when Do Not Track is set
- **Local Storage Only**: No data sent to external servers
- **Anonymous Sessions**: Generated UUIDs, no identifiers
- **Data Sanitization**: Error messages scrubbed of paths, URLs, emails
- **Full User Control**: Toggle, export JSON, and clear all data
- **Opt-out Model**: Analytics active by default but easily disabled

## Testing
- [x] Unit tests pass (`npm test`)
- [x] Lint passes (`npm run check`)
- [x] TypeScript compiles
- [x] 100+ new test cases added

## Notes
This implementation uses a self-hosted approach with local storage rather than an external analytics service. All data stays on the user's device. The PrivacySettings component can be integrated into a settings page to give users full control.

Closes #53