### PR TITLE
feat(GH-66): Implement share/copy link feature for poems

### DIFF
--- a/web/src/components/Layout/Header.tsx
+++ b/web/src/components/Layout/Header.tsx
@@ -143,6 +143,27 @@ function HelpIcon(): ReactElement {
 }
 
 /**
+ * Share/Link icon
+ */
+function ShareIcon(): ReactElement {
+  return (
+    <svg
+      className="header__icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+/**
  * Header component displays the application title and provides
  * access to theme toggle and help functionality.
  *
@@ -181,6 +202,11 @@ export function Header({ className = '' }: HeaderProps): ReactElement {
     openModalDialog('help');
   };
 
+  const handleShareClick = (): void => {
+    log('Opening share modal');
+    openModalDialog('share');
+  };
+
   const handleMenuClick = (): void => {
     log('Toggling sidebar');
     toggleSidebar();
@@ -210,6 +236,18 @@ export function Header({ className = '' }: HeaderProps): ReactElement {
       </div>
 
       <div className="header__right">
+        {/* Share button */}
+        <button
+          type="button"
+          className="header__button header__share-button"
+          onClick={handleShareClick}
+          aria-label="Share poem"
+          title="Share poem"
+          data-testid="share-button"
+        >
+          <ShareIcon />
+        </button>
+
         {/* Theme toggle button */}
         <button
           type="button"

--- a/web/src/components/Share/ShareDialog.css
+++ b/web/src/components/Share/ShareDialog.css
@@ -1,0 +1,464 @@
+/**
+ * ShareDialog Component Styles
+ *
+ * Styles for the share dialog modal.
+ */
+
+/* Overlay */
+.share-dialog__overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+  animation: share-dialog-fade-in 0.15s ease-out;
+}
+
+@keyframes share-dialog-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Dialog Container */
+.share-dialog {
+  background-color: var(--color-surface, white);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  width: 100%;
+  max-width: 500px;
+  max-height: calc(100vh - 2rem);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: share-dialog-slide-in 0.2s ease-out;
+}
+
+@keyframes share-dialog-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Header */
+.share-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.share-dialog__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #111827);
+}
+
+.share-dialog__close-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--color-text-secondary, #6b7280);
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.share-dialog__close-button:hover {
+  background-color: var(--color-button-secondary-bg, #f3f4f6);
+  color: var(--color-text-primary, #111827);
+}
+
+.share-dialog__close-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-primary, #3b82f6);
+}
+
+/* Content */
+.share-dialog__content {
+  padding: 1.25rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.share-dialog__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.share-dialog__section-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #374151);
+}
+
+/* Mode Options */
+.share-dialog__mode-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.share-dialog__mode-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background-color: var(--color-surface, #f9fafb);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.share-dialog__mode-option:hover:not(.share-dialog__mode-option--disabled) {
+  background-color: var(--color-button-secondary-bg, #f3f4f6);
+}
+
+.share-dialog__mode-option--selected {
+  border-color: var(--color-primary, #3b82f6);
+  background-color: rgba(59, 130, 246, 0.05);
+}
+
+.share-dialog__mode-option--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.share-dialog__mode-radio {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.share-dialog__mode-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.share-dialog__mode-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #374151);
+}
+
+.share-dialog__mode-description {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #6b7280);
+  line-height: 1.4;
+}
+
+.share-dialog__mode-unavailable {
+  color: var(--color-warning, #f59e0b);
+  font-style: italic;
+}
+
+/* Generate Button */
+.share-dialog__generate-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: white;
+  background-color: var(--color-primary, #3b82f6);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.share-dialog__generate-button:hover:not(:disabled) {
+  background-color: var(--color-primary-hover, #2563eb);
+}
+
+.share-dialog__generate-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.share-dialog__generate-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+/* Spinner */
+.share-dialog__spinner {
+  animation: share-dialog-spin 1s linear infinite;
+}
+
+@keyframes share-dialog-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Result Section */
+.share-dialog__result {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.share-dialog__url-container {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.share-dialog__url-input {
+  flex: 1;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.75rem;
+  font-family: monospace;
+  color: var(--color-text-primary, #374151);
+  background-color: var(--color-surface, #f9fafb);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.share-dialog__url-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #3b82f6);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.share-dialog__copy-button {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #374151);
+  background-color: var(--color-button-secondary-bg, #f3f4f6);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.share-dialog__copy-button:hover {
+  background-color: var(--color-button-secondary-hover, #e5e7eb);
+}
+
+.share-dialog__copy-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-primary, #3b82f6);
+}
+
+.share-dialog__copy-button--copied {
+  color: var(--color-success, #10b981);
+  border-color: var(--color-success, #10b981);
+  background-color: rgba(16, 185, 129, 0.1);
+}
+
+/* Stats */
+.share-dialog__stats {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.share-dialog__stat {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.share-dialog__stat--info {
+  color: var(--color-primary, #3b82f6);
+}
+
+/* Warning */
+.share-dialog__warning {
+  font-size: 0.75rem;
+  color: var(--color-warning, #f59e0b);
+  background-color: rgba(245, 158, 11, 0.1);
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  margin: 0;
+}
+
+/* Error */
+.share-dialog__error {
+  font-size: 0.875rem;
+  color: var(--color-error, #ef4444);
+  background-color: rgba(239, 68, 68, 0.1);
+  padding: 0.75rem;
+  border-radius: 6px;
+}
+
+.share-dialog__error p {
+  margin: 0;
+}
+
+/* Privacy Note */
+.share-dialog__privacy-note {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #6b7280);
+  background-color: var(--color-surface, #f9fafb);
+  padding: 0.75rem;
+  border-radius: 6px;
+  border-left: 3px solid var(--color-primary, #3b82f6);
+}
+
+.share-dialog__privacy-note p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.share-dialog__privacy-note strong {
+  color: var(--color-text-primary, #374151);
+}
+
+/* Empty State */
+.share-dialog__empty-message {
+  text-align: center;
+  color: var(--color-text-secondary, #6b7280);
+  padding: 2rem 1rem;
+  margin: 0;
+}
+
+/* Dark Mode */
+.dark .share-dialog {
+  background-color: var(--color-surface-dark, #1f2937);
+}
+
+.dark .share-dialog__header {
+  border-bottom-color: var(--color-border-dark, #374151);
+}
+
+.dark .share-dialog__title {
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .share-dialog__close-button {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .share-dialog__close-button:hover {
+  background-color: var(--color-button-secondary-bg-dark, #374151);
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .share-dialog__section-label {
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .share-dialog__mode-option {
+  background-color: var(--color-surface-dark, #111827);
+}
+
+.dark .share-dialog__mode-option:hover:not(.share-dialog__mode-option--disabled) {
+  background-color: var(--color-button-secondary-bg-dark, #374151);
+}
+
+.dark .share-dialog__mode-option--selected {
+  background-color: rgba(59, 130, 246, 0.1);
+}
+
+.dark .share-dialog__mode-label {
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .share-dialog__mode-description {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .share-dialog__url-input {
+  background-color: var(--color-surface-dark, #111827);
+  border-color: var(--color-border-dark, #374151);
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .share-dialog__copy-button {
+  background-color: var(--color-button-secondary-bg-dark, #374151);
+  border-color: var(--color-border-dark, #4b5563);
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .share-dialog__copy-button:hover {
+  background-color: var(--color-button-secondary-hover-dark, #4b5563);
+}
+
+.dark .share-dialog__stat {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .share-dialog__privacy-note {
+  background-color: var(--color-surface-dark, #111827);
+}
+
+.dark .share-dialog__privacy-note strong {
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .share-dialog__empty-message {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .share-dialog__overlay,
+  .share-dialog,
+  .share-dialog__spinner {
+    animation: none;
+  }
+}
+
+/* Mobile Responsive */
+@media (max-width: 480px) {
+  .share-dialog {
+    max-width: calc(100% - 2rem);
+    max-height: calc(100vh - 4rem);
+  }
+
+  .share-dialog__header {
+    padding: 0.875rem 1rem;
+  }
+
+  .share-dialog__content {
+    padding: 1rem;
+  }
+
+  .share-dialog__url-container {
+    flex-direction: column;
+  }
+
+  .share-dialog__copy-button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/web/src/components/Share/ShareDialog.test.tsx
+++ b/web/src/components/Share/ShareDialog.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Tests for ShareDialog Component
+ *
+ * @module components/Share/ShareDialog.test
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ShareDialog } from './ShareDialog';
+import { usePoemStore } from '@/stores/usePoemStore';
+import { useAnalysisStore } from '@/stores/useAnalysisStore';
+import { useMelodyStore } from '@/stores/useMelodyStore';
+import { createDefaultPoemAnalysis } from '@/types';
+
+// Mock clipboard API
+const mockWriteText = vi.fn();
+Object.assign(navigator, {
+  clipboard: {
+    writeText: mockWriteText,
+  },
+});
+
+// Create mock analysis using the factory function
+const mockAnalysis = createDefaultPoemAnalysis();
+
+describe('ShareDialog', () => {
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    // Reset stores
+    usePoemStore.getState().reset();
+    useAnalysisStore.getState().reset();
+    useMelodyStore.getState().reset();
+
+    // Reset mocks
+    mockOnClose.mockReset();
+    mockWriteText.mockReset();
+    mockWriteText.mockResolvedValue(undefined);
+  });
+
+  it('should not render when closed', () => {
+    render(<ShareDialog isOpen={false} onClose={mockOnClose} />);
+
+    expect(screen.queryByTestId('share-dialog')).not.toBeInTheDocument();
+  });
+
+  it('should render when open with no poem', () => {
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    expect(screen.getByTestId('share-dialog')).toBeInTheDocument();
+    expect(screen.getByText(/enter a poem first/i)).toBeInTheDocument();
+  });
+
+  it('should render share options when poem exists', () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    expect(screen.getByTestId('share-dialog')).toBeInTheDocument();
+    expect(screen.getByText('Share Poem')).toBeInTheDocument();
+    expect(screen.getByText('Poem Only')).toBeInTheDocument();
+    expect(screen.getByText('With Analysis')).toBeInTheDocument();
+    expect(screen.getByText('Full Project')).toBeInTheDocument();
+  });
+
+  it('should close when close button is clicked', async () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    const closeButton = screen.getByTestId('share-dialog-close');
+    await userEvent.click(closeButton);
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should close when overlay is clicked', async () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    const overlay = screen.getByTestId('share-dialog');
+    await userEvent.click(overlay);
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should close when Escape is pressed', () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should disable with-analysis option when no analysis exists', () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    const withAnalysisOption = screen.getByTestId('share-dialog-mode-with-analysis');
+    const radio = withAnalysisOption.querySelector('input[type="radio"]');
+
+    expect(radio).toBeDisabled();
+  });
+
+  it('should enable with-analysis option when analysis exists', () => {
+    usePoemStore.getState().setPoem('Roses are red');
+    useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    const withAnalysisOption = screen.getByTestId('share-dialog-mode-with-analysis');
+    const radio = withAnalysisOption.querySelector('input[type="radio"]');
+
+    expect(radio).not.toBeDisabled();
+  });
+
+  it('should generate share link when button is clicked', async () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    const generateButton = screen.getByTestId('share-dialog-generate');
+    await userEvent.click(generateButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('share-dialog-result')).toBeInTheDocument();
+    });
+  });
+
+  it('should show URL in input after generating', async () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    const generateButton = screen.getByTestId('share-dialog-generate');
+    await userEvent.click(generateButton);
+
+    await waitFor(() => {
+      const urlInput = screen.getByTestId('share-dialog-url') as HTMLInputElement;
+      expect(urlInput.value).toContain('#share=');
+    });
+  });
+
+  it('should copy URL to clipboard when copy button is clicked', async () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    // Generate link first
+    const generateButton = screen.getByTestId('share-dialog-generate');
+    await userEvent.click(generateButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('share-dialog-copy')).toBeInTheDocument();
+    });
+
+    // Click copy
+    const copyButton = screen.getByTestId('share-dialog-copy');
+    await userEvent.click(copyButton);
+
+    expect(mockWriteText).toHaveBeenCalled();
+  });
+
+  it('should show copied state after copying', async () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    // Generate link first
+    const generateButton = screen.getByTestId('share-dialog-generate');
+    await userEvent.click(generateButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('share-dialog-copy')).toBeInTheDocument();
+    });
+
+    // Click copy
+    const copyButton = screen.getByTestId('share-dialog-copy');
+    await userEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Copied!')).toBeInTheDocument();
+    });
+  });
+
+  it('should show privacy note', () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    expect(screen.getByText(/privacy note/i)).toBeInTheDocument();
+  });
+
+  it('should allow selecting different share modes', async () => {
+    usePoemStore.getState().setPoem('Roses are red');
+    useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    // Click on with-analysis option
+    const withAnalysisOption = screen.getByTestId('share-dialog-mode-with-analysis');
+    await userEvent.click(withAnalysisOption);
+
+    const radio = withAnalysisOption.querySelector('input[type="radio"]') as HTMLInputElement;
+    expect(radio.checked).toBe(true);
+  });
+
+  it('should auto-select with-analysis mode when only analysis exists', async () => {
+    usePoemStore.getState().setPoem('Roses are red');
+    useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    // Should auto-select with-analysis when analysis exists but no melody
+    const withAnalysisOption = screen.getByTestId('share-dialog-mode-with-analysis');
+    const radio = withAnalysisOption.querySelector('input[type="radio"]') as HTMLInputElement;
+
+    // With-analysis is selected when analysis exists (but no melody)
+    expect(radio.checked).toBe(true);
+  });
+
+  it('should show URL length stats after generating', async () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} />);
+
+    const generateButton = screen.getByTestId('share-dialog-generate');
+    await userEvent.click(generateButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/URL Length:/)).toBeInTheDocument();
+    });
+  });
+
+  it('should display the correct test ID', () => {
+    usePoemStore.getState().setPoem('Roses are red');
+
+    render(<ShareDialog isOpen={true} onClose={mockOnClose} testId="custom-share" />);
+
+    expect(screen.getByTestId('custom-share')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Share/ShareDialog.tsx
+++ b/web/src/components/Share/ShareDialog.tsx
@@ -1,0 +1,613 @@
+/**
+ * ShareDialog Component
+ *
+ * A modal dialog for generating and copying share links.
+ * Supports different share modes (poem-only, with-analysis, full).
+ *
+ * @module components/Share/ShareDialog
+ */
+
+import { useState, useEffect, useCallback, useRef, type ReactElement } from 'react';
+import { usePoemStore, selectHasPoem } from '@/stores/usePoemStore';
+import { useAnalysisStore, selectHasAnalysis } from '@/stores/useAnalysisStore';
+import { useMelodyStore, selectHasMelody } from '@/stores/useMelodyStore';
+import { useToastStore } from '@/stores/useToastStore';
+import { generateShareUrl, copyShareUrlToClipboard } from '@/lib/share';
+import type { ShareMode, ShareEncodeResult } from '@/lib/share';
+import './ShareDialog.css';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[ShareDialog] ${message}`, ...args);
+  }
+};
+
+/**
+ * Props for the ShareDialog component
+ */
+export interface ShareDialogProps {
+  /** Whether the dialog is open */
+  isOpen: boolean;
+  /** Callback when the dialog should be closed */
+  onClose: () => void;
+  /** Test ID for testing */
+  testId?: string;
+}
+
+/**
+ * Link icon for share button
+ */
+function LinkIcon(): ReactElement {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+/**
+ * Copy icon
+ */
+function CopyIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+/**
+ * Check icon (for copied state)
+ */
+function CheckIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+/**
+ * Close/X icon
+ */
+function CloseIcon(): ReactElement {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+/**
+ * Loading spinner
+ */
+function LoadingSpinner(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className="share-dialog__spinner"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" opacity="0.25" />
+      <path d="M12 2a10 10 0 0 1 10 10" />
+    </svg>
+  );
+}
+
+/**
+ * Share mode option configuration
+ */
+interface ShareModeOption {
+  mode: ShareMode;
+  label: string;
+  description: string;
+  requiresAnalysis?: boolean;
+  requiresMelody?: boolean;
+}
+
+const SHARE_MODES: ShareModeOption[] = [
+  {
+    mode: 'poem-only',
+    label: 'Poem Only',
+    description: 'Share just the poem text (smallest URL)',
+  },
+  {
+    mode: 'with-analysis',
+    label: 'With Analysis',
+    description: 'Include analysis results with the poem',
+    requiresAnalysis: true,
+  },
+  {
+    mode: 'full',
+    label: 'Full Project',
+    description: 'Include all versions, analysis, and melody',
+    requiresAnalysis: false, // Analysis is optional for full mode
+    requiresMelody: false,   // Melody is optional for full mode
+  },
+];
+
+/**
+ * ShareDialog provides a modal for generating and copying share links.
+ *
+ * Features:
+ * - Multiple share modes (poem-only, with-analysis, full)
+ * - URL generation with compression
+ * - Copy to clipboard functionality
+ * - URL length warnings
+ * - Keyboard accessible
+ * - Privacy note about URL visibility
+ *
+ * @example
+ * ```tsx
+ * <ShareDialog
+ *   isOpen={showShareDialog}
+ *   onClose={() => setShowShareDialog(false)}
+ * />
+ * ```
+ */
+export function ShareDialog({
+  isOpen,
+  onClose,
+  testId = 'share-dialog',
+}: ShareDialogProps): ReactElement | null {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousActiveElementRef = useRef<Element | null>(null);
+
+  // State
+  const [selectedMode, setSelectedMode] = useState<ShareMode>('poem-only');
+  const [shareResult, setShareResult] = useState<ShareEncodeResult | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Store state
+  const hasPoem = usePoemStore(selectHasPoem);
+  const hasAnalysis = useAnalysisStore(selectHasAnalysis);
+  const hasMelody = useMelodyStore(selectHasMelody);
+  const addToast = useToastStore((state) => state.addToast);
+
+  log('Rendering ShareDialog:', {
+    isOpen,
+    selectedMode,
+    hasPoem,
+    hasAnalysis,
+    hasMelody,
+  });
+
+  // Store the previously focused element when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      previousActiveElementRef.current = document.activeElement;
+      log('Stored previous active element:', previousActiveElementRef.current);
+    }
+  }, [isOpen]);
+
+  // Focus close button when dialog opens
+  useEffect(() => {
+    if (isOpen && closeButtonRef.current) {
+      const timeoutId = setTimeout(() => {
+        closeButtonRef.current?.focus();
+        log('Focused close button');
+      }, 10);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [isOpen]);
+
+  // Restore focus when dialog closes
+  useEffect(() => {
+    if (!isOpen && previousActiveElementRef.current) {
+      const elementToFocus = previousActiveElementRef.current as HTMLElement;
+      if (elementToFocus && typeof elementToFocus.focus === 'function') {
+        const timeoutId = setTimeout(() => {
+          elementToFocus.focus();
+          log('Restored focus to previous element');
+        }, 10);
+        return () => clearTimeout(timeoutId);
+      }
+    }
+  }, [isOpen]);
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      setShareResult(null);
+      setCopied(false);
+      // Auto-select best available mode
+      if (hasAnalysis && hasMelody) {
+        setSelectedMode('full');
+      } else if (hasAnalysis) {
+        setSelectedMode('with-analysis');
+      } else {
+        setSelectedMode('poem-only');
+      }
+    }
+  }, [isOpen, hasAnalysis, hasMelody]);
+
+  // Handle keyboard events
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent): void => {
+      if (!isOpen) return;
+
+      if (event.key === 'Escape') {
+        log('Escape pressed, closing dialog');
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      // Focus trap
+      if (event.key === 'Tab') {
+        const focusableElements = dialogRef.current?.querySelectorAll(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+
+        if (!focusableElements || focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0] as HTMLElement;
+        const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+          }
+        }
+      }
+    },
+    [isOpen, onClose]
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleKeyDown]);
+
+  // Prevent body scroll when dialog is open
+  useEffect(() => {
+    if (isOpen) {
+      const previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = previousOverflow;
+      };
+    }
+  }, [isOpen]);
+
+  // Generate share URL
+  const handleGenerateLink = useCallback(async () => {
+    log('Generating share link:', { mode: selectedMode });
+    setIsGenerating(true);
+    setCopied(false);
+
+    try {
+      const result = await generateShareUrl({ mode: selectedMode });
+      setShareResult(result);
+      log('Share link generated:', result);
+
+      if (result.success && result.url) {
+        addToast('Share link generated', { type: 'success', duration: 3000 });
+      } else if (!result.success) {
+        addToast(result.error || 'Failed to generate link', { type: 'error' });
+      }
+    } catch (error) {
+      log('Error generating share link:', error);
+      addToast('Failed to generate share link', { type: 'error' });
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [selectedMode, addToast]);
+
+  // Copy URL to clipboard
+  const handleCopyLink = useCallback(async () => {
+    if (!shareResult?.url) return;
+
+    log('Copying share link to clipboard');
+    const success = await copyShareUrlToClipboard(shareResult.url);
+
+    if (success) {
+      setCopied(true);
+      addToast('Link copied to clipboard', { type: 'success', duration: 2000 });
+      // Reset copied state after 3 seconds
+      setTimeout(() => setCopied(false), 3000);
+    } else {
+      addToast('Failed to copy link', { type: 'error' });
+    }
+  }, [shareResult?.url, addToast]);
+
+  // Handle overlay click
+  const handleOverlayClick = useCallback(
+    (event: React.MouseEvent): void => {
+      if (event.target === event.currentTarget) {
+        log('Overlay clicked, closing dialog');
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  // Check if mode is available
+  const isModeAvailable = (modeOption: ShareModeOption): boolean => {
+    if (modeOption.requiresAnalysis && !hasAnalysis) return false;
+    if (modeOption.requiresMelody && !hasMelody) return false;
+    return true;
+  };
+
+  // Don't render if not open
+  if (!isOpen) {
+    return null;
+  }
+
+  // Don't render if no poem
+  if (!hasPoem) {
+    return (
+      <div
+        className="share-dialog__overlay"
+        onClick={handleOverlayClick}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-dialog-title"
+        data-testid={testId}
+      >
+        <div
+          ref={dialogRef}
+          className="share-dialog"
+          data-testid={`${testId}-content`}
+        >
+          <div className="share-dialog__header">
+            <h2 id="share-dialog-title" className="share-dialog__title">
+              <LinkIcon />
+              Share Poem
+            </h2>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              className="share-dialog__close-button"
+              onClick={onClose}
+              aria-label="Close"
+              data-testid={`${testId}-close`}
+            >
+              <CloseIcon />
+            </button>
+          </div>
+          <div className="share-dialog__content">
+            <p className="share-dialog__empty-message">
+              Enter a poem first to generate a share link.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="share-dialog__overlay"
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="share-dialog-title"
+      data-testid={testId}
+    >
+      <div
+        ref={dialogRef}
+        className="share-dialog"
+        data-testid={`${testId}-content`}
+      >
+        {/* Header */}
+        <div className="share-dialog__header">
+          <h2 id="share-dialog-title" className="share-dialog__title">
+            <LinkIcon />
+            Share Poem
+          </h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="share-dialog__close-button"
+            onClick={onClose}
+            aria-label="Close"
+            data-testid={`${testId}-close`}
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="share-dialog__content">
+          {/* Mode Selection */}
+          <div className="share-dialog__section">
+            <label className="share-dialog__section-label">
+              Share Mode
+            </label>
+            <div className="share-dialog__mode-options">
+              {SHARE_MODES.map((modeOption) => {
+                const isAvailable = isModeAvailable(modeOption);
+                const isSelected = selectedMode === modeOption.mode;
+
+                return (
+                  <label
+                    key={modeOption.mode}
+                    className={`share-dialog__mode-option ${
+                      isSelected ? 'share-dialog__mode-option--selected' : ''
+                    } ${!isAvailable ? 'share-dialog__mode-option--disabled' : ''}`}
+                    data-testid={`${testId}-mode-${modeOption.mode}`}
+                  >
+                    <input
+                      type="radio"
+                      name="shareMode"
+                      value={modeOption.mode}
+                      checked={isSelected}
+                      disabled={!isAvailable}
+                      onChange={() => {
+                        setSelectedMode(modeOption.mode);
+                        setShareResult(null);
+                        setCopied(false);
+                      }}
+                      className="share-dialog__mode-radio"
+                    />
+                    <div className="share-dialog__mode-content">
+                      <span className="share-dialog__mode-label">
+                        {modeOption.label}
+                      </span>
+                      <span className="share-dialog__mode-description">
+                        {modeOption.description}
+                        {!isAvailable && modeOption.requiresAnalysis && (
+                          <span className="share-dialog__mode-unavailable">
+                            {' '}(requires analysis)
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Generate Button */}
+          <button
+            type="button"
+            className="share-dialog__generate-button"
+            onClick={handleGenerateLink}
+            disabled={isGenerating}
+            data-testid={`${testId}-generate`}
+          >
+            {isGenerating ? (
+              <>
+                <LoadingSpinner />
+                Generating...
+              </>
+            ) : (
+              <>
+                <LinkIcon />
+                Generate Link
+              </>
+            )}
+          </button>
+
+          {/* Share URL Result */}
+          {shareResult && shareResult.success && shareResult.url && (
+            <div className="share-dialog__result" data-testid={`${testId}-result`}>
+              <label className="share-dialog__section-label">
+                Share Link
+              </label>
+              <div className="share-dialog__url-container">
+                <input
+                  type="text"
+                  value={shareResult.url}
+                  readOnly
+                  className="share-dialog__url-input"
+                  onClick={(e) => (e.target as HTMLInputElement).select()}
+                  data-testid={`${testId}-url`}
+                />
+                <button
+                  type="button"
+                  className={`share-dialog__copy-button ${copied ? 'share-dialog__copy-button--copied' : ''}`}
+                  onClick={handleCopyLink}
+                  aria-label={copied ? 'Copied!' : 'Copy link'}
+                  data-testid={`${testId}-copy`}
+                >
+                  {copied ? <CheckIcon /> : <CopyIcon />}
+                  {copied ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+
+              {/* URL Stats */}
+              <div className="share-dialog__stats">
+                <span className="share-dialog__stat">
+                  URL Length: {shareResult.url.length} chars
+                </span>
+                {shareResult.compressed && (
+                  <span className="share-dialog__stat share-dialog__stat--info">
+                    Compressed
+                  </span>
+                )}
+              </div>
+
+              {/* Warning for long URLs */}
+              {shareResult.error && (
+                <p className="share-dialog__warning" data-testid={`${testId}-warning`}>
+                  {shareResult.error}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Error Result */}
+          {shareResult && !shareResult.success && (
+            <div className="share-dialog__error" data-testid={`${testId}-error`}>
+              <p>{shareResult.error}</p>
+            </div>
+          )}
+
+          {/* Privacy Note */}
+          <div className="share-dialog__privacy-note">
+            <p>
+              <strong>Privacy Note:</strong> The poem content will be encoded in the URL.
+              Anyone with the link can view the shared content. The URL will also be
+              visible in browser history.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ShareDialog;

--- a/web/src/components/Share/index.ts
+++ b/web/src/components/Share/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Share Components
+ *
+ * Components for sharing poem/project data via URL.
+ *
+ * @module components/Share
+ */
+
+export { ShareDialog } from './ShareDialog';
+export type { ShareDialogProps } from './ShareDialog';

--- a/web/src/lib/share/decode.test.ts
+++ b/web/src/lib/share/decode.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for share decoding utilities
+ *
+ * @module lib/share/decode.test
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  decodeFromBase64,
+  validateShareData,
+  decodeShareData,
+  importShareData,
+  decodeAndImportShareData,
+} from './decode';
+import { encodeToBase64, encodeShareData } from './encode';
+import { SHARE_SCHEMA_VERSION } from './types';
+import type { PoemOnlyShareData, WithAnalysisShareData, FullShareData } from './types';
+import { usePoemStore } from '../../stores/usePoemStore';
+import { useAnalysisStore } from '../../stores/useAnalysisStore';
+import { useMelodyStore } from '../../stores/useMelodyStore';
+import { createDefaultPoemAnalysis } from '../../types';
+
+// Create mock analysis using the factory function
+const mockAnalysis = createDefaultPoemAnalysis();
+
+describe('Share Decoding', () => {
+  beforeEach(() => {
+    // Reset stores before each test
+    usePoemStore.getState().reset();
+    useAnalysisStore.getState().reset();
+    useMelodyStore.getState().reset();
+  });
+
+  describe('decodeFromBase64', () => {
+    it('should decode a base64 encoded string', () => {
+      const original = 'Hello, World!';
+      const encoded = encodeToBase64(original);
+      const decoded = decodeFromBase64(encoded);
+
+      expect(decoded).toBe(original);
+    });
+
+    it('should decode unicode characters correctly', () => {
+      const original = 'Hello, 世界! 🌍';
+      const encoded = encodeToBase64(original);
+      const decoded = decodeFromBase64(encoded);
+
+      expect(decoded).toBe(original);
+    });
+
+    it('should handle URL-safe base64 characters', () => {
+      const original = 'Test+with/special=chars';
+      const encoded = encodeToBase64(original);
+      const decoded = decodeFromBase64(encoded);
+
+      expect(decoded).toBe(original);
+    });
+  });
+
+  describe('validateShareData', () => {
+    it('should validate poem-only share data', () => {
+      const data: PoemOnlyShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'poem-only',
+        poem: 'Roses are red',
+      };
+
+      const result = validateShareData(data);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject poem-only with empty poem', () => {
+      const data = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'poem-only',
+        poem: '',
+      };
+
+      const result = validateShareData(data);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('should validate with-analysis share data', () => {
+      const data: WithAnalysisShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'with-analysis',
+        poem: 'Roses are red',
+        analysis: mockAnalysis,
+      };
+
+      const result = validateShareData(data);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject with-analysis without analysis', () => {
+      const data = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'with-analysis',
+        poem: 'Roses are red',
+      };
+
+      const result = validateShareData(data);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('should validate full share data', () => {
+      const data: FullShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'full',
+        poem: {
+          original: 'Roses are red',
+          versions: [],
+          currentVersionIndex: -1,
+        },
+        analysis: null,
+        melody: null,
+      };
+
+      const result = validateShareData(data);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject invalid mode', () => {
+      const data = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'invalid-mode',
+        poem: 'Test',
+      };
+
+      const result = validateShareData(data);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Invalid share mode');
+    });
+
+    it('should reject missing version', () => {
+      const data = {
+        mode: 'poem-only',
+        poem: 'Test',
+      };
+
+      const result = validateShareData(data);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject null data', () => {
+      const result = validateShareData(null);
+
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('decodeShareData', () => {
+    it('should decode valid poem-only share data', async () => {
+      const data: PoemOnlyShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'poem-only',
+        poem: 'Roses are red,\nViolets are blue.',
+      };
+
+      const { encoded } = await encodeShareData(data, false);
+      const result = await decodeShareData(encoded);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data?.mode).toBe('poem-only');
+      expect((result.data as PoemOnlyShareData).poem).toBe(data.poem);
+    });
+
+    it('should decode valid with-analysis share data', async () => {
+      const data: WithAnalysisShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'with-analysis',
+        poem: 'Roses are red',
+        analysis: mockAnalysis,
+      };
+
+      const { encoded } = await encodeShareData(data, false);
+      const result = await decodeShareData(encoded);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.mode).toBe('with-analysis');
+    });
+
+    it('should decode valid full share data', async () => {
+      const data: FullShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'full',
+        poem: {
+          original: 'Roses are red',
+          versions: [],
+          currentVersionIndex: -1,
+        },
+        analysis: mockAnalysis,
+        melody: null,
+      };
+
+      const { encoded } = await encodeShareData(data, false);
+      const result = await decodeShareData(encoded);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.mode).toBe('full');
+    });
+
+    it('should fail on invalid base64', async () => {
+      const result = await decodeShareData('not-valid-base64!!!');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeTruthy();
+    });
+
+    it('should fail on invalid JSON', async () => {
+      const invalidJson = 'not valid json {{{';
+      const encoded = encodeToBase64(invalidJson);
+      const result = await decodeShareData(encoded);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('could not parse JSON');
+    });
+  });
+
+  describe('importShareData', () => {
+    it('should import poem-only share data', () => {
+      const data: PoemOnlyShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'poem-only',
+        poem: 'Roses are red,\nViolets are blue.',
+      };
+
+      const success = importShareData(data);
+
+      expect(success).toBe(true);
+      expect(usePoemStore.getState().original).toBe(data.poem);
+    });
+
+    it('should import with-analysis share data', () => {
+      const data: WithAnalysisShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'with-analysis',
+        poem: 'Roses are red',
+        analysis: mockAnalysis,
+      };
+
+      const success = importShareData(data);
+
+      expect(success).toBe(true);
+      expect(usePoemStore.getState().original).toBe(data.poem);
+      expect(useAnalysisStore.getState().analysis).toEqual(mockAnalysis);
+    });
+
+    it('should import full share data', () => {
+      const data: FullShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'full',
+        poem: {
+          original: 'Roses are red',
+          versions: [
+            {
+              id: 'v1',
+              lyrics: 'Roses are crimson',
+              timestamp: Date.now(),
+              changes: [],
+            },
+          ],
+          currentVersionIndex: 0,
+        },
+        analysis: mockAnalysis,
+        melody: null,
+      };
+
+      const success = importShareData(data);
+
+      expect(success).toBe(true);
+      expect(usePoemStore.getState().original).toBe(data.poem.original);
+      expect(usePoemStore.getState().versions.length).toBe(1);
+      expect(usePoemStore.getState().currentVersionIndex).toBe(0);
+      expect(useAnalysisStore.getState().analysis).toEqual(mockAnalysis);
+    });
+
+    it('should clear existing data by default', () => {
+      // Set up existing data
+      usePoemStore.getState().setPoem('Old poem');
+      useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+      const data: PoemOnlyShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'poem-only',
+        poem: 'New poem',
+      };
+
+      const success = importShareData(data);
+
+      expect(success).toBe(true);
+      expect(usePoemStore.getState().original).toBe('New poem');
+      expect(useAnalysisStore.getState().analysis).toBeNull();
+    });
+
+    it('should preserve existing data when clearExisting is false', () => {
+      // Set up existing data
+      usePoemStore.getState().setPoem('Old poem');
+      useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+      const data: PoemOnlyShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'poem-only',
+        poem: 'New poem',
+      };
+
+      const success = importShareData(data, { clearExisting: false });
+
+      expect(success).toBe(true);
+      // Poem is overwritten
+      expect(usePoemStore.getState().original).toBe('New poem');
+      // But analysis is preserved since clearExisting is false
+      // Note: poem-only mode doesn't import analysis, so existing analysis stays
+      expect(useAnalysisStore.getState().analysis).toEqual(mockAnalysis);
+    });
+  });
+
+  describe('decodeAndImportShareData', () => {
+    it('should decode and import valid share data', async () => {
+      const data: PoemOnlyShareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'poem-only',
+        poem: 'Roses are red,\nViolets are blue.',
+      };
+
+      const { encoded } = await encodeShareData(data, false);
+      const result = await decodeAndImportShareData(encoded);
+
+      expect(result.success).toBe(true);
+      expect(result.imported).toBe(true);
+      expect(result.mode).toBe('poem-only');
+      expect(usePoemStore.getState().original).toBe(data.poem);
+    });
+
+    it('should fail on invalid data without importing', async () => {
+      const result = await decodeAndImportShareData('invalid-data');
+
+      expect(result.success).toBe(false);
+      expect(result.imported).toBe(false);
+      expect(usePoemStore.getState().original).toBe('');
+    });
+  });
+});

--- a/web/src/lib/share/decode.ts
+++ b/web/src/lib/share/decode.ts
@@ -1,0 +1,398 @@
+/**
+ * Ghost Note - Share Decoding
+ *
+ * Functions for decoding shared project data from URLs.
+ * Handles both compressed and uncompressed formats.
+ *
+ * @module lib/share/decode
+ */
+
+import { usePoemStore } from '../../stores/usePoemStore';
+import { useAnalysisStore } from '../../stores/useAnalysisStore';
+import { useMelodyStore } from '../../stores/useMelodyStore';
+import type {
+  ShareData,
+  ShareDecodeResult,
+  PoemOnlyShareData,
+  WithAnalysisShareData,
+  FullShareData,
+} from './types';
+import {
+  isPoemOnlyShareData,
+  isWithAnalysisShareData,
+  isFullShareData,
+} from './types';
+
+// Logging helper for debugging
+const DEBUG = typeof import.meta !== 'undefined' && import.meta.env?.DEV;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[Share/Decode] ${message}`, ...args);
+  }
+};
+
+// =============================================================================
+// Decompression Utilities
+// =============================================================================
+
+/**
+ * Decompresses a base64-encoded compressed string.
+ *
+ * @param input - Base64-encoded compressed data
+ * @returns Decompressed string
+ */
+export async function decompressString(input: string): Promise<string> {
+  // Check if DecompressionStream is available
+  if (typeof DecompressionStream === 'undefined') {
+    log('DecompressionStream not available');
+    throw new Error('Decompression not supported in this browser');
+  }
+
+  try {
+    // Restore base64 padding and URL-safe characters
+    let base64 = input.replace(/-/g, '+').replace(/_/g, '/');
+    while (base64.length % 4) {
+      base64 += '=';
+    }
+
+    // Decode base64 to bytes
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+
+    // Decompress
+    const stream = new Blob([bytes]).stream();
+    const decompressedStream = stream.pipeThrough(new DecompressionStream('deflate'));
+
+    // Read decompressed data
+    const reader = decompressedStream.getReader();
+    const chunks: Uint8Array[] = [];
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+
+    // Combine chunks
+    const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const decompressed = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      decompressed.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    // Decode to string
+    const decoder = new TextDecoder();
+    const result = decoder.decode(decompressed);
+
+    log('Decompressed data:', {
+      compressedSize: bytes.length,
+      decompressedSize: decompressed.length,
+    });
+
+    return result;
+  } catch (error) {
+    log('Decompression failed:', error);
+    throw new Error('Failed to decompress share data');
+  }
+}
+
+/**
+ * Decodes a URL-safe base64 string (without compression).
+ *
+ * @param input - URL-safe base64 string
+ * @returns Decoded string
+ */
+export function decodeFromBase64(input: string): string {
+  // Restore URL-safe characters and padding
+  let base64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  while (base64.length % 4) {
+    base64 += '=';
+  }
+
+  // Decode
+  return decodeURIComponent(escape(atob(base64)));
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+/**
+ * Validates poem-only share data.
+ */
+function validatePoemOnlyData(data: unknown): data is PoemOnlyShareData {
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return (
+    d.mode === 'poem-only' &&
+    typeof d.poem === 'string' &&
+    d.poem.length > 0
+  );
+}
+
+/**
+ * Validates with-analysis share data.
+ */
+function validateWithAnalysisData(data: unknown): data is WithAnalysisShareData {
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return (
+    d.mode === 'with-analysis' &&
+    typeof d.poem === 'string' &&
+    d.poem.length > 0 &&
+    typeof d.analysis === 'object' &&
+    d.analysis !== null
+  );
+}
+
+/**
+ * Validates full share data.
+ */
+function validateFullData(data: unknown): data is FullShareData {
+  if (typeof data !== 'object' || data === null) return false;
+  const d = data as Record<string, unknown>;
+
+  if (d.mode !== 'full') return false;
+
+  // Validate poem structure
+  if (typeof d.poem !== 'object' || d.poem === null) return false;
+  const poem = d.poem as Record<string, unknown>;
+  if (
+    typeof poem.original !== 'string' ||
+    !Array.isArray(poem.versions) ||
+    typeof poem.currentVersionIndex !== 'number'
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Validates share data structure.
+ *
+ * @param data - Parsed JSON data
+ * @returns Validation result
+ */
+export function validateShareData(data: unknown): { valid: boolean; error?: string } {
+  if (typeof data !== 'object' || data === null) {
+    return { valid: false, error: 'Invalid share data format' };
+  }
+
+  const d = data as Record<string, unknown>;
+
+  // Check version
+  if (typeof d.version !== 'string') {
+    return { valid: false, error: 'Missing or invalid version' };
+  }
+
+  // Check mode
+  if (!['poem-only', 'with-analysis', 'full'].includes(d.mode as string)) {
+    return { valid: false, error: 'Invalid share mode' };
+  }
+
+  // Validate based on mode
+  switch (d.mode) {
+    case 'poem-only':
+      if (!validatePoemOnlyData(data)) {
+        return { valid: false, error: 'Invalid poem-only share data' };
+      }
+      break;
+    case 'with-analysis':
+      if (!validateWithAnalysisData(data)) {
+        return { valid: false, error: 'Invalid with-analysis share data' };
+      }
+      break;
+    case 'full':
+      if (!validateFullData(data)) {
+        return { valid: false, error: 'Invalid full share data' };
+      }
+      break;
+  }
+
+  return { valid: true };
+}
+
+// =============================================================================
+// Decoding Functions
+// =============================================================================
+
+/**
+ * Decodes share data from an encoded string.
+ *
+ * @param encoded - Encoded share data string
+ * @returns Decoded share data or error
+ */
+export async function decodeShareData(encoded: string): Promise<ShareDecodeResult> {
+  log('Decoding share data:', { length: encoded.length });
+
+  try {
+    let jsonString: string;
+
+    // Check if data is compressed (prefixed with 'c:')
+    if (encoded.startsWith('c:')) {
+      log('Detected compressed data');
+      const compressedData = encoded.slice(2);
+      jsonString = await decompressString(compressedData);
+    } else {
+      log('Detected uncompressed data');
+      jsonString = decodeFromBase64(encoded);
+    }
+
+    // Parse JSON
+    let data: unknown;
+    try {
+      data = JSON.parse(jsonString);
+    } catch (parseError) {
+      log('JSON parse error:', parseError);
+      return {
+        success: false,
+        error: 'Invalid share data: could not parse JSON',
+      };
+    }
+
+    // Validate structure
+    const validation = validateShareData(data);
+    if (!validation.valid) {
+      return {
+        success: false,
+        error: validation.error || 'Invalid share data structure',
+      };
+    }
+
+    const shareData = data as ShareData;
+
+    log('Successfully decoded share data:', {
+      mode: shareData.mode,
+      version: shareData.version,
+    });
+
+    return {
+      success: true,
+      data: shareData,
+      mode: shareData.mode,
+      version: shareData.version,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown decoding error';
+    log('Error decoding share data:', error);
+    return {
+      success: false,
+      error: message,
+    };
+  }
+}
+
+// =============================================================================
+// Import Functions
+// =============================================================================
+
+/**
+ * Options for importing share data into the application state.
+ */
+export interface ImportShareOptions {
+  /** Whether to clear existing data before importing (default: true) */
+  clearExisting?: boolean;
+  /** Whether to trigger analysis for poem-only imports (default: false) */
+  autoAnalyze?: boolean;
+}
+
+/**
+ * Imports decoded share data into the application state.
+ *
+ * @param data - Decoded share data
+ * @param options - Import options
+ * @returns Whether import was successful
+ */
+export function importShareData(
+  data: ShareData,
+  options: ImportShareOptions = {}
+): boolean {
+  const { clearExisting = true } = options;
+
+  log('Importing share data:', {
+    mode: data.mode,
+    version: data.version,
+    clearExisting,
+  });
+
+  try {
+    // Clear existing data if requested
+    if (clearExisting) {
+      log('Clearing existing data...');
+      usePoemStore.getState().reset();
+      useAnalysisStore.getState().reset();
+      useMelodyStore.getState().reset();
+    }
+
+    // Import based on mode
+    if (isPoemOnlyShareData(data)) {
+      log('Importing poem-only data');
+      usePoemStore.getState().setPoem(data.poem);
+    } else if (isWithAnalysisShareData(data)) {
+      log('Importing with-analysis data');
+      usePoemStore.getState().setPoem(data.poem);
+      useAnalysisStore.getState().setAnalysis(data.analysis);
+    } else if (isFullShareData(data)) {
+      log('Importing full data');
+
+      // Import poem data
+      usePoemStore.getState().setPoem(data.poem.original);
+      usePoemStore.setState({
+        versions: data.poem.versions,
+        currentVersionIndex: data.poem.currentVersionIndex,
+      });
+
+      // Import analysis if present
+      if (data.analysis) {
+        useAnalysisStore.getState().setAnalysis(data.analysis);
+      }
+
+      // Import melody if present
+      if (data.melody && data.melody.data && data.melody.abcNotation) {
+        useMelodyStore.getState().setMelody(data.melody.data, data.melody.abcNotation);
+      } else if (data.melody?.abcNotation) {
+        useMelodyStore.getState().setAbcNotation(data.melody.abcNotation);
+      }
+    }
+
+    log('Share data imported successfully');
+    return true;
+  } catch (error) {
+    log('Error importing share data:', error);
+    return false;
+  }
+}
+
+/**
+ * Decodes and imports share data from an encoded string.
+ *
+ * @param encoded - Encoded share data string
+ * @param options - Import options
+ * @returns Result of the decode and import operation
+ */
+export async function decodeAndImportShareData(
+  encoded: string,
+  options: ImportShareOptions = {}
+): Promise<ShareDecodeResult & { imported: boolean }> {
+  const decodeResult = await decodeShareData(encoded);
+
+  if (!decodeResult.success || !decodeResult.data) {
+    return {
+      ...decodeResult,
+      imported: false,
+    };
+  }
+
+  const imported = importShareData(decodeResult.data, options);
+
+  return {
+    ...decodeResult,
+    imported,
+  };
+}

--- a/web/src/lib/share/encode.test.ts
+++ b/web/src/lib/share/encode.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for share encoding utilities
+ *
+ * @module lib/share/encode.test
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  encodeToBase64,
+  buildPoemOnlyShareData,
+  buildWithAnalysisShareData,
+  buildFullShareData,
+  buildShareData,
+  encodeShareData,
+  generateShareUrl,
+  copyShareUrlToClipboard,
+} from './encode';
+import { SHARE_SCHEMA_VERSION } from './types';
+import { usePoemStore } from '../../stores/usePoemStore';
+import { useAnalysisStore } from '../../stores/useAnalysisStore';
+import { useMelodyStore } from '../../stores/useMelodyStore';
+import { createDefaultPoemAnalysis } from '../../types';
+
+// Mock clipboard API
+const mockWriteText = vi.fn();
+Object.assign(navigator, {
+  clipboard: {
+    writeText: mockWriteText,
+  },
+});
+
+// Create mock analysis using the factory function
+const mockAnalysis = createDefaultPoemAnalysis();
+
+describe('Share Encoding', () => {
+  beforeEach(() => {
+    // Reset stores before each test
+    usePoemStore.getState().reset();
+    useAnalysisStore.getState().reset();
+    useMelodyStore.getState().reset();
+    mockWriteText.mockReset();
+  });
+
+  describe('encodeToBase64', () => {
+    it('should encode a simple string to URL-safe base64', () => {
+      const input = 'Hello, World!';
+      const encoded = encodeToBase64(input);
+
+      expect(encoded).toBeTruthy();
+      expect(encoded).not.toContain('+');
+      expect(encoded).not.toContain('/');
+      expect(encoded).not.toContain('=');
+    });
+
+    it('should encode unicode characters correctly', () => {
+      const input = 'Hello, 世界! 🌍';
+      const encoded = encodeToBase64(input);
+
+      expect(encoded).toBeTruthy();
+      expect(encoded.length).toBeGreaterThan(0);
+    });
+
+    it('should encode JSON strings', () => {
+      const data = { poem: 'Roses are red', mode: 'poem-only' };
+      const input = JSON.stringify(data);
+      const encoded = encodeToBase64(input);
+
+      expect(encoded).toBeTruthy();
+    });
+  });
+
+  describe('buildPoemOnlyShareData', () => {
+    it('should build share data with just the poem', () => {
+      const poem = 'Roses are red,\nViolets are blue.';
+      usePoemStore.getState().setPoem(poem);
+
+      const shareData = buildPoemOnlyShareData();
+
+      expect(shareData.version).toBe(SHARE_SCHEMA_VERSION);
+      expect(shareData.mode).toBe('poem-only');
+      expect(shareData.poem).toBe(poem);
+    });
+
+    it('should return empty poem when no poem is set', () => {
+      const shareData = buildPoemOnlyShareData();
+
+      expect(shareData.poem).toBe('');
+    });
+  });
+
+  describe('buildWithAnalysisShareData', () => {
+    it('should return null when no analysis is available', () => {
+      usePoemStore.getState().setPoem('Test poem');
+
+      const shareData = buildWithAnalysisShareData();
+
+      expect(shareData).toBeNull();
+    });
+
+    it('should build share data with poem and analysis', () => {
+      const poem = 'Roses are red,\nViolets are blue.';
+      usePoemStore.getState().setPoem(poem);
+      useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+      const shareData = buildWithAnalysisShareData();
+
+      expect(shareData).not.toBeNull();
+      expect(shareData?.version).toBe(SHARE_SCHEMA_VERSION);
+      expect(shareData?.mode).toBe('with-analysis');
+      expect(shareData?.poem).toBe(poem);
+      expect(shareData?.analysis).toEqual(mockAnalysis);
+    });
+  });
+
+  describe('buildFullShareData', () => {
+    it('should build full share data with all content', () => {
+      const poem = 'Roses are red,\nViolets are blue.';
+      usePoemStore.getState().setPoem(poem);
+      useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+      const shareData = buildFullShareData();
+
+      expect(shareData.version).toBe(SHARE_SCHEMA_VERSION);
+      expect(shareData.mode).toBe('full');
+      expect(shareData.poem.original).toBe(poem);
+      expect(shareData.analysis).toEqual(mockAnalysis);
+    });
+
+    it('should include lyric versions', () => {
+      const poem = 'Roses are red,\nViolets are blue.';
+      usePoemStore.getState().setPoem(poem);
+      usePoemStore.getState().addVersion('Roses are crimson,\nViolets are azure.', 'Style change');
+
+      const shareData = buildFullShareData();
+
+      expect(shareData.poem.versions.length).toBe(1);
+      expect(shareData.poem.versions[0].lyrics).toBe('Roses are crimson,\nViolets are azure.');
+    });
+  });
+
+  describe('buildShareData', () => {
+    it('should build poem-only data', () => {
+      usePoemStore.getState().setPoem('Test poem');
+
+      const shareData = buildShareData('poem-only');
+
+      expect(shareData?.mode).toBe('poem-only');
+    });
+
+    it('should build with-analysis data when analysis exists', () => {
+      usePoemStore.getState().setPoem('Test poem');
+      useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+      const shareData = buildShareData('with-analysis');
+
+      expect(shareData?.mode).toBe('with-analysis');
+    });
+
+    it('should return null for with-analysis when no analysis', () => {
+      usePoemStore.getState().setPoem('Test poem');
+
+      const shareData = buildShareData('with-analysis');
+
+      expect(shareData).toBeNull();
+    });
+
+    it('should build full data', () => {
+      usePoemStore.getState().setPoem('Test poem');
+
+      const shareData = buildShareData('full');
+
+      expect(shareData?.mode).toBe('full');
+    });
+  });
+
+  describe('encodeShareData', () => {
+    it('should encode share data without compression for small data', async () => {
+      const shareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'poem-only' as const,
+        poem: 'Short poem',
+      };
+
+      const result = await encodeShareData(shareData, false);
+
+      expect(result.encoded).toBeTruthy();
+      expect(result.compressed).toBe(false);
+      expect(result.size).toBeGreaterThan(0);
+    });
+
+    it('should encode without c: prefix for uncompressed data', async () => {
+      const shareData = {
+        version: SHARE_SCHEMA_VERSION,
+        mode: 'poem-only' as const,
+        poem: 'Short poem',
+      };
+
+      const result = await encodeShareData(shareData, false);
+
+      expect(result.encoded.startsWith('c:')).toBe(false);
+    });
+  });
+
+  describe('generateShareUrl', () => {
+    it('should fail when no poem exists', async () => {
+      const result = await generateShareUrl({ mode: 'poem-only' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('No poem to share');
+    });
+
+    it('should generate a share URL for poem-only mode', async () => {
+      usePoemStore.getState().setPoem('Roses are red,\nViolets are blue.');
+
+      const result = await generateShareUrl({ mode: 'poem-only' });
+
+      expect(result.success).toBe(true);
+      expect(result.url).toBeTruthy();
+      expect(result.url).toContain('#share=');
+      expect(result.mode).toBe('poem-only');
+    });
+
+    it('should generate a share URL with query params when useFragment is false', async () => {
+      usePoemStore.getState().setPoem('Roses are red');
+
+      const result = await generateShareUrl({ mode: 'poem-only', useFragment: false });
+
+      expect(result.success).toBe(true);
+      expect(result.url).toContain('?share=');
+    });
+
+    it('should fail for with-analysis mode when no analysis exists', async () => {
+      usePoemStore.getState().setPoem('Test poem');
+
+      const result = await generateShareUrl({ mode: 'with-analysis' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Analysis is required');
+    });
+
+    it('should generate a share URL for with-analysis mode', async () => {
+      usePoemStore.getState().setPoem('Roses are red');
+      useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+      const result = await generateShareUrl({ mode: 'with-analysis' });
+
+      expect(result.success).toBe(true);
+      expect(result.url).toBeTruthy();
+      expect(result.mode).toBe('with-analysis');
+    });
+
+    it('should generate a share URL for full mode', async () => {
+      usePoemStore.getState().setPoem('Roses are red');
+      useAnalysisStore.getState().setAnalysis(mockAnalysis);
+
+      const result = await generateShareUrl({ mode: 'full' });
+
+      expect(result.success).toBe(true);
+      expect(result.url).toBeTruthy();
+      expect(result.mode).toBe('full');
+    });
+  });
+
+  describe('copyShareUrlToClipboard', () => {
+    it('should copy URL to clipboard', async () => {
+      mockWriteText.mockResolvedValueOnce(undefined);
+      const url = 'https://example.com/#share=abc123';
+
+      const result = await copyShareUrlToClipboard(url);
+
+      expect(result).toBe(true);
+      expect(mockWriteText).toHaveBeenCalledWith(url);
+    });
+
+    it('should return false when clipboard write fails', async () => {
+      mockWriteText.mockRejectedValueOnce(new Error('Permission denied'));
+      const url = 'https://example.com/#share=abc123';
+
+      // Mock execCommand fallback to fail
+      const originalExecCommand = document.execCommand;
+      document.execCommand = vi.fn().mockReturnValue(false);
+
+      const result = await copyShareUrlToClipboard(url);
+
+      expect(result).toBe(false);
+
+      document.execCommand = originalExecCommand;
+    });
+  });
+});

--- a/web/src/lib/share/encode.ts
+++ b/web/src/lib/share/encode.ts
@@ -1,0 +1,360 @@
+/**
+ * Ghost Note - Share Encoding
+ *
+ * Functions for encoding project data for URL sharing.
+ * Uses compression and base64 encoding for reasonable URL lengths.
+ *
+ * @module lib/share/encode
+ */
+
+import { usePoemStore } from '../../stores/usePoemStore';
+import { useAnalysisStore } from '../../stores/useAnalysisStore';
+import { useMelodyStore } from '../../stores/useMelodyStore';
+import type {
+  ShareData,
+  ShareMode,
+  ShareOptions,
+  ShareEncodeResult,
+  PoemOnlyShareData,
+  WithAnalysisShareData,
+  FullShareData,
+} from './types';
+import { SHARE_SCHEMA_VERSION } from './types';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Maximum recommended URL length (most browsers support ~2000 chars) */
+const MAX_URL_LENGTH = 2000;
+
+/** Threshold for applying compression (bytes) */
+const COMPRESSION_THRESHOLD = 500;
+
+// Logging helper for debugging
+const DEBUG = typeof import.meta !== 'undefined' && import.meta.env?.DEV;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[Share/Encode] ${message}`, ...args);
+  }
+};
+
+// =============================================================================
+// Compression Utilities
+// =============================================================================
+
+/**
+ * Compresses a string using the browser's CompressionStream API.
+ * Falls back to uncompressed if API is not available.
+ *
+ * @param input - String to compress
+ * @returns Base64-encoded compressed data
+ */
+export async function compressString(input: string): Promise<string> {
+  // Check if CompressionStream is available
+  if (typeof CompressionStream === 'undefined') {
+    log('CompressionStream not available, using base64 only');
+    return btoa(unescape(encodeURIComponent(input)));
+  }
+
+  try {
+    // Convert string to Uint8Array
+    const encoder = new TextEncoder();
+    const inputBytes = encoder.encode(input);
+
+    // Create compression stream
+    const stream = new Blob([inputBytes]).stream();
+    const compressedStream = stream.pipeThrough(new CompressionStream('deflate'));
+
+    // Read compressed data
+    const reader = compressedStream.getReader();
+    const chunks: Uint8Array[] = [];
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+
+    // Combine chunks
+    const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const compressed = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      compressed.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    // Convert to base64
+    const base64 = btoa(String.fromCharCode(...compressed));
+    log('Compressed data:', {
+      originalSize: inputBytes.length,
+      compressedSize: compressed.length,
+      ratio: (compressed.length / inputBytes.length * 100).toFixed(1) + '%',
+    });
+
+    return base64;
+  } catch (error) {
+    log('Compression failed, using base64 only:', error);
+    return btoa(unescape(encodeURIComponent(input)));
+  }
+}
+
+/**
+ * Encodes a string to URL-safe base64 (without compression).
+ *
+ * @param input - String to encode
+ * @returns URL-safe base64 string
+ */
+export function encodeToBase64(input: string): string {
+  // Use URL-safe base64 encoding
+  const base64 = btoa(unescape(encodeURIComponent(input)));
+  // Replace non-URL-safe characters
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+// =============================================================================
+// Share Data Builders
+// =============================================================================
+
+/**
+ * Builds poem-only share data from the current state.
+ */
+export function buildPoemOnlyShareData(): PoemOnlyShareData {
+  const poemState = usePoemStore.getState();
+  return {
+    version: SHARE_SCHEMA_VERSION,
+    mode: 'poem-only',
+    poem: poemState.original,
+  };
+}
+
+/**
+ * Builds share data with analysis from the current state.
+ */
+export function buildWithAnalysisShareData(): WithAnalysisShareData | null {
+  const poemState = usePoemStore.getState();
+  const analysisState = useAnalysisStore.getState();
+
+  if (!analysisState.analysis) {
+    log('No analysis available for sharing');
+    return null;
+  }
+
+  return {
+    version: SHARE_SCHEMA_VERSION,
+    mode: 'with-analysis',
+    poem: poemState.original,
+    analysis: analysisState.analysis,
+  };
+}
+
+/**
+ * Builds full share data from the current state.
+ */
+export function buildFullShareData(): FullShareData {
+  const poemState = usePoemStore.getState();
+  const analysisState = useAnalysisStore.getState();
+  const melodyState = useMelodyStore.getState();
+
+  return {
+    version: SHARE_SCHEMA_VERSION,
+    mode: 'full',
+    poem: {
+      original: poemState.original,
+      versions: poemState.versions,
+      currentVersionIndex: poemState.currentVersionIndex,
+    },
+    analysis: analysisState.analysis,
+    melody: melodyState.melody || melodyState.abcNotation
+      ? {
+          data: melodyState.melody,
+          abcNotation: melodyState.abcNotation,
+        }
+      : null,
+  };
+}
+
+/**
+ * Builds share data based on the specified mode.
+ *
+ * @param mode - Share mode to use
+ * @returns Share data or null if required data is missing
+ */
+export function buildShareData(mode: ShareMode): ShareData | null {
+  switch (mode) {
+    case 'poem-only':
+      return buildPoemOnlyShareData();
+    case 'with-analysis':
+      return buildWithAnalysisShareData();
+    case 'full':
+      return buildFullShareData();
+  }
+}
+
+// =============================================================================
+// Encoding Functions
+// =============================================================================
+
+/**
+ * Encodes share data to a URL-safe string.
+ *
+ * @param data - Share data to encode
+ * @param compress - Whether to use compression
+ * @returns Encoded string (possibly compressed and base64-encoded)
+ */
+export async function encodeShareData(
+  data: ShareData,
+  compress: boolean = true
+): Promise<{ encoded: string; compressed: boolean; size: number }> {
+  const jsonString = JSON.stringify(data);
+  const size = new Blob([jsonString]).size;
+
+  log('Encoding share data:', {
+    mode: data.mode,
+    jsonSize: size,
+    shouldCompress: compress && size > COMPRESSION_THRESHOLD,
+  });
+
+  // Use compression for larger data
+  if (compress && size > COMPRESSION_THRESHOLD) {
+    const compressed = await compressString(jsonString);
+    // Prefix with 'c:' to indicate compressed data
+    return {
+      encoded: 'c:' + compressed.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, ''),
+      compressed: true,
+      size,
+    };
+  }
+
+  // Use simple base64 for smaller data
+  const encoded = encodeToBase64(jsonString);
+  return {
+    encoded,
+    compressed: false,
+    size,
+  };
+}
+
+/**
+ * Generates a share URL for the current project state.
+ *
+ * @param options - Share options
+ * @returns Share result with URL or error
+ */
+export async function generateShareUrl(
+  options: ShareOptions = {}
+): Promise<ShareEncodeResult> {
+  const { mode = 'poem-only', compress = true, useFragment = true } = options;
+
+  log('Generating share URL:', { mode, compress, useFragment });
+
+  // Check if there's a poem to share
+  const poemState = usePoemStore.getState();
+  if (!poemState.original.trim()) {
+    return {
+      success: false,
+      error: 'No poem to share',
+      mode,
+      dataSize: 0,
+      compressed: false,
+    };
+  }
+
+  // Build share data
+  const shareData = buildShareData(mode);
+  if (!shareData) {
+    return {
+      success: false,
+      error: mode === 'with-analysis'
+        ? 'Analysis is required for this share mode. Please analyze the poem first.'
+        : 'Failed to build share data',
+      mode,
+      dataSize: 0,
+      compressed: false,
+    };
+  }
+
+  try {
+    // Encode the data
+    const { encoded, compressed, size } = await encodeShareData(shareData, compress);
+
+    // Build the URL
+    const baseUrl = window.location.origin + window.location.pathname;
+    const url = useFragment
+      ? `${baseUrl}#share=${encoded}`
+      : `${baseUrl}?share=${encoded}`;
+
+    log('Generated share URL:', {
+      urlLength: url.length,
+      dataSize: size,
+      compressed,
+    });
+
+    // Warn if URL is too long
+    if (url.length > MAX_URL_LENGTH) {
+      log('Warning: URL exceeds recommended length');
+      return {
+        success: true,
+        url,
+        mode,
+        dataSize: size,
+        compressed,
+        error: `URL length (${url.length} chars) exceeds recommended limit (${MAX_URL_LENGTH}). Consider using a shorter share mode.`,
+      };
+    }
+
+    return {
+      success: true,
+      url,
+      mode,
+      dataSize: size,
+      compressed,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown encoding error';
+    log('Error generating share URL:', error);
+    return {
+      success: false,
+      error: message,
+      mode,
+      dataSize: 0,
+      compressed: false,
+    };
+  }
+}
+
+/**
+ * Copies the share URL to the clipboard.
+ *
+ * @param url - URL to copy
+ * @returns Whether copying was successful
+ */
+export async function copyShareUrlToClipboard(url: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(url);
+    log('Copied share URL to clipboard');
+    return true;
+  } catch (error) {
+    log('Failed to copy to clipboard:', error);
+
+    // Fallback for older browsers
+    try {
+      const textArea = document.createElement('textarea');
+      textArea.value = url;
+      textArea.style.position = 'fixed';
+      textArea.style.left = '-999999px';
+      textArea.style.top = '-999999px';
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      const success = document.execCommand('copy');
+      document.body.removeChild(textArea);
+      log('Fallback clipboard copy:', success ? 'success' : 'failed');
+      return success;
+    } catch (fallbackError) {
+      log('Fallback clipboard copy failed:', fallbackError);
+      return false;
+    }
+  }
+}

--- a/web/src/lib/share/index.ts
+++ b/web/src/lib/share/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Ghost Note - URL Sharing
+ *
+ * Functions for sharing poem/project data via URL.
+ * Supports both full project sharing and poem-only sharing.
+ *
+ * @module lib/share
+ */
+
+export * from './encode';
+export * from './decode';
+export * from './url';
+export * from './types';

--- a/web/src/lib/share/types.ts
+++ b/web/src/lib/share/types.ts
@@ -1,0 +1,150 @@
+/**
+ * Ghost Note - Share Types
+ *
+ * Type definitions for URL sharing functionality.
+ *
+ * @module lib/share/types
+ */
+
+import type { LyricVersion } from '../../stores/types';
+import type { PoemAnalysis } from '../../types';
+import type { Melody } from '../melody/types';
+
+// =============================================================================
+// Share Mode Types
+// =============================================================================
+
+/**
+ * Share mode determines what data is included in the shared link.
+ * - 'poem-only': Only includes the original poem text (smallest URL)
+ * - 'with-analysis': Includes poem and analysis results
+ * - 'full': Includes poem, analysis, melody, and versions (largest URL)
+ */
+export type ShareMode = 'poem-only' | 'with-analysis' | 'full';
+
+/**
+ * Schema version for share data format.
+ * Increment when making breaking changes to share data structure.
+ */
+export const SHARE_SCHEMA_VERSION = '1.0.0';
+
+// =============================================================================
+// Share Data Types
+// =============================================================================
+
+/**
+ * Minimal share data - just the poem text.
+ */
+export interface PoemOnlyShareData {
+  version: string;
+  mode: 'poem-only';
+  poem: string;
+}
+
+/**
+ * Share data with analysis included.
+ */
+export interface WithAnalysisShareData {
+  version: string;
+  mode: 'with-analysis';
+  poem: string;
+  analysis: PoemAnalysis;
+}
+
+/**
+ * Full share data with all project details.
+ */
+export interface FullShareData {
+  version: string;
+  mode: 'full';
+  poem: {
+    original: string;
+    versions: LyricVersion[];
+    currentVersionIndex: number;
+  };
+  analysis: PoemAnalysis | null;
+  melody: {
+    data: Melody | null;
+    abcNotation: string | null;
+  } | null;
+}
+
+/**
+ * Union type for all share data formats.
+ */
+export type ShareData = PoemOnlyShareData | WithAnalysisShareData | FullShareData;
+
+// =============================================================================
+// Share Result Types
+// =============================================================================
+
+/**
+ * Result of encoding share data to URL.
+ */
+export interface ShareEncodeResult {
+  /** Whether encoding was successful */
+  success: boolean;
+  /** The generated share URL (if successful) */
+  url?: string;
+  /** Error message (if failed) */
+  error?: string;
+  /** The share mode used */
+  mode: ShareMode;
+  /** Approximate size of the encoded data in bytes */
+  dataSize: number;
+  /** Whether compression was applied */
+  compressed: boolean;
+}
+
+/**
+ * Result of decoding share data from URL.
+ */
+export interface ShareDecodeResult {
+  /** Whether decoding was successful */
+  success: boolean;
+  /** The decoded share data (if successful) */
+  data?: ShareData;
+  /** Error message (if failed) */
+  error?: string;
+  /** The detected share mode */
+  mode?: ShareMode;
+  /** Schema version of the share data */
+  version?: string;
+}
+
+/**
+ * Options for generating a share URL.
+ */
+export interface ShareOptions {
+  /** Share mode (what data to include) */
+  mode?: ShareMode;
+  /** Whether to use compression (default: true for larger data) */
+  compress?: boolean;
+  /** Whether to use the short URL fragment format (default: true) */
+  useFragment?: boolean;
+}
+
+// =============================================================================
+// Type Guards
+// =============================================================================
+
+/**
+ * Check if share data is poem-only mode.
+ */
+export function isPoemOnlyShareData(data: ShareData): data is PoemOnlyShareData {
+  return data.mode === 'poem-only';
+}
+
+/**
+ * Check if share data is with-analysis mode.
+ */
+export function isWithAnalysisShareData(data: ShareData): data is WithAnalysisShareData {
+  return data.mode === 'with-analysis';
+}
+
+/**
+ * Check if share data is full mode.
+ */
+export function isFullShareData(data: ShareData): data is FullShareData {
+  return data.mode === 'full';
+}

--- a/web/src/lib/share/url.test.ts
+++ b/web/src/lib/share/url.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for share URL utilities
+ *
+ * @module lib/share/url.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  extractShareDataFromUrl,
+  hasShareDataInUrl,
+  clearShareDataFromUrl,
+  checkShareUrl,
+  SHARE_PARAM_NAME,
+} from './url';
+
+describe('Share URL Utilities', () => {
+  // Save original location
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Reset location before each test
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'https://example.com/',
+        origin: 'https://example.com',
+        pathname: '/',
+        hash: '',
+        search: '',
+      },
+      writable: true,
+    });
+
+    // Mock history.replaceState
+    vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Restore original location
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+    vi.restoreAllMocks();
+  });
+
+  describe('extractShareDataFromUrl', () => {
+    it('should extract share data from hash fragment', () => {
+      window.location.hash = '#share=abc123';
+
+      const data = extractShareDataFromUrl();
+
+      expect(data).toBe('abc123');
+    });
+
+    it('should extract share data from query parameters', () => {
+      window.location.search = '?share=xyz789';
+
+      const data = extractShareDataFromUrl();
+
+      expect(data).toBe('xyz789');
+    });
+
+    it('should prefer hash fragment over query parameters', () => {
+      window.location.hash = '#share=fromHash';
+      window.location.search = '?share=fromQuery';
+
+      const data = extractShareDataFromUrl();
+
+      expect(data).toBe('fromHash');
+    });
+
+    it('should return null when no share data is present', () => {
+      window.location.hash = '';
+      window.location.search = '';
+
+      const data = extractShareDataFromUrl();
+
+      expect(data).toBeNull();
+    });
+
+    it('should handle hash with other parameters', () => {
+      window.location.hash = '#other=value&share=abc123&another=thing';
+
+      const data = extractShareDataFromUrl();
+
+      expect(data).toBe('abc123');
+    });
+
+    it('should handle URL-encoded share data', () => {
+      window.location.hash = '#share=abc%2B123%3D%3D';
+
+      const data = extractShareDataFromUrl();
+
+      expect(data).toBe('abc+123==');
+    });
+  });
+
+  describe('hasShareDataInUrl', () => {
+    it('should return true when share data exists in hash', () => {
+      window.location.hash = '#share=abc123';
+
+      expect(hasShareDataInUrl()).toBe(true);
+    });
+
+    it('should return true when share data exists in query', () => {
+      window.location.search = '?share=xyz789';
+
+      expect(hasShareDataInUrl()).toBe(true);
+    });
+
+    it('should return false when no share data exists', () => {
+      window.location.hash = '';
+      window.location.search = '';
+
+      expect(hasShareDataInUrl()).toBe(false);
+    });
+
+    it('should return false when hash has other parameters but not share', () => {
+      window.location.hash = '#other=value';
+
+      expect(hasShareDataInUrl()).toBe(false);
+    });
+  });
+
+  describe('clearShareDataFromUrl', () => {
+    it('should clear share data from hash', () => {
+      window.location.hash = '#share=abc123';
+      window.location.href = 'https://example.com/#share=abc123';
+
+      clearShareDataFromUrl();
+
+      expect(window.history.replaceState).toHaveBeenCalled();
+    });
+
+    it('should clear share data from query parameters', () => {
+      window.location.search = '?share=xyz789';
+      window.location.href = 'https://example.com/?share=xyz789';
+
+      clearShareDataFromUrl();
+
+      expect(window.history.replaceState).toHaveBeenCalled();
+    });
+
+    it('should preserve other hash parameters', () => {
+      window.location.hash = '#other=value&share=abc123';
+      window.location.href = 'https://example.com/#other=value&share=abc123';
+
+      clearShareDataFromUrl();
+
+      expect(window.history.replaceState).toHaveBeenCalled();
+      const call = (window.history.replaceState as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[2]).toContain('other=value');
+      expect(call[2]).not.toContain('share=');
+    });
+
+    it('should not update URL when no share data present', () => {
+      window.location.hash = '';
+      window.location.search = '';
+      window.location.href = 'https://example.com/';
+
+      clearShareDataFromUrl();
+
+      expect(window.history.replaceState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkShareUrl', () => {
+    it('should detect share data in hash', () => {
+      window.location.hash = '#share=abc123';
+
+      const result = checkShareUrl();
+
+      expect(result.hasShareData).toBe(true);
+      expect(result.encodedData).toBe('abc123');
+      expect(result.source).toBe('hash');
+    });
+
+    it('should detect share data in query', () => {
+      window.location.search = '?share=xyz789';
+
+      const result = checkShareUrl();
+
+      expect(result.hasShareData).toBe(true);
+      expect(result.encodedData).toBe('xyz789');
+      expect(result.source).toBe('query');
+    });
+
+    it('should return no share data when not present', () => {
+      window.location.hash = '';
+      window.location.search = '';
+
+      const result = checkShareUrl();
+
+      expect(result.hasShareData).toBe(false);
+      expect(result.encodedData).toBeNull();
+      expect(result.source).toBeNull();
+    });
+
+    it('should prefer hash over query', () => {
+      window.location.hash = '#share=hashData';
+      window.location.search = '?share=queryData';
+
+      const result = checkShareUrl();
+
+      expect(result.hasShareData).toBe(true);
+      expect(result.encodedData).toBe('hashData');
+      expect(result.source).toBe('hash');
+    });
+  });
+
+  describe('SHARE_PARAM_NAME', () => {
+    it('should be "share"', () => {
+      expect(SHARE_PARAM_NAME).toBe('share');
+    });
+  });
+});

--- a/web/src/lib/share/url.ts
+++ b/web/src/lib/share/url.ts
@@ -1,0 +1,194 @@
+/**
+ * Ghost Note - URL Parsing
+ *
+ * Functions for parsing share data from URLs.
+ *
+ * @module lib/share/url
+ */
+
+import type { ShareDecodeResult } from './types';
+import { decodeShareData, decodeAndImportShareData, type ImportShareOptions } from './decode';
+
+// Logging helper for debugging
+const DEBUG = typeof import.meta !== 'undefined' && import.meta.env?.DEV;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[Share/URL] ${message}`, ...args);
+  }
+};
+
+// =============================================================================
+// URL Parameter Names
+// =============================================================================
+
+/** URL parameter/fragment name for share data */
+export const SHARE_PARAM_NAME = 'share';
+
+// =============================================================================
+// URL Parsing Functions
+// =============================================================================
+
+/**
+ * Extracts share data from the current URL.
+ *
+ * Checks both hash fragment (#share=...) and query parameters (?share=...).
+ * Fragment is checked first as it's the preferred method.
+ *
+ * @returns Encoded share data string or null if not found
+ */
+export function extractShareDataFromUrl(): string | null {
+  log('Extracting share data from URL:', window.location.href);
+
+  // Check hash fragment first (preferred method)
+  if (window.location.hash) {
+    const hashParams = new URLSearchParams(window.location.hash.slice(1));
+    const shareData = hashParams.get(SHARE_PARAM_NAME);
+    if (shareData) {
+      log('Found share data in hash fragment');
+      return shareData;
+    }
+  }
+
+  // Check query parameters
+  const queryParams = new URLSearchParams(window.location.search);
+  const shareData = queryParams.get(SHARE_PARAM_NAME);
+  if (shareData) {
+    log('Found share data in query parameters');
+    return shareData;
+  }
+
+  log('No share data found in URL');
+  return null;
+}
+
+/**
+ * Checks if the current URL contains share data.
+ *
+ * @returns Whether share data is present
+ */
+export function hasShareDataInUrl(): boolean {
+  return extractShareDataFromUrl() !== null;
+}
+
+/**
+ * Clears share data from the URL without triggering a page reload.
+ * Preserves other parameters if present.
+ */
+export function clearShareDataFromUrl(): void {
+  log('Clearing share data from URL');
+
+  const url = new URL(window.location.href);
+
+  // Clear from hash
+  if (url.hash) {
+    const hashParams = new URLSearchParams(url.hash.slice(1));
+    if (hashParams.has(SHARE_PARAM_NAME)) {
+      hashParams.delete(SHARE_PARAM_NAME);
+      const newHash = hashParams.toString();
+      url.hash = newHash ? `#${newHash}` : '';
+    }
+  }
+
+  // Clear from query params
+  if (url.searchParams.has(SHARE_PARAM_NAME)) {
+    url.searchParams.delete(SHARE_PARAM_NAME);
+  }
+
+  // Update URL without reload
+  const newUrl = url.toString();
+  if (newUrl !== window.location.href) {
+    window.history.replaceState({}, '', newUrl);
+    log('URL updated:', newUrl);
+  }
+}
+
+/**
+ * Parses and decodes share data from the current URL.
+ *
+ * @returns Decode result or null if no share data in URL
+ */
+export async function parseShareDataFromUrl(): Promise<ShareDecodeResult | null> {
+  const encoded = extractShareDataFromUrl();
+
+  if (!encoded) {
+    return null;
+  }
+
+  return decodeShareData(encoded);
+}
+
+/**
+ * Parses share data from URL and imports it into the application state.
+ *
+ * @param options - Import options
+ * @returns Result of the parse and import operation, or null if no share data
+ */
+export async function parseAndImportShareDataFromUrl(
+  options: ImportShareOptions = {}
+): Promise<(ShareDecodeResult & { imported: boolean }) | null> {
+  const encoded = extractShareDataFromUrl();
+
+  if (!encoded) {
+    log('No share data in URL to import');
+    return null;
+  }
+
+  log('Importing share data from URL...');
+  const result = await decodeAndImportShareData(encoded, options);
+
+  // Clear the share data from URL after successful import
+  if (result.imported) {
+    clearShareDataFromUrl();
+  }
+
+  return result;
+}
+
+/**
+ * Result of checking for share data in URL.
+ */
+export interface ShareUrlCheckResult {
+  /** Whether share data is present in the URL */
+  hasShareData: boolean;
+  /** The encoded share data (if present) */
+  encodedData: string | null;
+  /** Where the share data was found */
+  source: 'hash' | 'query' | null;
+}
+
+/**
+ * Checks the current URL for share data and returns details.
+ *
+ * @returns Share URL check result
+ */
+export function checkShareUrl(): ShareUrlCheckResult {
+  // Check hash fragment first
+  if (window.location.hash) {
+    const hashParams = new URLSearchParams(window.location.hash.slice(1));
+    const shareData = hashParams.get(SHARE_PARAM_NAME);
+    if (shareData) {
+      return {
+        hasShareData: true,
+        encodedData: shareData,
+        source: 'hash',
+      };
+    }
+  }
+
+  // Check query parameters
+  const queryParams = new URLSearchParams(window.location.search);
+  const shareData = queryParams.get(SHARE_PARAM_NAME);
+  if (shareData) {
+    return {
+      hasShareData: true,
+      encodedData: shareData,
+      source: 'query',
+    };
+  }
+
+  return {
+    hasShareData: false,
+    encodedData: null,
+    source: null,
+  };
+}

--- a/web/src/stores/types.ts
+++ b/web/src/stores/types.ts
@@ -93,7 +93,8 @@ export type ModalType =
   | 'import'
   | 'help'
   | 'version-history'
-  | 'recording-manager';
+  | 'recording-manager'
+  | 'share';
 
 /**
  * Panel identifiers for visibility tracking


### PR DESCRIPTION
## Summary
Implements a share/copy link feature that allows users to generate shareable URLs encoding poem content. URLs can be shared with others who can then load the poem by visiting the link.

## Changes
- `web/src/lib/share/` - New URL sharing utility module
  - `types.ts` - Share data types and type guards
  - `encode.ts` - Compression and encoding functions (Base64, DEFLATE)
  - `decode.ts` - Decompression and decoding functions
  - `url.ts` - URL parsing utilities for extracting/clearing share data
  - `index.ts` - Module exports

- `web/src/components/Share/` - New ShareDialog component
  - `ShareDialog.tsx` - Modal dialog for generating share links
  - `ShareDialog.css` - Styling with dark mode support
  - `ShareDialog.test.tsx` - Component tests

- `web/src/stores/types.ts` - Added 'share' to ModalType union

- `web/src/App.tsx` - Added URL parsing on app initialization to import shared content

- `web/src/components/Layout/Header.tsx` - Added share button to toolbar

## Features
- Three share modes:
  - **Poem Only**: Smallest URL, just the poem text
  - **With Analysis**: Includes analysis results
  - **Full Project**: All versions, analysis, and melody
- URL compression using DEFLATE for large content
- Copy to clipboard functionality
- Auto-import from URL hash fragment or query parameter
- Privacy note about URL visibility in browser history
- Keyboard accessible modal with focus trap

## Testing
- [x] Unit tests pass (`npm test`)
- [x] Check passes (`npm run check`)
- [x] Manual testing performed

## Notes
- Uses hash fragment (#share=...) by default for privacy (not sent to server)
- Fallback to query parameter (?share=...) available
- Compressed data prefixed with 'c:' to distinguish from uncompressed

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)