### PR TITLE
feat(GH-45): Add in-app help documentation system

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,6 +44,7 @@ import {
   selectShouldShowTutorial,
 } from '@/stores/useTutorialStore';
 import { ShareDialog } from '@/components/Share';
+import { HelpPanel } from '@/components/Help';
 import { useKeyboardShortcuts } from '@/hooks';
 import './App.css';
 
@@ -525,9 +526,11 @@ function App(): React.ReactElement {
   const analysis = useAnalysisStore((state) => state.analysis);
   const currentLyrics = usePoemStore(selectCurrentLyrics);
 
-  // UI store for notifications and export dialog
+  // UI store for notifications, modals, and help panel
   const showNotification = useUIStore((state) => state.showNotification);
   const openModalDialog = useUIStore((state) => state.openModalDialog);
+  const openModal = useUIStore((state) => state.openModal);
+  const closeModal = useUIStore((state) => state.closeModal);
 
   // Undo store for undo/redo functionality
   const canUndo = useUndoStore(selectCanUndo);
@@ -539,10 +542,6 @@ function App(): React.ReactElement {
 
   // Poem store for setting lyrics after undo/redo
   const updateCurrentVersion = usePoemStore((state) => state.updateCurrentVersion);
-
-  // UI store for share dialog
-  const openModal = useUIStore((state) => state.openModal);
-  const closeModal = useUIStore((state) => state.closeModal);
 
   // Toast store for notifications
   const addToast = useToastStore((state) => state.addToast);
@@ -924,6 +923,10 @@ function App(): React.ReactElement {
       />
       <ShareDialog
         isOpen={openModal === 'share'}
+        onClose={closeModal}
+      />
+      <HelpPanel
+        isOpen={openModal === 'help'}
         onClose={closeModal}
       />
       <ToastContainer position="top-right" />

--- a/web/src/components/Help/FAQ.css
+++ b/web/src/components/Help/FAQ.css
@@ -1,0 +1,228 @@
+/**
+ * FAQ Styles
+ *
+ * Styles for the FAQ accordion component.
+ */
+
+.faq {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Controls */
+.faq__controls {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.5rem;
+}
+
+.faq__control-button {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-primary, #3b82f6);
+  background: none;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.faq__control-button:hover {
+  background-color: var(--color-primary-subtle, #eff6ff);
+}
+
+/* Category groups */
+.faq__category-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.faq__category-group + .faq__category-group {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+.faq__category-title {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted, #9ca3af);
+}
+
+/* FAQ list */
+.faq__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+/* FAQ item */
+.faq__item {
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: box-shadow 0.15s;
+}
+
+.faq__item:hover {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.faq__item--expanded {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+/* Question button */
+.faq__question {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.875rem 1rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #111827);
+  background-color: var(--color-surface, #ffffff);
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.15s;
+}
+
+.faq__question:hover {
+  background-color: var(--color-hover, #f9fafb);
+}
+
+.faq__question:focus {
+  outline: 2px solid var(--color-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
+.faq__question-text {
+  flex: 1;
+  padding-right: 1rem;
+}
+
+/* Chevron icon */
+.faq__chevron {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--color-text-muted, #9ca3af);
+  flex-shrink: 0;
+  transition: transform 0.2s ease-out;
+}
+
+.faq__chevron--expanded {
+  transform: rotate(180deg);
+}
+
+/* Answer section */
+.faq__answer {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.25s ease-out;
+}
+
+.faq__item--expanded .faq__answer {
+  grid-template-rows: 1fr;
+}
+
+.faq__answer-content {
+  overflow: hidden;
+  padding: 0 1rem;
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary, #4b5563);
+  line-height: 1.6;
+}
+
+.faq__item--expanded .faq__answer-content {
+  padding: 0.75rem 1rem 1rem 1rem;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+/* Category badge in answer */
+.faq__category-badge {
+  display: inline-block;
+  margin-top: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--color-primary, #3b82f6);
+  background-color: var(--color-primary-subtle, #eff6ff);
+  border-radius: 4px;
+}
+
+/* Empty state */
+.faq__empty {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.faq__empty p {
+  margin: 0;
+}
+
+/* Dark mode */
+.dark .faq__control-button {
+  color: var(--color-primary, #60a5fa);
+}
+
+.dark .faq__control-button:hover {
+  background-color: rgba(59, 130, 246, 0.1);
+}
+
+.dark .faq__category-group + .faq__category-group {
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .faq__category-title {
+  color: var(--color-text-muted-dark, #6b7280);
+}
+
+.dark .faq__item {
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .faq__question {
+  background-color: var(--color-surface-dark, #1f2937);
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .faq__question:hover {
+  background-color: var(--color-hover-dark, #374151);
+}
+
+.dark .faq__chevron {
+  color: var(--color-text-muted-dark, #6b7280);
+}
+
+.dark .faq__answer-content {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .faq__item--expanded .faq__answer-content {
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .faq__category-badge {
+  background-color: rgba(59, 130, 246, 0.15);
+}
+
+.dark .faq__empty {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .faq__chevron,
+  .faq__answer {
+    transition: none;
+  }
+}

--- a/web/src/components/Help/FAQ.test.tsx
+++ b/web/src/components/Help/FAQ.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * Tests for FAQ Component
+ *
+ * @module components/Help/FAQ.test
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { FAQ, type FAQProps } from './FAQ';
+import { FAQ_ITEMS, HELP_CATEGORIES } from './helpContent';
+
+describe('FAQ', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('rendering', () => {
+    it('renders the FAQ component', () => {
+      render(<FAQ />);
+      expect(screen.getByTestId('faq')).toBeInTheDocument();
+    });
+
+    it('renders all FAQ items when no category filter', () => {
+      render(<FAQ />);
+
+      FAQ_ITEMS.forEach((item) => {
+        expect(screen.getByTestId(`faq-item-${item.id}`)).toBeInTheDocument();
+      });
+    });
+
+    it('renders toggle all button', () => {
+      render(<FAQ />);
+      expect(screen.getByTestId('faq-toggle-all')).toBeInTheDocument();
+      expect(screen.getByTestId('faq-toggle-all')).toHaveTextContent('Expand All');
+    });
+
+    it('groups items by category when no filter applied', () => {
+      render(<FAQ />);
+
+      // Should show category titles as headers for grouping
+      const uniqueCategories = [...new Set(FAQ_ITEMS.map((item) => item.category))];
+      const categoryHeaders = document.querySelectorAll('.faq__category-title');
+
+      // Should have one header per unique category
+      expect(categoryHeaders.length).toBe(uniqueCategories.length);
+
+      // Each category title should appear in a header
+      uniqueCategories.forEach((catId) => {
+        const category = HELP_CATEGORIES.find((c) => c.id === catId);
+        if (category) {
+          const header = Array.from(categoryHeaders).find(
+            (h) => h.textContent === category.title
+          );
+          expect(header).toBeInTheDocument();
+        }
+      });
+    });
+  });
+
+  describe('category filtering', () => {
+    it('filters items by category', () => {
+      render(<FAQ category="analysis" />);
+
+      const analysisFAQs = FAQ_ITEMS.filter((item) => item.category === 'analysis');
+      const otherFAQs = FAQ_ITEMS.filter((item) => item.category !== 'analysis');
+
+      analysisFAQs.forEach((item) => {
+        expect(screen.getByTestId(`faq-item-${item.id}`)).toBeInTheDocument();
+      });
+
+      otherFAQs.forEach((item) => {
+        expect(screen.queryByTestId(`faq-item-${item.id}`)).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows empty state when category has no items', () => {
+      // Use a category that doesn't exist
+      render(<FAQ category={'non-existent' as FAQProps['category']} />);
+      expect(screen.getByText('No questions available for this category.')).toBeInTheDocument();
+    });
+
+    it('does not group by category when filter is applied', () => {
+      render(<FAQ category="analysis" />);
+
+      // Should not show the category title as a header when filtered
+      const categoryHeaders = document.querySelectorAll('.faq__category-title');
+      expect(categoryHeaders.length).toBe(0);
+    });
+  });
+
+  describe('maxItems prop', () => {
+    it('limits displayed items when maxItems is set', () => {
+      render(<FAQ maxItems={3} />);
+
+      const items = screen.getAllByTestId(/^faq-item-/);
+      expect(items.length).toBe(3);
+    });
+
+    it('shows all items when maxItems is 0', () => {
+      render(<FAQ maxItems={0} />);
+
+      const items = screen.getAllByTestId(/^faq-item-/);
+      expect(items.length).toBe(FAQ_ITEMS.length);
+    });
+
+    it('combines category filter and maxItems', () => {
+      const analysisFAQs = FAQ_ITEMS.filter((item) => item.category === 'analysis');
+      const limit = Math.min(2, analysisFAQs.length);
+
+      render(<FAQ category="analysis" maxItems={limit} />);
+
+      const items = screen.getAllByTestId(/^faq-item-/);
+      expect(items.length).toBe(limit);
+    });
+  });
+
+  describe('expand/collapse functionality', () => {
+    it('expands an item when question is clicked', () => {
+      render(<FAQ />);
+
+      const firstItem = FAQ_ITEMS[0];
+      const questionButton = screen.getByTestId(`faq-question-${firstItem.id}`);
+
+      expect(questionButton).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.click(questionButton);
+
+      expect(questionButton).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('collapses an expanded item when clicked again', () => {
+      render(<FAQ />);
+
+      const firstItem = FAQ_ITEMS[0];
+      const questionButton = screen.getByTestId(`faq-question-${firstItem.id}`);
+
+      // Expand
+      fireEvent.click(questionButton);
+      expect(questionButton).toHaveAttribute('aria-expanded', 'true');
+
+      // Collapse
+      fireEvent.click(questionButton);
+      expect(questionButton).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('allows multiple items to be expanded simultaneously', () => {
+      render(<FAQ />);
+
+      const firstItem = FAQ_ITEMS[0];
+      const secondItem = FAQ_ITEMS[1];
+
+      const firstButton = screen.getByTestId(`faq-question-${firstItem.id}`);
+      const secondButton = screen.getByTestId(`faq-question-${secondItem.id}`);
+
+      fireEvent.click(firstButton);
+      fireEvent.click(secondButton);
+
+      expect(firstButton).toHaveAttribute('aria-expanded', 'true');
+      expect(secondButton).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  describe('expand all / collapse all', () => {
+    it('expands all items when Expand All is clicked', () => {
+      render(<FAQ />);
+
+      const toggleButton = screen.getByTestId('faq-toggle-all');
+      expect(toggleButton).toHaveTextContent('Expand All');
+
+      fireEvent.click(toggleButton);
+
+      expect(toggleButton).toHaveTextContent('Collapse All');
+
+      FAQ_ITEMS.forEach((item) => {
+        const questionButton = screen.getByTestId(`faq-question-${item.id}`);
+        expect(questionButton).toHaveAttribute('aria-expanded', 'true');
+      });
+    });
+
+    it('collapses all items when Collapse All is clicked', () => {
+      render(<FAQ />);
+
+      const toggleButton = screen.getByTestId('faq-toggle-all');
+
+      // First expand all
+      fireEvent.click(toggleButton);
+      expect(toggleButton).toHaveTextContent('Collapse All');
+
+      // Then collapse all
+      fireEvent.click(toggleButton);
+      expect(toggleButton).toHaveTextContent('Expand All');
+
+      FAQ_ITEMS.forEach((item) => {
+        const questionButton = screen.getByTestId(`faq-question-${item.id}`);
+        expect(questionButton).toHaveAttribute('aria-expanded', 'false');
+      });
+    });
+
+    it('changes button text when at least one item is expanded', () => {
+      render(<FAQ />);
+
+      const toggleButton = screen.getByTestId('faq-toggle-all');
+      const firstItem = FAQ_ITEMS[0];
+      const questionButton = screen.getByTestId(`faq-question-${firstItem.id}`);
+
+      expect(toggleButton).toHaveTextContent('Expand All');
+
+      fireEvent.click(questionButton);
+
+      expect(toggleButton).toHaveTextContent('Collapse All');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('uses aria-expanded on question buttons', () => {
+      render(<FAQ />);
+
+      const firstItem = FAQ_ITEMS[0];
+      const questionButton = screen.getByTestId(`faq-question-${firstItem.id}`);
+
+      expect(questionButton).toHaveAttribute('aria-expanded');
+    });
+
+    it('uses aria-controls to link question to answer', () => {
+      render(<FAQ />);
+
+      const firstItem = FAQ_ITEMS[0];
+      const questionButton = screen.getByTestId(`faq-question-${firstItem.id}`);
+
+      expect(questionButton).toHaveAttribute('aria-controls', `faq-answer-${firstItem.id}`);
+    });
+
+    it('uses aria-hidden on answer when collapsed', () => {
+      render(<FAQ />);
+
+      const firstItem = FAQ_ITEMS[0];
+      const answer = document.getElementById(`faq-answer-${firstItem.id}`);
+
+      expect(answer).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('chevron icon is hidden from screen readers', () => {
+      render(<FAQ />);
+
+      const chevrons = document.querySelectorAll('.faq__chevron');
+      chevrons.forEach((chevron) => {
+        expect(chevron).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
+  });
+
+  describe('content rendering', () => {
+    it('renders question text', () => {
+      render(<FAQ />);
+
+      FAQ_ITEMS.forEach((item) => {
+        expect(screen.getByText(item.question)).toBeInTheDocument();
+      });
+    });
+
+    it('renders answer text', () => {
+      render(<FAQ />);
+
+      FAQ_ITEMS.forEach((item) => {
+        // Answer is rendered but may be hidden
+        const answerElement = document.getElementById(`faq-answer-${item.id}`);
+        expect(answerElement).toBeInTheDocument();
+      });
+    });
+
+    it('shows category badge in answer', () => {
+      render(<FAQ />);
+
+      // Expand first item to see badge
+      const firstItem = FAQ_ITEMS[0];
+      const questionButton = screen.getByTestId(`faq-question-${firstItem.id}`);
+      fireEvent.click(questionButton);
+
+      // Check for category badge within the answer element
+      const answerElement = document.getElementById(`faq-answer-${firstItem.id}`);
+      expect(answerElement).toBeInTheDocument();
+      expect(answerElement?.querySelector('.faq__category-badge')).toBeInTheDocument();
+    });
+  });
+
+  describe('onTopicSelect callback', () => {
+    it('passes onTopicSelect prop to component', () => {
+      const mockCallback = vi.fn();
+      render(<FAQ onTopicSelect={mockCallback} />);
+
+      // The component receives the prop (reserved for future use)
+      expect(screen.getByTestId('faq')).toBeInTheDocument();
+    });
+  });
+
+  describe('visual states', () => {
+    it('applies expanded class to item when expanded', () => {
+      render(<FAQ />);
+
+      const firstItem = FAQ_ITEMS[0];
+      const itemElement = screen.getByTestId(`faq-item-${firstItem.id}`);
+      const questionButton = screen.getByTestId(`faq-question-${firstItem.id}`);
+
+      expect(itemElement).not.toHaveClass('faq__item--expanded');
+
+      fireEvent.click(questionButton);
+
+      expect(itemElement).toHaveClass('faq__item--expanded');
+    });
+
+    it('applies expanded class to chevron when expanded', () => {
+      render(<FAQ />);
+
+      const firstItem = FAQ_ITEMS[0];
+      const questionButton = screen.getByTestId(`faq-question-${firstItem.id}`);
+      const chevron = questionButton.querySelector('.faq__chevron');
+
+      expect(chevron).not.toHaveClass('faq__chevron--expanded');
+
+      fireEvent.click(questionButton);
+
+      expect(chevron).toHaveClass('faq__chevron--expanded');
+    });
+  });
+});

--- a/web/src/components/Help/FAQ.tsx
+++ b/web/src/components/Help/FAQ.tsx
@@ -1,0 +1,249 @@
+/**
+ * FAQ Component
+ *
+ * Displays frequently asked questions in an accordion-style format.
+ * Questions can be expanded/collapsed individually.
+ *
+ * @module components/Help/FAQ
+ */
+
+import { useState, useCallback, type ReactElement } from 'react';
+import {
+  FAQ_ITEMS,
+  HELP_CATEGORIES,
+  type FAQItem,
+  type HelpTopic,
+  type HelpCategory,
+} from './helpContent';
+import './FAQ.css';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[FAQ] ${message}`, ...args);
+  }
+};
+
+/**
+ * Props for FAQ component
+ */
+export interface FAQProps {
+  /** Optional filter by category */
+  category?: HelpCategory;
+  /** Callback when user clicks on a link to a help topic (reserved for future use) */
+  onTopicSelect?: (topic: HelpTopic) => void;
+  /** Maximum number of items to show (0 = all) */
+  maxItems?: number;
+}
+
+/**
+ * Chevron icon for accordion
+ */
+function ChevronIcon({ expanded }: { expanded: boolean }): ReactElement {
+  return (
+    <svg
+      className={`faq__chevron ${expanded ? 'faq__chevron--expanded' : ''}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+/**
+ * Single FAQ item with expandable answer
+ */
+function FAQItemComponent({
+  item,
+  isExpanded,
+  onToggle,
+}: {
+  item: FAQItem;
+  isExpanded: boolean;
+  onToggle: () => void;
+}): ReactElement {
+  // Parse answer for links to help topics
+  const parseAnswer = (text: string): ReactElement[] => {
+    // Simple implementation - just return the text as-is
+    // Could be enhanced to detect and create links to help topics
+    return [<span key="text">{text}</span>];
+  };
+
+  const category = HELP_CATEGORIES.find((c) => c.id === item.category);
+
+  return (
+    <div
+      className={`faq__item ${isExpanded ? 'faq__item--expanded' : ''}`}
+      data-testid={`faq-item-${item.id}`}
+    >
+      <button
+        type="button"
+        className="faq__question"
+        onClick={onToggle}
+        aria-expanded={isExpanded}
+        aria-controls={`faq-answer-${item.id}`}
+        data-testid={`faq-question-${item.id}`}
+      >
+        <span className="faq__question-text">{item.question}</span>
+        <ChevronIcon expanded={isExpanded} />
+      </button>
+
+      <div
+        id={`faq-answer-${item.id}`}
+        className="faq__answer"
+        aria-hidden={!isExpanded}
+      >
+        <div className="faq__answer-content">
+          {parseAnswer(item.answer)}
+        </div>
+        {category && (
+          <span className="faq__category-badge">{category.title}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * FAQ displays frequently asked questions in an accordion format.
+ *
+ * Features:
+ * - Expandable/collapsible questions
+ * - Category filtering
+ * - Links to related help topics
+ * - Accessible accordion pattern
+ *
+ * @example
+ * ```tsx
+ * <FAQ
+ *   category="analysis"
+ *   onTopicSelect={(topic) => navigateToTopic(topic)}
+ * />
+ * ```
+ */
+export function FAQ({
+  category,
+  onTopicSelect: _onTopicSelect, // Reserved for future use
+  maxItems = 0,
+}: FAQProps): ReactElement {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  // Log for debugging (onTopicSelect reserved for future topic linking feature)
+  log('Rendering FAQ:', { category, itemCount: FAQ_ITEMS.length, hasTopicSelectHandler: !!_onTopicSelect });
+
+  // Filter items by category if provided
+  let items = category
+    ? FAQ_ITEMS.filter((item) => item.category === category)
+    : FAQ_ITEMS;
+
+  // Limit items if maxItems is set
+  if (maxItems > 0) {
+    items = items.slice(0, maxItems);
+  }
+
+  // Group items by category for display
+  const groupedItems = items.reduce<Map<HelpCategory, FAQItem[]>>((acc, item) => {
+    const existingItems = acc.get(item.category) || [];
+    acc.set(item.category, [...existingItems, item]);
+    return acc;
+  }, new Map());
+
+  // Toggle expansion
+  const handleToggle = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  // Expand all
+  const handleExpandAll = useCallback(() => {
+    // Get fresh item IDs since we can't depend on the array
+    const currentItems = category
+      ? FAQ_ITEMS.filter((item) => item.category === category)
+      : FAQ_ITEMS;
+    const limitedItems = maxItems > 0 ? currentItems.slice(0, maxItems) : currentItems;
+    setExpandedIds(new Set(limitedItems.map((item) => item.id)));
+  }, [category, maxItems]);
+
+  // Collapse all
+  const handleCollapseAll = useCallback(() => {
+    setExpandedIds(new Set());
+  }, []);
+
+  const hasExpanded = expandedIds.size > 0;
+
+  return (
+    <div className="faq" data-testid="faq">
+      {/* Controls */}
+      <div className="faq__controls">
+        <button
+          type="button"
+          className="faq__control-button"
+          onClick={hasExpanded ? handleCollapseAll : handleExpandAll}
+          data-testid="faq-toggle-all"
+        >
+          {hasExpanded ? 'Collapse All' : 'Expand All'}
+        </button>
+      </div>
+
+      {/* Grouped FAQ items */}
+      {category ? (
+        // Single category - no grouping needed
+        <div className="faq__list">
+          {items.map((item) => (
+            <FAQItemComponent
+              key={item.id}
+              item={item}
+              isExpanded={expandedIds.has(item.id)}
+              onToggle={() => handleToggle(item.id)}
+            />
+          ))}
+        </div>
+      ) : (
+        // Multiple categories - group them
+        Array.from(groupedItems.entries()).map(([cat, catItems]) => {
+          const categoryInfo = HELP_CATEGORIES.find((c) => c.id === cat);
+          return (
+            <div key={cat} className="faq__category-group">
+              <h3 className="faq__category-title">
+                {categoryInfo?.title ?? cat}
+              </h3>
+              <div className="faq__list">
+                {catItems.map((item) => (
+                  <FAQItemComponent
+                    key={item.id}
+                    item={item}
+                    isExpanded={expandedIds.has(item.id)}
+                    onToggle={() => handleToggle(item.id)}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })
+      )}
+
+      {/* Empty state */}
+      {items.length === 0 && (
+        <div className="faq__empty">
+          <p>No questions available for this category.</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FAQ;

--- a/web/src/components/Help/HelpPanel.css
+++ b/web/src/components/Help/HelpPanel.css
@@ -1,0 +1,413 @@
+/**
+ * HelpPanel Styles
+ *
+ * Styles for the sliding help drawer component.
+ */
+
+/* Overlay */
+.help-panel__overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 100;
+  animation: help-overlay-fade-in 0.2s ease-out;
+}
+
+@keyframes help-overlay-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Panel */
+.help-panel {
+  width: 100%;
+  max-width: 480px;
+  height: 100%;
+  background-color: var(--color-surface, #ffffff);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+  animation: help-panel-slide-in 0.25s ease-out;
+}
+
+@keyframes help-panel-slide-in {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+/* Header */
+.help-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  flex-shrink: 0;
+}
+
+.help-panel__header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.help-panel__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #111827);
+}
+
+.help-panel__back-button,
+.help-panel__close-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--color-text-secondary, #6b7280);
+  transition: all 0.15s;
+}
+
+.help-panel__back-button:hover,
+.help-panel__close-button:hover {
+  background-color: var(--color-hover, #f3f4f6);
+  color: var(--color-text-primary, #111827);
+}
+
+.help-panel__back-button svg,
+.help-panel__close-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+/* Search */
+.help-panel__search {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  flex-shrink: 0;
+}
+
+.help-panel__search svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--color-text-muted, #9ca3af);
+  flex-shrink: 0;
+}
+
+.help-panel__search-input {
+  flex: 1;
+  padding: 0.5rem;
+  font-size: 0.9375rem;
+  border: none;
+  background: transparent;
+  color: var(--color-text-primary, #111827);
+  outline: none;
+}
+
+.help-panel__search-input::placeholder {
+  color: var(--color-text-muted, #9ca3af);
+}
+
+/* Content */
+.help-panel__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem;
+}
+
+/* Categories */
+.help-panel__categories {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.help-panel__category-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem;
+  background-color: var(--color-surface-elevated, #f9fafb);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.15s;
+  text-align: left;
+  width: 100%;
+}
+
+.help-panel__category-card:hover {
+  background-color: var(--color-hover, #f3f4f6);
+  border-color: var(--color-border-hover, #d1d5db);
+  transform: translateY(-1px);
+}
+
+.help-panel__category-card:focus {
+  outline: 2px solid var(--color-primary, #3b82f6);
+  outline-offset: 2px;
+}
+
+.help-panel__category-card--faq {
+  margin-top: 0.5rem;
+  border-style: dashed;
+}
+
+.help-panel__category-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background-color: var(--color-primary-subtle, #eff6ff);
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.help-panel__category-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--color-primary, #3b82f6);
+}
+
+.help-panel__category-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.help-panel__category-title {
+  margin: 0 0 0.25rem 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #111827);
+}
+
+.help-panel__category-description {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+  line-height: 1.4;
+}
+
+/* Topics list */
+.help-panel__topics {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.help-panel__topic-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0.875rem 1rem;
+  background-color: var(--color-surface, #ffffff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+  text-align: left;
+  width: 100%;
+}
+
+.help-panel__topic-item:hover {
+  background-color: var(--color-hover, #f9fafb);
+  border-color: var(--color-border-hover, #d1d5db);
+}
+
+.help-panel__topic-item:focus {
+  outline: 2px solid var(--color-primary, #3b82f6);
+  outline-offset: 2px;
+}
+
+.help-panel__topic-title {
+  margin: 0 0 0.25rem 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #111827);
+}
+
+.help-panel__topic-summary {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+  line-height: 1.4;
+}
+
+.help-panel__topic-category {
+  margin-top: 0.5rem;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--color-primary, #3b82f6);
+  background-color: var(--color-primary-subtle, #eff6ff);
+  border-radius: 4px;
+}
+
+/* Search results */
+.help-panel__search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.help-panel__result-count {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.help-panel__no-results {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.help-panel__no-results p {
+  margin: 0;
+}
+
+.help-panel__no-results-hint {
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted, #9ca3af);
+}
+
+/* Footer */
+.help-panel__footer {
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+  flex-shrink: 0;
+}
+
+.help-panel__footer-text {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted, #9ca3af);
+  text-align: center;
+}
+
+.help-panel__footer-text kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.25rem;
+  padding: 0 0.375rem;
+  margin: 0 0.25rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #4b5563);
+  background-color: var(--color-kbd-bg, #f3f4f6);
+  border: 1px solid var(--color-kbd-border, #d1d5db);
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+/* Dark mode */
+.dark .help-panel {
+  background-color: var(--color-surface-dark, #1f2937);
+}
+
+.dark .help-panel__header,
+.dark .help-panel__search,
+.dark .help-panel__footer {
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .help-panel__title,
+.dark .help-panel__category-title,
+.dark .help-panel__topic-title {
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .help-panel__back-button,
+.dark .help-panel__close-button {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .help-panel__back-button:hover,
+.dark .help-panel__close-button:hover {
+  background-color: var(--color-hover-dark, #374151);
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .help-panel__search-input {
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .help-panel__search-input::placeholder {
+  color: var(--color-text-muted-dark, #6b7280);
+}
+
+.dark .help-panel__category-card,
+.dark .help-panel__topic-item {
+  background-color: var(--color-surface-elevated-dark, #111827);
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .help-panel__category-card:hover,
+.dark .help-panel__topic-item:hover {
+  background-color: var(--color-hover-dark, #1f2937);
+  border-color: var(--color-border-hover-dark, #4b5563);
+}
+
+.dark .help-panel__category-description,
+.dark .help-panel__topic-summary,
+.dark .help-panel__result-count,
+.dark .help-panel__no-results {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .help-panel__no-results-hint,
+.dark .help-panel__footer-text {
+  color: var(--color-text-muted-dark, #6b7280);
+}
+
+.dark .help-panel__category-icon {
+  background-color: rgba(59, 130, 246, 0.1);
+}
+
+.dark .help-panel__topic-category {
+  background-color: rgba(59, 130, 246, 0.15);
+}
+
+.dark .help-panel__footer-text kbd {
+  background-color: var(--color-kbd-bg-dark, #374151);
+  border-color: var(--color-kbd-border-dark, #4b5563);
+  color: var(--color-text-secondary-dark, #e5e7eb);
+}
+
+/* Mobile adjustments */
+@media (max-width: 480px) {
+  .help-panel {
+    max-width: 100%;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .help-panel__overlay,
+  .help-panel {
+    animation: none;
+  }
+}

--- a/web/src/components/Help/HelpPanel.test.tsx
+++ b/web/src/components/Help/HelpPanel.test.tsx
@@ -1,0 +1,495 @@
+/**
+ * Tests for HelpPanel Component
+ *
+ * @module components/Help/HelpPanel.test
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { HelpPanel, type HelpPanelProps } from './HelpPanel';
+import { HELP_CATEGORIES, HELP_TOPICS, getTopicsByCategory } from './helpContent';
+
+// Mock useFocusTrap hook
+vi.mock('@/hooks', () => ({
+  useFocusTrap: vi.fn(() => ({
+    containerRef: { current: null },
+  })),
+}));
+
+describe('HelpPanel', () => {
+  const defaultProps: HelpPanelProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    document.body.style.overflow = '';
+  });
+
+  describe('rendering', () => {
+    it('renders nothing when closed', () => {
+      render(<HelpPanel {...defaultProps} isOpen={false} />);
+      expect(screen.queryByTestId('help-panel')).not.toBeInTheDocument();
+    });
+
+    it('renders the panel when open', () => {
+      render(<HelpPanel {...defaultProps} />);
+      expect(screen.getByTestId('help-panel')).toBeInTheDocument();
+    });
+
+    it('renders the overlay', () => {
+      render(<HelpPanel {...defaultProps} />);
+      expect(screen.getByTestId('help-panel-overlay')).toBeInTheDocument();
+    });
+
+    it('renders Help Center title initially', () => {
+      render(<HelpPanel {...defaultProps} />);
+      expect(screen.getByText('Help Center')).toBeInTheDocument();
+    });
+
+    it('renders the close button', () => {
+      render(<HelpPanel {...defaultProps} />);
+      expect(screen.getByTestId('help-close-button')).toBeInTheDocument();
+    });
+
+    it('renders the search input', () => {
+      render(<HelpPanel {...defaultProps} />);
+      expect(screen.getByTestId('help-search-input')).toBeInTheDocument();
+    });
+
+    it('renders footer with keyboard hint', () => {
+      render(<HelpPanel {...defaultProps} />);
+      expect(screen.getByText(/Press/)).toBeInTheDocument();
+      expect(screen.getByText('?')).toBeInTheDocument();
+    });
+  });
+
+  describe('categories view', () => {
+    it('renders all help categories', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      HELP_CATEGORIES.forEach((category) => {
+        expect(screen.getByTestId(`help-category-${category.id}`)).toBeInTheDocument();
+      });
+    });
+
+    it('renders FAQ link', () => {
+      render(<HelpPanel {...defaultProps} />);
+      expect(screen.getByTestId('help-faq-link')).toBeInTheDocument();
+    });
+
+    it('displays category titles', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      HELP_CATEGORIES.forEach((category) => {
+        expect(screen.getByText(category.title)).toBeInTheDocument();
+      });
+    });
+
+    it('displays category descriptions', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      HELP_CATEGORIES.forEach((category) => {
+        expect(screen.getByText(category.description)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('category navigation', () => {
+    it('shows topics when category is clicked', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const firstCategory = HELP_CATEGORIES[0];
+      fireEvent.click(screen.getByTestId(`help-category-${firstCategory.id}`));
+
+      // Should show category title in header
+      expect(screen.getByText(firstCategory.title)).toBeInTheDocument();
+
+      // Should show topics for that category
+      const topics = getTopicsByCategory(firstCategory.id);
+      topics.forEach((topic) => {
+        expect(screen.getByTestId(`help-topic-${topic.id}`)).toBeInTheDocument();
+      });
+    });
+
+    it('shows back button after selecting category', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const firstCategory = HELP_CATEGORIES[0];
+      fireEvent.click(screen.getByTestId(`help-category-${firstCategory.id}`));
+
+      expect(screen.getByTestId('help-back-button')).toBeInTheDocument();
+    });
+
+    it('returns to categories when back is clicked from topics', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const firstCategory = HELP_CATEGORIES[0];
+      fireEvent.click(screen.getByTestId(`help-category-${firstCategory.id}`));
+      fireEvent.click(screen.getByTestId('help-back-button'));
+
+      expect(screen.getByText('Help Center')).toBeInTheDocument();
+      HELP_CATEGORIES.forEach((category) => {
+        expect(screen.getByTestId(`help-category-${category.id}`)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('topic navigation', () => {
+    it('shows topic detail when topic is clicked', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const firstCategory = HELP_CATEGORIES[0];
+      fireEvent.click(screen.getByTestId(`help-category-${firstCategory.id}`));
+
+      const topics = getTopicsByCategory(firstCategory.id);
+      const firstTopic = topics[0];
+      fireEvent.click(screen.getByTestId(`help-topic-${firstTopic.id}`));
+
+      // Should show topic detail via HelpSection test ID
+      expect(screen.getByTestId(`help-section-${firstTopic.id}`)).toBeInTheDocument();
+    });
+
+    it('returns to topics list when back is clicked from topic', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const firstCategory = HELP_CATEGORIES[0];
+      fireEvent.click(screen.getByTestId(`help-category-${firstCategory.id}`));
+
+      const topics = getTopicsByCategory(firstCategory.id);
+      fireEvent.click(screen.getByTestId(`help-topic-${topics[0].id}`));
+      fireEvent.click(screen.getByTestId('help-back-button'));
+
+      // Should show topics list again
+      topics.forEach((topic) => {
+        expect(screen.getByTestId(`help-topic-${topic.id}`)).toBeInTheDocument();
+      });
+    });
+
+    it('navigates to related topic from HelpSection', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      // Find a topic with related topics
+      const topicWithRelated = HELP_TOPICS.find((t) => t.related && t.related.length > 0);
+      if (!topicWithRelated) return;
+
+      // Navigate to the topic
+      fireEvent.click(screen.getByTestId(`help-category-${topicWithRelated.category}`));
+      fireEvent.click(screen.getByTestId(`help-topic-${topicWithRelated.id}`));
+
+      // Click a related topic
+      const relatedId = topicWithRelated.related![0];
+      const relatedButton = screen.getByTestId(`help-related-${relatedId}`);
+      fireEvent.click(relatedButton);
+
+      // Should now show the related topic
+      const relatedTopic = HELP_TOPICS.find((t) => t.id === relatedId);
+      if (relatedTopic) {
+        expect(screen.getByText(relatedTopic.summary)).toBeInTheDocument();
+      }
+    });
+  });
+
+  describe('FAQ view', () => {
+    it('shows FAQ when FAQ link is clicked', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId('help-faq-link'));
+
+      expect(screen.getByText('Frequently Asked Questions')).toBeInTheDocument();
+      expect(screen.getByTestId('faq')).toBeInTheDocument();
+    });
+
+    it('returns to categories when back is clicked from FAQ', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId('help-faq-link'));
+      fireEvent.click(screen.getByTestId('help-back-button'));
+
+      expect(screen.getByText('Help Center')).toBeInTheDocument();
+    });
+  });
+
+  describe('search functionality', () => {
+    it('searches topics when typing in search input', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const searchInput = screen.getByTestId('help-search-input');
+      fireEvent.change(searchInput, { target: { value: 'melody' } });
+
+      expect(screen.getByText('Search Results')).toBeInTheDocument();
+    });
+
+    it('shows result count', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const searchInput = screen.getByTestId('help-search-input');
+      fireEvent.change(searchInput, { target: { value: 'melody' } });
+
+      expect(screen.getByText(/result/)).toBeInTheDocument();
+    });
+
+    it('shows no results message for non-matching query', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const searchInput = screen.getByTestId('help-search-input');
+      fireEvent.change(searchInput, { target: { value: 'xyznonexistent123' } });
+
+      expect(screen.getByText(/No results found/)).toBeInTheDocument();
+    });
+
+    it('returns to categories when search is cleared', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const searchInput = screen.getByTestId('help-search-input');
+      fireEvent.change(searchInput, { target: { value: 'melody' } });
+      fireEvent.change(searchInput, { target: { value: '' } });
+
+      expect(screen.getByText('Help Center')).toBeInTheDocument();
+    });
+
+    it('clears search when back is clicked', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const searchInput = screen.getByTestId('help-search-input');
+      fireEvent.change(searchInput, { target: { value: 'melody' } });
+      fireEvent.click(screen.getByTestId('help-back-button'));
+
+      expect(searchInput).toHaveValue('');
+      expect(screen.getByText('Help Center')).toBeInTheDocument();
+    });
+
+    it('can navigate to topic from search results', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const searchInput = screen.getByTestId('help-search-input');
+      fireEvent.change(searchInput, { target: { value: 'Ghost Note' } });
+
+      // Click on a search result
+      const firstResult = screen.getByTestId('help-search-result-what-is-ghost-note');
+      fireEvent.click(firstResult);
+
+      // Should show topic detail - verify via the test ID for HelpSection
+      expect(screen.getByTestId('help-section-what-is-ghost-note')).toBeInTheDocument();
+    });
+  });
+
+  describe('initial props', () => {
+    it('opens to categories view initially', () => {
+      render(<HelpPanel {...defaultProps} initialCategory="analysis" />);
+
+      // Open panel should start at categories view
+      expect(screen.getByText('Help Center')).toBeInTheDocument();
+    });
+
+    it('accepts initialTopic prop', () => {
+      // The initialTopic prop is used to navigate to a topic on open transition
+      // For a fresh render, it's processed when the panel opens
+      render(<HelpPanel {...defaultProps} initialTopic="what-is-ghost-note" />);
+
+      // Panel should render and accept the prop
+      expect(screen.getByTestId('help-panel')).toBeInTheDocument();
+    });
+  });
+
+  describe('close behavior', () => {
+    it('calls onClose when close button is clicked', () => {
+      const onClose = vi.fn();
+      render(<HelpPanel isOpen={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByTestId('help-close-button'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when overlay is clicked', () => {
+      const onClose = vi.fn();
+      render(<HelpPanel isOpen={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByTestId('help-panel-overlay'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose when panel content is clicked', () => {
+      const onClose = vi.fn();
+      render(<HelpPanel isOpen={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByTestId('help-panel'));
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('body scroll prevention', () => {
+    it('prevents body scroll when open', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      expect(document.body.style.overflow).toBe('hidden');
+    });
+
+    it('restores body scroll when closed', () => {
+      const { rerender } = render(<HelpPanel {...defaultProps} />);
+
+      expect(document.body.style.overflow).toBe('hidden');
+
+      rerender(<HelpPanel {...defaultProps} isOpen={false} />);
+
+      expect(document.body.style.overflow).toBe('');
+    });
+  });
+
+  describe('state reset on close/open', () => {
+    it('resets to categories view when reopened', async () => {
+      const { rerender } = render(<HelpPanel {...defaultProps} />);
+
+      // Navigate to a category
+      fireEvent.click(screen.getByTestId(`help-category-${HELP_CATEGORIES[0].id}`));
+
+      // Close panel
+      rerender(<HelpPanel {...defaultProps} isOpen={false} />);
+
+      // Reopen panel
+      rerender(<HelpPanel {...defaultProps} isOpen={true} />);
+
+      // Should be back at categories
+      expect(screen.getByText('Help Center')).toBeInTheDocument();
+    });
+
+    it('clears search when reopened', async () => {
+      const { rerender } = render(<HelpPanel {...defaultProps} />);
+
+      // Perform a search
+      const searchInput = screen.getByTestId('help-search-input');
+      fireEvent.change(searchInput, { target: { value: 'test' } });
+
+      // Close panel
+      rerender(<HelpPanel {...defaultProps} isOpen={false} />);
+
+      // Reopen panel
+      rerender(<HelpPanel {...defaultProps} isOpen={true} />);
+
+      // Search should be cleared
+      expect(screen.getByTestId('help-search-input')).toHaveValue('');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has role="dialog"', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      expect(screen.getByTestId('help-panel')).toHaveAttribute('role', 'dialog');
+    });
+
+    it('has aria-modal="true"', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      expect(screen.getByTestId('help-panel')).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('has aria-labelledby pointing to title', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      expect(screen.getByTestId('help-panel')).toHaveAttribute(
+        'aria-labelledby',
+        'help-panel-title'
+      );
+    });
+
+    it('close button has aria-label', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      expect(screen.getByTestId('help-close-button')).toHaveAttribute(
+        'aria-label',
+        'Close help'
+      );
+    });
+
+    it('back button has aria-label', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId(`help-category-${HELP_CATEGORIES[0].id}`));
+
+      expect(screen.getByTestId('help-back-button')).toHaveAttribute(
+        'aria-label',
+        'Go back'
+      );
+    });
+
+    it('search input has aria-label', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      expect(screen.getByTestId('help-search-input')).toHaveAttribute(
+        'aria-label',
+        'Search help topics'
+      );
+    });
+  });
+
+  describe('topic display', () => {
+    it('shows topic summaries in list view', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const firstCategory = HELP_CATEGORIES[0];
+      fireEvent.click(screen.getByTestId(`help-category-${firstCategory.id}`));
+
+      const topics = getTopicsByCategory(firstCategory.id);
+      topics.forEach((topic) => {
+        expect(screen.getByText(topic.summary)).toBeInTheDocument();
+      });
+    });
+
+    it('shows topic category badge in search results', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const searchInput = screen.getByTestId('help-search-input');
+      fireEvent.change(searchInput, { target: { value: 'melody' } });
+
+      // Search results should show the category badge
+      const categoryBadges = document.querySelectorAll('.help-panel__topic-category');
+      expect(categoryBadges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles rapid category switching', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      HELP_CATEGORIES.forEach((category) => {
+        fireEvent.click(screen.getByTestId(`help-category-${category.id}`));
+        fireEvent.click(screen.getByTestId('help-back-button'));
+      });
+
+      expect(screen.getByText('Help Center')).toBeInTheDocument();
+    });
+
+    it('handles opening panel multiple times', () => {
+      const { rerender } = render(<HelpPanel {...defaultProps} isOpen={false} />);
+
+      for (let i = 0; i < 5; i++) {
+        rerender(<HelpPanel {...defaultProps} isOpen={true} />);
+        rerender(<HelpPanel {...defaultProps} isOpen={false} />);
+      }
+
+      rerender(<HelpPanel {...defaultProps} isOpen={true} />);
+      expect(screen.getByTestId('help-panel')).toBeInTheDocument();
+    });
+
+    it('handles empty search results gracefully', () => {
+      render(<HelpPanel {...defaultProps} />);
+
+      const searchInput = screen.getByTestId('help-search-input');
+      fireEvent.change(searchInput, { target: { value: 'zzznonexistent999' } });
+
+      expect(screen.getByText(/No results found/)).toBeInTheDocument();
+      expect(screen.getByText(/Try different keywords/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/Help/HelpPanel.tsx
+++ b/web/src/components/Help/HelpPanel.tsx
@@ -1,0 +1,549 @@
+/**
+ * HelpPanel Component
+ *
+ * A sliding drawer that provides access to all help documentation.
+ * Features search, category navigation, and topic browsing.
+ *
+ * @module components/Help/HelpPanel
+ */
+
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  type ReactElement,
+  type ChangeEvent,
+} from 'react';
+import { useFocusTrap } from '@/hooks';
+import {
+  HELP_CATEGORIES,
+  HELP_TOPICS,
+  searchTopics,
+  getTopicsByCategory,
+  type HelpCategory,
+  type HelpTopic,
+} from './helpContent';
+import { HelpSection } from './HelpSection';
+import { FAQ } from './FAQ';
+import './HelpPanel.css';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[HelpPanel] ${message}`, ...args);
+  }
+};
+
+/**
+ * Props for HelpPanel component
+ */
+export interface HelpPanelProps {
+  /** Whether the panel is open */
+  isOpen: boolean;
+  /** Callback to close the panel */
+  onClose: () => void;
+  /** Initial category to show (optional) */
+  initialCategory?: HelpCategory;
+  /** Initial topic ID to show (optional) */
+  initialTopic?: string;
+}
+
+/**
+ * Panel view modes
+ */
+type ViewMode = 'categories' | 'topics' | 'topic' | 'faq' | 'search';
+
+/**
+ * Category icons as SVG components
+ */
+function CategoryIcon({ icon }: { icon: string }): ReactElement {
+  switch (icon) {
+    case 'rocket':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+          <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+          <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
+          <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+        </svg>
+      );
+    case 'chart':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <line x1="18" y1="20" x2="18" y2="10" />
+          <line x1="12" y1="20" x2="12" y2="4" />
+          <line x1="6" y1="20" x2="6" y2="14" />
+        </svg>
+      );
+    case 'lightbulb':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
+          <path d="M9 18h6" />
+          <path d="M10 22h4" />
+        </svg>
+      );
+    case 'music':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M9 18V5l12-2v13" />
+          <circle cx="6" cy="18" r="3" />
+          <circle cx="18" cy="16" r="3" />
+        </svg>
+      );
+    case 'microphone':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+          <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+          <line x1="12" y1="19" x2="12" y2="23" />
+          <line x1="8" y1="23" x2="16" y2="23" />
+        </svg>
+      );
+    case 'keyboard':
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="2" y="4" width="20" height="16" rx="2" ry="2" />
+          <line x1="6" y1="8" x2="6" y2="8" />
+          <line x1="10" y1="8" x2="10" y2="8" />
+          <line x1="14" y1="8" x2="14" y2="8" />
+          <line x1="18" y1="8" x2="18" y2="8" />
+          <line x1="8" y1="12" x2="8" y2="12" />
+          <line x1="12" y1="12" x2="12" y2="12" />
+          <line x1="16" y1="12" x2="16" y2="12" />
+          <line x1="7" y1="16" x2="17" y2="16" />
+        </svg>
+      );
+    default:
+      return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" />
+          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+      );
+  }
+}
+
+/**
+ * Back arrow icon
+ */
+function BackIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="19" y1="12" x2="5" y2="12" />
+      <polyline points="12 19 5 12 12 5" />
+    </svg>
+  );
+}
+
+/**
+ * Close icon
+ */
+function CloseIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+/**
+ * Search icon
+ */
+function SearchIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  );
+}
+
+/**
+ * FAQ icon
+ */
+function FAQIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
+/**
+ * HelpPanel provides a comprehensive help system with search and navigation.
+ *
+ * Features:
+ * - Category-based navigation
+ * - Full-text search across all topics
+ * - Topic detail view with related topics
+ * - FAQ section
+ * - Keyboard navigation and focus trapping
+ *
+ * @example
+ * ```tsx
+ * <HelpPanel
+ *   isOpen={showHelp}
+ *   onClose={() => setShowHelp(false)}
+ * />
+ * ```
+ */
+export function HelpPanel({
+  isOpen,
+  onClose,
+  initialCategory,
+  initialTopic,
+}: HelpPanelProps): ReactElement | null {
+  // View state
+  const [viewMode, setViewMode] = useState<ViewMode>('categories');
+  const [selectedCategory, setSelectedCategory] = useState<HelpCategory | null>(
+    initialCategory ?? null
+  );
+  const [selectedTopic, setSelectedTopic] = useState<HelpTopic | null>(null);
+
+  // Search state
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<HelpTopic[]>([]);
+
+  // Track previous isOpen state with a ref
+  const wasOpenRef = useRef(isOpen);
+
+  log('Rendering HelpPanel:', { isOpen, viewMode, selectedCategory });
+
+  // Focus trap for the panel
+  const { containerRef } = useFocusTrap({
+    enabled: isOpen,
+    autoFocus: true,
+    returnFocus: true,
+    initialFocusSelector: '[data-testid="help-search-input"]',
+    onEscape: onClose,
+  });
+
+  // Handle panel open/close transitions
+  // This effect uses a ref to track previous state and only sets state when panel opens
+  useEffect(() => {
+    const wasOpen = wasOpenRef.current;
+    wasOpenRef.current = isOpen;
+
+    // Panel just opened - initialize with initial topic if provided
+    if (isOpen && !wasOpen && initialTopic) {
+      const topic = HELP_TOPICS.find((t) => t.id === initialTopic);
+      if (topic) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: initializing state on panel open
+        setViewMode('topic');
+         
+        setSelectedCategory(topic.category);
+         
+        setSelectedTopic(topic);
+      }
+    }
+    // Panel just closed - reset state for next open
+    if (!isOpen && wasOpen) {
+       
+      setViewMode('categories');
+       
+      setSelectedCategory(initialCategory ?? null);
+       
+      setSelectedTopic(null);
+       
+      setSearchQuery('');
+       
+      setSearchResults([]);
+    }
+  }, [isOpen, initialTopic, initialCategory]);
+
+  // Prevent body scroll when panel is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  // Handle search
+  const handleSearch = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const query = e.target.value;
+    setSearchQuery(query);
+
+    if (query.trim()) {
+      const results = searchTopics(query);
+      setSearchResults(results);
+      setViewMode('search');
+    } else {
+      setSearchResults([]);
+      setViewMode('categories');
+    }
+  }, []);
+
+  // Handle category selection
+  const handleCategorySelect = useCallback((category: HelpCategory) => {
+    log('Category selected:', category);
+    setSelectedCategory(category);
+    setViewMode('topics');
+    setSearchQuery('');
+  }, []);
+
+  // Handle topic selection
+  const handleTopicSelect = useCallback((topic: HelpTopic) => {
+    log('Topic selected:', topic.id);
+    setSelectedTopic(topic);
+    setViewMode('topic');
+  }, []);
+
+  // Handle back navigation
+  const handleBack = useCallback(() => {
+    log('Back clicked, current view:', viewMode);
+    if (viewMode === 'topic') {
+      if (selectedCategory) {
+        setViewMode('topics');
+      } else {
+        setViewMode('categories');
+      }
+      setSelectedTopic(null);
+    } else if (viewMode === 'topics') {
+      setViewMode('categories');
+      setSelectedCategory(null);
+    } else if (viewMode === 'faq') {
+      setViewMode('categories');
+    } else if (viewMode === 'search') {
+      setSearchQuery('');
+      setSearchResults([]);
+      setViewMode('categories');
+    }
+  }, [viewMode, selectedCategory]);
+
+  // Handle FAQ navigation
+  const handleFAQClick = useCallback(() => {
+    log('FAQ clicked');
+    setViewMode('faq');
+    setSearchQuery('');
+  }, []);
+
+  // Handle overlay click
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        log('Overlay clicked, closing panel');
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  // Don't render if not open
+  if (!isOpen) {
+    return null;
+  }
+
+  // Get current title based on view
+  const getTitle = (): string => {
+    switch (viewMode) {
+      case 'categories':
+        return 'Help Center';
+      case 'topics':
+        return (
+          HELP_CATEGORIES.find((c) => c.id === selectedCategory)?.title ?? 'Help'
+        );
+      case 'topic':
+        return selectedTopic?.title ?? 'Help';
+      case 'faq':
+        return 'Frequently Asked Questions';
+      case 'search':
+        return 'Search Results';
+      default:
+        return 'Help';
+    }
+  };
+
+  // Render categories view
+  const renderCategories = (): ReactElement => (
+    <div className="help-panel__categories">
+      {HELP_CATEGORIES.map((category) => (
+        <button
+          key={category.id}
+          type="button"
+          className="help-panel__category-card"
+          onClick={() => handleCategorySelect(category.id)}
+          data-testid={`help-category-${category.id}`}
+        >
+          <div className="help-panel__category-icon">
+            <CategoryIcon icon={category.icon} />
+          </div>
+          <div className="help-panel__category-content">
+            <h3 className="help-panel__category-title">{category.title}</h3>
+            <p className="help-panel__category-description">
+              {category.description}
+            </p>
+          </div>
+        </button>
+      ))}
+
+      {/* FAQ quick link */}
+      <button
+        type="button"
+        className="help-panel__category-card help-panel__category-card--faq"
+        onClick={handleFAQClick}
+        data-testid="help-faq-link"
+      >
+        <div className="help-panel__category-icon">
+          <FAQIcon />
+        </div>
+        <div className="help-panel__category-content">
+          <h3 className="help-panel__category-title">FAQ</h3>
+          <p className="help-panel__category-description">
+            Common questions and answers
+          </p>
+        </div>
+      </button>
+    </div>
+  );
+
+  // Render topics list
+  const renderTopics = (): ReactElement => {
+    const topics = selectedCategory ? getTopicsByCategory(selectedCategory) : [];
+
+    return (
+      <div className="help-panel__topics">
+        {topics.map((topic) => (
+          <button
+            key={topic.id}
+            type="button"
+            className="help-panel__topic-item"
+            onClick={() => handleTopicSelect(topic)}
+            data-testid={`help-topic-${topic.id}`}
+          >
+            <h4 className="help-panel__topic-title">{topic.title}</h4>
+            <p className="help-panel__topic-summary">{topic.summary}</p>
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  // Render search results
+  const renderSearchResults = (): ReactElement => (
+    <div className="help-panel__search-results">
+      {searchResults.length === 0 ? (
+        <div className="help-panel__no-results">
+          <p>No results found for "{searchQuery}"</p>
+          <p className="help-panel__no-results-hint">
+            Try different keywords or browse categories
+          </p>
+        </div>
+      ) : (
+        <>
+          <p className="help-panel__result-count">
+            {searchResults.length} result{searchResults.length !== 1 ? 's' : ''}{' '}
+            for "{searchQuery}"
+          </p>
+          {searchResults.map((topic) => (
+            <button
+              key={topic.id}
+              type="button"
+              className="help-panel__topic-item"
+              onClick={() => handleTopicSelect(topic)}
+              data-testid={`help-search-result-${topic.id}`}
+            >
+              <h4 className="help-panel__topic-title">{topic.title}</h4>
+              <p className="help-panel__topic-summary">{topic.summary}</p>
+              <span className="help-panel__topic-category">
+                {HELP_CATEGORIES.find((c) => c.id === topic.category)?.title}
+              </span>
+            </button>
+          ))}
+        </>
+      )}
+    </div>
+  );
+
+  return (
+    <div
+      className="help-panel__overlay"
+      onClick={handleOverlayClick}
+      data-testid="help-panel-overlay"
+    >
+      <div
+        ref={containerRef as React.RefObject<HTMLDivElement>}
+        className="help-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="help-panel-title"
+        data-testid="help-panel"
+      >
+        {/* Header */}
+        <div className="help-panel__header">
+          <div className="help-panel__header-left">
+            {viewMode !== 'categories' && (
+              <button
+                type="button"
+                className="help-panel__back-button"
+                onClick={handleBack}
+                aria-label="Go back"
+                data-testid="help-back-button"
+              >
+                <BackIcon />
+              </button>
+            )}
+            <h2 id="help-panel-title" className="help-panel__title">
+              {getTitle()}
+            </h2>
+          </div>
+          <button
+            type="button"
+            className="help-panel__close-button"
+            onClick={onClose}
+            aria-label="Close help"
+            data-testid="help-close-button"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="help-panel__search">
+          <SearchIcon />
+          <input
+            type="search"
+            placeholder="Search help topics..."
+            value={searchQuery}
+            onChange={handleSearch}
+            className="help-panel__search-input"
+            data-testid="help-search-input"
+            aria-label="Search help topics"
+          />
+        </div>
+
+        {/* Content */}
+        <div className="help-panel__content">
+          {viewMode === 'categories' && renderCategories()}
+          {viewMode === 'topics' && renderTopics()}
+          {viewMode === 'topic' && selectedTopic && (
+            <HelpSection
+              topic={selectedTopic}
+              onTopicSelect={handleTopicSelect}
+            />
+          )}
+          {viewMode === 'faq' && <FAQ onTopicSelect={handleTopicSelect} />}
+          {viewMode === 'search' && renderSearchResults()}
+        </div>
+
+        {/* Footer */}
+        <div className="help-panel__footer">
+          <p className="help-panel__footer-text">
+            Press <kbd>?</kbd> anytime to open this help panel
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default HelpPanel;

--- a/web/src/components/Help/HelpSection.css
+++ b/web/src/components/Help/HelpSection.css
@@ -1,0 +1,224 @@
+/**
+ * HelpSection Styles
+ *
+ * Styles for the topic-specific help content component.
+ */
+
+.help-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Category badge */
+.help-section__category-badge {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-primary, #3b82f6);
+  background-color: var(--color-primary-subtle, #eff6ff);
+  border-radius: 4px;
+}
+
+/* Title */
+.help-section__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #111827);
+  line-height: 1.3;
+}
+
+/* Summary */
+.help-section__summary {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-style: italic;
+  color: var(--color-text-secondary, #6b7280);
+  line-height: 1.5;
+  border-left: 3px solid var(--color-primary, #3b82f6);
+  padding-left: 0.875rem;
+}
+
+/* Content */
+.help-section__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.help-section__paragraph {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--color-text-primary, #374151);
+  line-height: 1.65;
+}
+
+.help-section__paragraph strong {
+  font-weight: 600;
+  color: var(--color-text-primary, #111827);
+}
+
+.help-section__subheading {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #111827);
+}
+
+/* Lists */
+.help-section__list {
+  margin: 0;
+  padding-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.help-section__list li {
+  font-size: 0.9375rem;
+  color: var(--color-text-primary, #374151);
+  line-height: 1.5;
+}
+
+.help-section__list li strong {
+  font-weight: 600;
+  color: var(--color-text-primary, #111827);
+}
+
+.help-section__list--ordered {
+  list-style-type: decimal;
+}
+
+/* Related topics */
+.help-section__related {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+.help-section__related-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.75rem 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted, #9ca3af);
+}
+
+.help-section__related-title svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.help-section__related-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.help-section__related-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 0.875rem;
+  background-color: var(--color-surface-elevated, #f9fafb);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  width: 100%;
+  text-align: left;
+}
+
+.help-section__related-item:hover {
+  background-color: var(--color-hover, #f3f4f6);
+  border-color: var(--color-border-hover, #d1d5db);
+}
+
+.help-section__related-item:focus {
+  outline: 2px solid var(--color-primary, #3b82f6);
+  outline-offset: 2px;
+}
+
+.help-section__related-item-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #374151);
+}
+
+.help-section__related-item-arrow {
+  font-size: 0.875rem;
+  color: var(--color-text-muted, #9ca3af);
+}
+
+/* Keywords (hidden but present for search engines/screen readers) */
+.help-section__keywords {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Dark mode */
+.dark .help-section__category-badge {
+  background-color: rgba(59, 130, 246, 0.15);
+}
+
+.dark .help-section__title {
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .help-section__summary {
+  color: var(--color-text-secondary-dark, #9ca3af);
+}
+
+.dark .help-section__paragraph,
+.dark .help-section__list li {
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .help-section__paragraph strong,
+.dark .help-section__list li strong,
+.dark .help-section__subheading {
+  color: var(--color-text-primary-dark, #f9fafb);
+}
+
+.dark .help-section__related {
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .help-section__related-title {
+  color: var(--color-text-muted-dark, #6b7280);
+}
+
+.dark .help-section__related-item {
+  background-color: var(--color-surface-elevated-dark, #111827);
+  border-color: var(--color-border-dark, #374151);
+}
+
+.dark .help-section__related-item:hover {
+  background-color: var(--color-hover-dark, #1f2937);
+  border-color: var(--color-border-hover-dark, #4b5563);
+}
+
+.dark .help-section__related-item-title {
+  color: var(--color-text-primary-dark, #e5e7eb);
+}
+
+.dark .help-section__related-item-arrow {
+  color: var(--color-text-muted-dark, #6b7280);
+}

--- a/web/src/components/Help/HelpSection.test.tsx
+++ b/web/src/components/Help/HelpSection.test.tsx
@@ -1,0 +1,375 @@
+/**
+ * Tests for HelpSection Component
+ *
+ * @module components/Help/HelpSection.test
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { HelpSection, type HelpSectionProps } from './HelpSection';
+import { HELP_TOPICS, getTopicById, HELP_CATEGORIES } from './helpContent';
+
+describe('HelpSection', () => {
+  // Get a topic with related topics for testing
+  const topicWithRelated = HELP_TOPICS.find((t) => t.related && t.related.length > 0);
+  const topicWithoutRelated = HELP_TOPICS.find((t) => !t.related || t.related.length === 0);
+
+  const defaultTopic = getTopicById('what-is-ghost-note')!;
+
+  const defaultProps: HelpSectionProps = {
+    topic: defaultTopic,
+  };
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('rendering', () => {
+    it('renders the HelpSection component', () => {
+      render(<HelpSection {...defaultProps} />);
+      expect(screen.getByTestId(`help-section-${defaultTopic.id}`)).toBeInTheDocument();
+    });
+
+    it('renders as an article element', () => {
+      render(<HelpSection {...defaultProps} />);
+      const section = screen.getByTestId(`help-section-${defaultTopic.id}`);
+      expect(section.tagName.toLowerCase()).toBe('article');
+    });
+
+    it('renders the topic title', () => {
+      render(<HelpSection {...defaultProps} />);
+      expect(screen.getByText(defaultTopic.title)).toBeInTheDocument();
+    });
+
+    it('renders the topic summary', () => {
+      render(<HelpSection {...defaultProps} />);
+      expect(screen.getByText(defaultTopic.summary)).toBeInTheDocument();
+    });
+
+    it('renders the category badge', () => {
+      render(<HelpSection {...defaultProps} />);
+      const category = HELP_CATEGORIES.find((c) => c.id === defaultTopic.category);
+      if (category) {
+        expect(screen.getByText(category.title)).toBeInTheDocument();
+      }
+    });
+
+    it('renders the keywords section', () => {
+      render(<HelpSection {...defaultProps} />);
+      expect(screen.getByText(/Keywords:/)).toBeInTheDocument();
+      defaultTopic.keywords.forEach((keyword) => {
+        expect(screen.getByText(/Keywords:/).textContent).toContain(keyword);
+      });
+    });
+  });
+
+  describe('content formatting', () => {
+    it('parses bold text correctly', () => {
+      // Create a topic with bold text
+      const topicWithBold = {
+        ...defaultTopic,
+        content: 'This is **bold** text',
+      };
+
+      render(<HelpSection topic={topicWithBold} />);
+
+      const strongElements = document.querySelectorAll('strong');
+      const boldText = Array.from(strongElements).find(
+        (el) => el.textContent === 'bold'
+      );
+      expect(boldText).toBeInTheDocument();
+    });
+
+    it('parses bullet lists correctly', () => {
+      const topicWithList = {
+        ...defaultTopic,
+        content: '- Item one\n- Item two\n- Item three',
+      };
+
+      render(<HelpSection topic={topicWithList} />);
+
+      const lists = document.querySelectorAll('ul');
+      expect(lists.length).toBeGreaterThan(0);
+
+      const listItems = document.querySelectorAll('li');
+      expect(listItems.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('parses numbered lists correctly', () => {
+      const topicWithNumberedList = {
+        ...defaultTopic,
+        content: '1. First item\n2. Second item\n3. Third item',
+      };
+
+      render(<HelpSection topic={topicWithNumberedList} />);
+
+      const orderedLists = document.querySelectorAll('ol');
+      expect(orderedLists.length).toBeGreaterThan(0);
+    });
+
+    it('parses headers (bold lines) correctly', () => {
+      const topicWithHeader = {
+        ...defaultTopic,
+        content: '**Section Title**\n\nSome content here',
+      };
+
+      render(<HelpSection topic={topicWithHeader} />);
+
+      const headers = document.querySelectorAll('h4.help-section__subheading');
+      expect(headers.length).toBeGreaterThan(0);
+      expect(headers[0].textContent).toBe('Section Title');
+    });
+
+    it('renders plain paragraphs', () => {
+      const topicWithParagraph = {
+        ...defaultTopic,
+        content: 'This is a plain paragraph.',
+      };
+
+      render(<HelpSection topic={topicWithParagraph} />);
+
+      const paragraphs = document.querySelectorAll('p.help-section__paragraph');
+      expect(paragraphs.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('related topics', () => {
+    it('renders related topics section when topic has related and onTopicSelect provided', () => {
+      if (!topicWithRelated) {
+        return; // Skip if no topic with related exists
+      }
+
+      const mockOnTopicSelect = vi.fn();
+      render(
+        <HelpSection
+          topic={topicWithRelated}
+          onTopicSelect={mockOnTopicSelect}
+        />
+      );
+
+      expect(screen.getByText('Related Topics')).toBeInTheDocument();
+    });
+
+    it('does not render related topics when onTopicSelect is not provided', () => {
+      if (!topicWithRelated) {
+        return;
+      }
+
+      render(<HelpSection topic={topicWithRelated} />);
+
+      expect(screen.queryByText('Related Topics')).not.toBeInTheDocument();
+    });
+
+    it('does not render related topics when topic has no related', () => {
+      if (!topicWithoutRelated) {
+        return;
+      }
+
+      const mockOnTopicSelect = vi.fn();
+      render(
+        <HelpSection
+          topic={topicWithoutRelated}
+          onTopicSelect={mockOnTopicSelect}
+        />
+      );
+
+      expect(screen.queryByText('Related Topics')).not.toBeInTheDocument();
+    });
+
+    it('renders related topic buttons', () => {
+      if (!topicWithRelated || !topicWithRelated.related) {
+        return;
+      }
+
+      const mockOnTopicSelect = vi.fn();
+      render(
+        <HelpSection
+          topic={topicWithRelated}
+          onTopicSelect={mockOnTopicSelect}
+        />
+      );
+
+      topicWithRelated.related.forEach((relatedId) => {
+        const relatedTopic = getTopicById(relatedId);
+        if (relatedTopic) {
+          expect(
+            screen.getByTestId(`help-related-${relatedId}`)
+          ).toBeInTheDocument();
+        }
+      });
+    });
+
+    it('calls onTopicSelect when related topic is clicked', () => {
+      if (!topicWithRelated || !topicWithRelated.related) {
+        return;
+      }
+
+      const mockOnTopicSelect = vi.fn();
+      render(
+        <HelpSection
+          topic={topicWithRelated}
+          onTopicSelect={mockOnTopicSelect}
+        />
+      );
+
+      const firstRelatedId = topicWithRelated.related[0];
+      const relatedButton = screen.getByTestId(`help-related-${firstRelatedId}`);
+
+      fireEvent.click(relatedButton);
+
+      expect(mockOnTopicSelect).toHaveBeenCalledTimes(1);
+      expect(mockOnTopicSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ id: firstRelatedId })
+      );
+    });
+
+    it('shows related topic title in button', () => {
+      if (!topicWithRelated || !topicWithRelated.related) {
+        return;
+      }
+
+      const mockOnTopicSelect = vi.fn();
+      render(
+        <HelpSection
+          topic={topicWithRelated}
+          onTopicSelect={mockOnTopicSelect}
+        />
+      );
+
+      const firstRelatedId = topicWithRelated.related[0];
+      const relatedTopic = getTopicById(firstRelatedId);
+      if (relatedTopic) {
+        expect(screen.getByText(relatedTopic.title)).toBeInTheDocument();
+      }
+    });
+  });
+
+  describe('accessibility', () => {
+    it('keywords section is hidden from screen readers', () => {
+      render(<HelpSection {...defaultProps} />);
+      const keywords = document.querySelector('.help-section__keywords');
+      expect(keywords).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('link icon is hidden from screen readers', () => {
+      if (!topicWithRelated) {
+        return;
+      }
+
+      const mockOnTopicSelect = vi.fn();
+      render(
+        <HelpSection
+          topic={topicWithRelated}
+          onTopicSelect={mockOnTopicSelect}
+        />
+      );
+
+      const svg = document.querySelector('.help-section__related-title svg');
+      if (svg) {
+        expect(svg).toHaveAttribute('aria-hidden', 'true');
+      }
+    });
+
+    it('related topic buttons have type="button"', () => {
+      if (!topicWithRelated || !topicWithRelated.related) {
+        return;
+      }
+
+      const mockOnTopicSelect = vi.fn();
+      render(
+        <HelpSection
+          topic={topicWithRelated}
+          onTopicSelect={mockOnTopicSelect}
+        />
+      );
+
+      const firstRelatedId = topicWithRelated.related[0];
+      const relatedButton = screen.getByTestId(`help-related-${firstRelatedId}`);
+      expect(relatedButton).toHaveAttribute('type', 'button');
+    });
+  });
+
+  describe('different topics', () => {
+    it('renders correctly for each category', () => {
+      HELP_CATEGORIES.forEach((category) => {
+        const topicInCategory = HELP_TOPICS.find((t) => t.category === category.id);
+        if (topicInCategory) {
+          const { unmount } = render(<HelpSection topic={topicInCategory} />);
+          expect(
+            screen.getByTestId(`help-section-${topicInCategory.id}`)
+          ).toBeInTheDocument();
+          unmount();
+        }
+      });
+    });
+
+    it('updates when topic prop changes', () => {
+      const firstTopic = HELP_TOPICS[0];
+      const secondTopic = HELP_TOPICS[1];
+
+      const { rerender } = render(<HelpSection topic={firstTopic} />);
+      expect(screen.getByText(firstTopic.title)).toBeInTheDocument();
+
+      rerender(<HelpSection topic={secondTopic} />);
+      expect(screen.getByText(secondTopic.title)).toBeInTheDocument();
+      expect(screen.queryByText(firstTopic.title)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('complex content parsing', () => {
+    it('handles multiple bold sections', () => {
+      const topicWithMultipleBold = {
+        ...defaultTopic,
+        content: '**First** and **second** bold items',
+      };
+
+      render(<HelpSection topic={topicWithMultipleBold} />);
+
+      const strongElements = document.querySelectorAll('strong');
+      expect(strongElements.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('handles mixed content types', () => {
+      const topicWithMixedContent = {
+        ...defaultTopic,
+        content: `**Header Section**
+
+Some intro text here.
+
+- First bullet
+- Second bullet
+
+1. Numbered one
+2. Numbered two
+
+More paragraph text with **bold** words.`,
+      };
+
+      render(<HelpSection topic={topicWithMixedContent} />);
+
+      // Should have headers
+      expect(document.querySelectorAll('h4').length).toBeGreaterThan(0);
+
+      // Should have lists
+      expect(document.querySelectorAll('ul').length).toBeGreaterThan(0);
+      expect(document.querySelectorAll('ol').length).toBeGreaterThan(0);
+
+      // Should have paragraphs
+      expect(document.querySelectorAll('p.help-section__paragraph').length).toBeGreaterThan(0);
+    });
+
+    it('handles empty content gracefully', () => {
+      const topicWithEmptyContent = {
+        ...defaultTopic,
+        content: '',
+      };
+
+      render(<HelpSection topic={topicWithEmptyContent} />);
+
+      // Should still render the section
+      expect(
+        screen.getByTestId(`help-section-${topicWithEmptyContent.id}`)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/Help/HelpSection.tsx
+++ b/web/src/components/Help/HelpSection.tsx
@@ -1,0 +1,260 @@
+/**
+ * HelpSection Component
+ *
+ * Renders a single help topic with formatted content and related topics.
+ * Supports markdown-like formatting in the content.
+ *
+ * @module components/Help/HelpSection
+ */
+
+import { useMemo, type ReactElement } from 'react';
+import {
+  type HelpTopic,
+  getRelatedTopics,
+  getCategoryById,
+} from './helpContent';
+import './HelpSection.css';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[HelpSection] ${message}`, ...args);
+  }
+};
+
+/**
+ * Props for HelpSection component
+ */
+export interface HelpSectionProps {
+  /** The topic to display */
+  topic: HelpTopic;
+  /** Callback when a related topic is selected */
+  onTopicSelect?: (topic: HelpTopic) => void;
+}
+
+/**
+ * Parse markdown-like content into React elements
+ *
+ * Supports:
+ * - **bold** text
+ * - Bullet lists (- item)
+ * - Numbered lists (1. item)
+ * - Headers (lines ending with :)
+ */
+function parseContent(content: string): ReactElement[] {
+  const lines = content.split('\n');
+  const elements: ReactElement[] = [];
+  let currentList: { type: 'ul' | 'ol'; items: ReactElement[] } | null = null;
+  let listKey = 0;
+
+  const parseInlineFormatting = (text: string): ReactElement => {
+    // Parse **bold** markers
+    const parts: (string | ReactElement)[] = [];
+    let remaining = text;
+    let key = 0;
+
+    while (remaining.length > 0) {
+      const boldMatch = remaining.match(/\*\*(.+?)\*\*/);
+      if (boldMatch) {
+        const beforeBold = remaining.substring(0, boldMatch.index);
+        if (beforeBold) {
+          parts.push(beforeBold);
+        }
+        parts.push(
+          <strong key={`bold-${key++}`}>{boldMatch[1]}</strong>
+        );
+        remaining = remaining.substring(
+          (boldMatch.index ?? 0) + boldMatch[0].length
+        );
+      } else {
+        parts.push(remaining);
+        break;
+      }
+    }
+
+    return <>{parts}</>;
+  };
+
+  const flushList = (): void => {
+    if (currentList) {
+      if (currentList.type === 'ul') {
+        elements.push(
+          <ul key={`list-${listKey++}`} className="help-section__list">
+            {currentList.items}
+          </ul>
+        );
+      } else {
+        elements.push(
+          <ol key={`list-${listKey++}`} className="help-section__list help-section__list--ordered">
+            {currentList.items}
+          </ol>
+        );
+      }
+      currentList = null;
+    }
+  };
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+
+    // Empty line - flush any current list and add spacing
+    if (!trimmed) {
+      flushList();
+      return;
+    }
+
+    // Bullet list item
+    if (trimmed.startsWith('- ')) {
+      if (!currentList || currentList.type !== 'ul') {
+        flushList();
+        currentList = { type: 'ul', items: [] };
+      }
+      currentList.items.push(
+        <li key={`item-${index}`}>{parseInlineFormatting(trimmed.substring(2))}</li>
+      );
+      return;
+    }
+
+    // Numbered list item
+    const numberedMatch = trimmed.match(/^(\d+)\.\s+(.+)/);
+    if (numberedMatch) {
+      if (!currentList || currentList.type !== 'ol') {
+        flushList();
+        currentList = { type: 'ol', items: [] };
+      }
+      currentList.items.push(
+        <li key={`item-${index}`}>{parseInlineFormatting(numberedMatch[2])}</li>
+      );
+      return;
+    }
+
+    // Regular line - flush any list first
+    flushList();
+
+    // Check if it's a header (bold line or ends with :)
+    if (trimmed.startsWith('**') && trimmed.endsWith('**')) {
+      const headerText = trimmed.slice(2, -2);
+      elements.push(
+        <h4 key={`header-${index}`} className="help-section__subheading">
+          {headerText}
+        </h4>
+      );
+      return;
+    }
+
+    // Regular paragraph
+    elements.push(
+      <p key={`para-${index}`} className="help-section__paragraph">
+        {parseInlineFormatting(trimmed)}
+      </p>
+    );
+  });
+
+  // Flush any remaining list
+  flushList();
+
+  return elements;
+}
+
+/**
+ * Link icon for related topics
+ */
+function LinkIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+/**
+ * HelpSection renders a single help topic with full content.
+ *
+ * Features:
+ * - Markdown-like content formatting
+ * - Bold text, lists, headers
+ * - Related topics section
+ * - Category badge
+ *
+ * @example
+ * ```tsx
+ * <HelpSection
+ *   topic={selectedTopic}
+ *   onTopicSelect={(topic) => setSelectedTopic(topic)}
+ * />
+ * ```
+ */
+export function HelpSection({
+  topic,
+  onTopicSelect,
+}: HelpSectionProps): ReactElement {
+  log('Rendering HelpSection:', topic.id);
+
+  // Parse content into elements
+  const contentElements = useMemo(() => parseContent(topic.content), [topic.content]);
+
+  // Get related topics
+  const relatedTopics = useMemo(() => getRelatedTopics(topic.id), [topic.id]);
+
+  // Get category info
+  const category = getCategoryById(topic.category);
+
+  return (
+    <article className="help-section" data-testid={`help-section-${topic.id}`}>
+      {/* Category badge */}
+      {category && (
+        <span className="help-section__category-badge">
+          {category.title}
+        </span>
+      )}
+
+      {/* Title */}
+      <h3 className="help-section__title">{topic.title}</h3>
+
+      {/* Summary */}
+      <p className="help-section__summary">{topic.summary}</p>
+
+      {/* Main content */}
+      <div className="help-section__content">
+        {contentElements}
+      </div>
+
+      {/* Related topics */}
+      {relatedTopics.length > 0 && onTopicSelect && (
+        <div className="help-section__related">
+          <h4 className="help-section__related-title">
+            <LinkIcon />
+            Related Topics
+          </h4>
+          <div className="help-section__related-list">
+            {relatedTopics.map((relatedTopic) => (
+              <button
+                key={relatedTopic.id}
+                type="button"
+                className="help-section__related-item"
+                onClick={() => onTopicSelect(relatedTopic)}
+                data-testid={`help-related-${relatedTopic.id}`}
+              >
+                <span className="help-section__related-item-title">
+                  {relatedTopic.title}
+                </span>
+                <span className="help-section__related-item-arrow">
+                  &rarr;
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Keywords (for screen readers) */}
+      <div className="help-section__keywords" aria-hidden="true">
+        Keywords: {topic.keywords.join(', ')}
+      </div>
+    </article>
+  );
+}
+
+export default HelpSection;

--- a/web/src/components/Help/TooltipProvider.css
+++ b/web/src/components/Help/TooltipProvider.css
@@ -1,0 +1,176 @@
+/**
+ * TooltipProvider Styles
+ *
+ * Styles for the tooltip system.
+ */
+
+/* Tooltip wrapper - inline display */
+.tooltip-wrapper {
+  display: inline-flex;
+}
+
+/* Tooltip element */
+.tooltip {
+  position: fixed;
+  z-index: 150;
+  display: flex;
+  flex-direction: column;
+  max-width: 280px;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-tooltip-bg, #1f2937);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  opacity: 0;
+  visibility: hidden;
+  transform: scale(0.95);
+  transition: opacity 0.15s ease-out, transform 0.15s ease-out, visibility 0.15s;
+  pointer-events: none;
+}
+
+.tooltip--visible {
+  opacity: 1;
+  visibility: visible;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+/* Position transforms */
+.tooltip--top {
+  transform-origin: bottom center;
+  translate: -50% -100%;
+}
+
+.tooltip--bottom {
+  transform-origin: top center;
+  translate: -50% 0;
+}
+
+.tooltip--left {
+  transform-origin: right center;
+  translate: -100% -50%;
+}
+
+.tooltip--right {
+  transform-origin: left center;
+  translate: 0 -50%;
+}
+
+.tooltip--visible.tooltip--top,
+.tooltip--visible.tooltip--bottom,
+.tooltip--visible.tooltip--left,
+.tooltip--visible.tooltip--right {
+  transform: scale(1);
+}
+
+/* Tooltip content */
+.tooltip__content {
+  font-size: 0.8125rem;
+  color: var(--color-tooltip-text, #f9fafb);
+  line-height: 1.4;
+}
+
+/* Help link */
+.tooltip__help-link {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 0.375rem;
+  padding: 0;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-primary-light, #93c5fd);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.tooltip__help-link:hover {
+  color: var(--color-primary-lighter, #bfdbfe);
+  text-decoration: underline;
+}
+
+/* Arrow */
+.tooltip__arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border: 6px solid transparent;
+}
+
+.tooltip--top .tooltip__arrow {
+  bottom: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: var(--color-tooltip-bg, #1f2937);
+  border-bottom: none;
+}
+
+.tooltip--bottom .tooltip__arrow {
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom-color: var(--color-tooltip-bg, #1f2937);
+  border-top: none;
+}
+
+.tooltip--left .tooltip__arrow {
+  right: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left-color: var(--color-tooltip-bg, #1f2937);
+  border-right: none;
+}
+
+.tooltip--right .tooltip__arrow {
+  left: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-right-color: var(--color-tooltip-bg, #1f2937);
+  border-left: none;
+}
+
+/* Light mode tooltip - still dark background for contrast */
+.light .tooltip {
+  background-color: var(--color-tooltip-bg, #1f2937);
+}
+
+.light .tooltip__content {
+  color: var(--color-tooltip-text, #f9fafb);
+}
+
+/* Dark mode tooltip */
+.dark .tooltip {
+  background-color: var(--color-tooltip-bg-dark, #374151);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.dark .tooltip--top .tooltip__arrow {
+  border-top-color: var(--color-tooltip-bg-dark, #374151);
+}
+
+.dark .tooltip--bottom .tooltip__arrow {
+  border-bottom-color: var(--color-tooltip-bg-dark, #374151);
+}
+
+.dark .tooltip--left .tooltip__arrow {
+  border-left-color: var(--color-tooltip-bg-dark, #374151);
+}
+
+.dark .tooltip--right .tooltip__arrow {
+  border-right-color: var(--color-tooltip-bg-dark, #374151);
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .tooltip {
+    transition: opacity 0.1s;
+    transform: none !important;
+  }
+
+  .tooltip--top,
+  .tooltip--bottom,
+  .tooltip--left,
+  .tooltip--right {
+    transform: none;
+  }
+}

--- a/web/src/components/Help/TooltipProvider.test.tsx
+++ b/web/src/components/Help/TooltipProvider.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Tests for TooltipProvider Component
+ *
+ * @module components/Help/TooltipProvider.test
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import {
+  TooltipProvider,
+  Tooltip,
+  useTooltip,
+} from './TooltipProvider';
+
+// Helper component to access tooltip context
+function TestTooltipConsumer(): React.ReactElement {
+  const { showTooltip, hideTooltip, isShown } = useTooltip();
+
+  return (
+    <div>
+      <button
+        data-testid="trigger-show"
+        onMouseEnter={(e) => {
+          showTooltip(
+            { id: 'test-tooltip', content: 'Test tooltip content' },
+            e.currentTarget
+          );
+        }}
+        onMouseLeave={() => hideTooltip('test-tooltip')}
+      >
+        Trigger
+      </button>
+      <span data-testid="is-shown">{isShown('test-tooltip') ? 'shown' : 'hidden'}</span>
+    </div>
+  );
+}
+
+describe('TooltipProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  describe('rendering', () => {
+    it('renders children', () => {
+      render(
+        <TooltipProvider>
+          <div data-testid="child">Child content</div>
+        </TooltipProvider>
+      );
+
+      expect(screen.getByTestId('child')).toBeInTheDocument();
+    });
+
+    it('does not render tooltip initially', () => {
+      render(
+        <TooltipProvider>
+          <div>Content</div>
+        </TooltipProvider>
+      );
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('context functionality', () => {
+    it('provides showTooltip function', () => {
+      render(
+        <TooltipProvider>
+          <TestTooltipConsumer />
+        </TooltipProvider>
+      );
+
+      expect(screen.getByTestId('trigger-show')).toBeInTheDocument();
+    });
+
+    it('provides hideTooltip function', () => {
+      render(
+        <TooltipProvider>
+          <TestTooltipConsumer />
+        </TooltipProvider>
+      );
+
+      // The trigger can be used to test hideTooltip
+      const trigger = screen.getByTestId('trigger-show');
+      expect(trigger).toBeInTheDocument();
+    });
+
+    it('provides isShown function', () => {
+      render(
+        <TooltipProvider>
+          <TestTooltipConsumer />
+        </TooltipProvider>
+      );
+
+      const isShownIndicator = screen.getByTestId('is-shown');
+      // Initially not shown
+      expect(isShownIndicator).toHaveTextContent('hidden');
+    });
+  });
+
+  describe('Tooltip component', () => {
+    it('renders wrapper around children', () => {
+      render(
+        <TooltipProvider>
+          <Tooltip content="Test content">
+            <button data-testid="wrapped-button">Button</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      expect(screen.getByTestId('wrapped-button')).toBeInTheDocument();
+    });
+
+    it('wraps child in span with tooltip-wrapper class', () => {
+      render(
+        <TooltipProvider>
+          <Tooltip content="Hover tooltip">
+            <button data-testid="hover-button">Hover me</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      const wrapper = screen.getByTestId('hover-button').parentElement;
+      expect(wrapper).toHaveClass('tooltip-wrapper');
+    });
+
+    it('attaches mouse event handlers', () => {
+      render(
+        <TooltipProvider>
+          <Tooltip content="Focus tooltip">
+            <button data-testid="focus-button">Focus me</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      const wrapper = screen.getByTestId('focus-button').parentElement;
+      // Wrapper should exist and be able to receive events
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper?.tagName.toLowerCase()).toBe('span');
+    });
+
+    it('renders disabled state correctly', () => {
+      render(
+        <TooltipProvider>
+          <Tooltip content="Disabled tooltip" disabled>
+            <button data-testid="disabled-tooltip-button">Disabled</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      const wrapper = screen.getByTestId('disabled-tooltip-button').parentElement;
+      // Disabled tooltip should not have aria-describedby
+      expect(wrapper).not.toHaveAttribute('aria-describedby');
+    });
+
+    it('accepts delay prop', () => {
+      render(
+        <TooltipProvider>
+          <Tooltip content="Custom delay tooltip" delay={500}>
+            <button data-testid="delay-button">Custom delay</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      const wrapper = screen.getByTestId('delay-button').parentElement;
+      expect(wrapper).toBeInTheDocument();
+    });
+  });
+
+  describe('tooltip positioning', () => {
+    it('passes position prop to Tooltip', () => {
+      render(
+        <TooltipProvider>
+          <Tooltip content="Position test" position="bottom">
+            <button data-testid="position-button">Position</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      // Tooltip wrapper is rendered
+      const wrapper = screen.getByTestId('position-button').parentElement;
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper).toHaveClass('tooltip-wrapper');
+    });
+  });
+
+  describe('help topic integration', () => {
+    it('accepts helpTopicId prop', () => {
+      const mockOnOpenHelp = vi.fn();
+
+      render(
+        <TooltipProvider onOpenHelp={mockOnOpenHelp}>
+          <Tooltip content="With help" helpTopicId="what-is-ghost-note">
+            <button data-testid="help-button">Help topic</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      // Tooltip wrapper is rendered with aria-describedby
+      const wrapper = screen.getByTestId('help-button').parentElement;
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper).toHaveAttribute('aria-describedby');
+    });
+
+    it('renders without onOpenHelp callback', () => {
+      render(
+        <TooltipProvider>
+          <Tooltip content="No help callback" helpTopicId="what-is-ghost-note">
+            <button data-testid="no-callback-button">No callback</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      // Tooltip wrapper is rendered
+      const wrapper = screen.getByTestId('no-callback-button').parentElement;
+      expect(wrapper).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('wrapper has aria-describedby when not disabled', () => {
+      render(
+        <TooltipProvider>
+          <Tooltip content="Describedby test">
+            <button data-testid="describedby-button">Describedby</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      const wrapper = screen.getByTestId('describedby-button').parentElement;
+      expect(wrapper).toHaveAttribute('aria-describedby');
+    });
+
+    it('wrapper does not have aria-describedby when disabled', () => {
+      render(
+        <TooltipProvider>
+          <Tooltip content="Disabled describedby" disabled>
+            <button data-testid="disabled-describedby-button">Disabled</button>
+          </Tooltip>
+        </TooltipProvider>
+      );
+
+      const wrapper = screen.getByTestId('disabled-describedby-button').parentElement;
+      expect(wrapper).not.toHaveAttribute('aria-describedby');
+    });
+  });
+});
+
+describe('useTooltip', () => {
+  it('provides default context when used outside provider', () => {
+    // This should not throw
+    function TestComponent(): React.ReactElement {
+      const context = useTooltip();
+      return (
+        <div data-testid="context-test">
+          <span>{typeof context.showTooltip}</span>
+          <span>{typeof context.hideTooltip}</span>
+          <span>{typeof context.isShown}</span>
+        </div>
+      );
+    }
+
+    render(<TestComponent />);
+    expect(screen.getByTestId('context-test')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/Help/TooltipProvider.tsx
+++ b/web/src/components/Help/TooltipProvider.tsx
@@ -1,0 +1,448 @@
+/**
+ * TooltipProvider Component
+ *
+ * Provides context-aware tooltips that can be attached to any element.
+ * Supports positioning, delays, and help topic links.
+ *
+ * @module components/Help/TooltipProvider
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  useId,
+  type ReactNode,
+  type ReactElement,
+} from 'react';
+import { getTopicById, type HelpTopic } from './helpContent';
+import './TooltipProvider.css';
+
+// Logging helper for debugging
+const DEBUG = import.meta.env?.DEV ?? false;
+const log = (message: string, ...args: unknown[]): void => {
+  if (DEBUG) {
+    console.log(`[TooltipProvider] ${message}`, ...args);
+  }
+};
+
+/**
+ * Tooltip position options
+ */
+export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
+
+/**
+ * Tooltip configuration
+ */
+export interface TooltipConfig {
+  /** Unique identifier */
+  id: string;
+  /** Tooltip content text */
+  content: string;
+  /** Preferred position */
+  position?: TooltipPosition;
+  /** Delay before showing (ms) */
+  delay?: number;
+  /** Optional help topic ID to link to */
+  helpTopicId?: string;
+  /** Optional aria-describedby target */
+  describedBy?: string;
+}
+
+/**
+ * Active tooltip state
+ */
+interface ActiveTooltip {
+  config: TooltipConfig;
+  rect: DOMRect;
+  helpTopic?: HelpTopic;
+}
+
+/**
+ * Tooltip context type
+ */
+interface TooltipContextType {
+  /** Register a tooltip with its target element */
+  showTooltip: (config: TooltipConfig, element: HTMLElement) => void;
+  /** Hide the currently shown tooltip */
+  hideTooltip: (id: string) => void;
+  /** Check if a tooltip is currently shown */
+  isShown: (id: string) => boolean;
+  /** Open the help panel to a specific topic */
+  onOpenHelp?: (topicId: string) => void;
+}
+
+/**
+ * Default context values
+ */
+const TooltipContext = createContext<TooltipContextType>({
+  showTooltip: () => {},
+  hideTooltip: () => {},
+  isShown: () => false,
+  onOpenHelp: undefined,
+});
+
+/**
+ * Props for TooltipProvider
+ */
+export interface TooltipProviderProps {
+  /** Child elements */
+  children: ReactNode;
+  /** Default delay before showing tooltips (ms) */
+  defaultDelay?: number;
+  /** Callback when user clicks to open help */
+  onOpenHelp?: (topicId: string) => void;
+}
+
+/**
+ * Calculate optimal tooltip position
+ */
+function calculatePosition(
+  rect: DOMRect,
+  position: TooltipPosition,
+  tooltipRect?: DOMRect
+): { top: number; left: number; position: TooltipPosition } {
+  const offset = 8;
+  const padding = 12;
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  let top = 0;
+  let left = 0;
+  let finalPosition = position;
+
+  // Calculate initial position
+  switch (position) {
+    case 'top':
+      top = rect.top - offset;
+      left = rect.left + rect.width / 2;
+      break;
+    case 'bottom':
+      top = rect.bottom + offset;
+      left = rect.left + rect.width / 2;
+      break;
+    case 'left':
+      top = rect.top + rect.height / 2;
+      left = rect.left - offset;
+      break;
+    case 'right':
+      top = rect.top + rect.height / 2;
+      left = rect.right + offset;
+      break;
+  }
+
+  // Adjust if would overflow viewport
+  if (tooltipRect) {
+    // Check horizontal overflow
+    if (left - tooltipRect.width / 2 < padding) {
+      left = padding + tooltipRect.width / 2;
+    } else if (left + tooltipRect.width / 2 > viewportWidth - padding) {
+      left = viewportWidth - padding - tooltipRect.width / 2;
+    }
+
+    // Check vertical overflow and flip if needed
+    if (position === 'top' && top - tooltipRect.height < padding) {
+      top = rect.bottom + offset;
+      finalPosition = 'bottom';
+    } else if (
+      position === 'bottom' &&
+      top + tooltipRect.height > viewportHeight - padding
+    ) {
+      top = rect.top - offset;
+      finalPosition = 'top';
+    }
+  }
+
+  return { top, left, position: finalPosition };
+}
+
+/**
+ * TooltipProvider manages tooltips for its children.
+ *
+ * Features:
+ * - Context-based tooltip system
+ * - Automatic positioning
+ * - Configurable delays
+ * - Help topic integration
+ * - Accessible (aria support)
+ *
+ * @example
+ * ```tsx
+ * <TooltipProvider onOpenHelp={(id) => setHelpTopic(id)}>
+ *   <App />
+ * </TooltipProvider>
+ * ```
+ */
+export function TooltipProvider({
+  children,
+  defaultDelay = 300,
+  onOpenHelp,
+}: TooltipProviderProps): ReactElement {
+  const [activeTooltip, setActiveTooltip] = useState<ActiveTooltip | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const showTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  log('Rendering TooltipProvider');
+
+  // Clear timeouts on unmount
+  useEffect(() => {
+    return () => {
+      if (showTimeoutRef.current) clearTimeout(showTimeoutRef.current);
+      if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+    };
+  }, []);
+
+  // Show a tooltip
+  const showTooltip = useCallback(
+    (config: TooltipConfig, element: HTMLElement) => {
+      // Clear any pending hide
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+      }
+
+      const delay = config.delay ?? defaultDelay;
+      log('Showing tooltip:', config.id, { delay });
+
+      // Set up delayed show
+      showTimeoutRef.current = setTimeout(() => {
+        const rect = element.getBoundingClientRect();
+        const helpTopic = config.helpTopicId
+          ? getTopicById(config.helpTopicId)
+          : undefined;
+
+        setActiveTooltip({ config, rect, helpTopic });
+        setIsVisible(true);
+      }, delay);
+    },
+    [defaultDelay]
+  );
+
+  // Hide a tooltip
+  const hideTooltip = useCallback((id: string) => {
+    // Clear any pending show
+    if (showTimeoutRef.current) {
+      clearTimeout(showTimeoutRef.current);
+    }
+
+    log('Hiding tooltip:', id);
+
+    // Small delay before hiding to allow moving to tooltip
+    hideTimeoutRef.current = setTimeout(() => {
+      setIsVisible(false);
+      // Clear tooltip after fade out
+      setTimeout(() => {
+        setActiveTooltip((current) => {
+          if (current?.config.id === id) {
+            return null;
+          }
+          return current;
+        });
+      }, 150);
+    }, 100);
+  }, []);
+
+  // Check if a tooltip is shown
+  const isShown = useCallback(
+    (id: string) => {
+      return activeTooltip?.config.id === id && isVisible;
+    },
+    [activeTooltip, isVisible]
+  );
+
+  // State for calculated position
+  const [tooltipPosition, setTooltipPosition] = useState<{
+    top: number;
+    left: number;
+    position: TooltipPosition;
+  } | null>(null);
+
+  // Calculate tooltip position after render when tooltip element is available
+  // Note: setState in effect is intentional here to update position after DOM layout
+  useEffect(() => {
+    if (activeTooltip && isVisible) {
+      // Use requestAnimationFrame to ensure tooltip is rendered
+      requestAnimationFrame(() => {
+        const tooltipRect = tooltipRef.current?.getBoundingClientRect();
+        const position = calculatePosition(
+          activeTooltip.rect,
+          activeTooltip.config.position ?? 'top',
+          tooltipRect
+        );
+         
+        setTooltipPosition(position);
+      });
+    } else {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: clearing position when tooltip is hidden
+      setTooltipPosition(null);
+    }
+  }, [activeTooltip, isVisible]);
+
+  // Handle help link click
+  const handleHelpClick = useCallback(() => {
+    if (activeTooltip?.helpTopic && onOpenHelp) {
+      log('Opening help for topic:', activeTooltip.helpTopic.id);
+      onOpenHelp(activeTooltip.helpTopic.id);
+      setIsVisible(false);
+    }
+  }, [activeTooltip, onOpenHelp]);
+
+  return (
+    <TooltipContext.Provider
+      value={{ showTooltip, hideTooltip, isShown, onOpenHelp }}
+    >
+      {children}
+
+      {/* Tooltip element */}
+      {activeTooltip && tooltipPosition && (
+        <div
+          ref={tooltipRef}
+          className={`tooltip tooltip--${tooltipPosition.position} ${
+            isVisible ? 'tooltip--visible' : ''
+          }`}
+          style={{
+            top: tooltipPosition.top,
+            left: tooltipPosition.left,
+          }}
+          role="tooltip"
+          aria-hidden={!isVisible}
+          data-testid={`tooltip-${activeTooltip.config.id}`}
+          onMouseEnter={() => {
+            if (hideTimeoutRef.current) {
+              clearTimeout(hideTimeoutRef.current);
+            }
+          }}
+          onMouseLeave={() => hideTooltip(activeTooltip.config.id)}
+        >
+          <div className="tooltip__content">{activeTooltip.config.content}</div>
+
+          {activeTooltip.helpTopic && onOpenHelp && (
+            <button
+              type="button"
+              className="tooltip__help-link"
+              onClick={handleHelpClick}
+              data-testid={`tooltip-help-link-${activeTooltip.config.id}`}
+            >
+              Learn more &rarr;
+            </button>
+          )}
+
+          <div className="tooltip__arrow" />
+        </div>
+      )}
+    </TooltipContext.Provider>
+  );
+}
+
+/**
+ * Hook to access tooltip context
+ */
+export function useTooltip(): TooltipContextType {
+  return useContext(TooltipContext);
+}
+
+/**
+ * Props for Tooltip component
+ */
+export interface TooltipProps {
+  /** The element to attach the tooltip to */
+  children: ReactElement;
+  /** Tooltip content */
+  content: string;
+  /** Preferred position */
+  position?: TooltipPosition;
+  /** Delay before showing (ms) */
+  delay?: number;
+  /** Optional help topic ID */
+  helpTopicId?: string;
+  /** Whether tooltip is disabled */
+  disabled?: boolean;
+}
+
+/**
+ * Tooltip wrapper component.
+ *
+ * Wraps a single element and shows a tooltip on hover.
+ *
+ * @example
+ * ```tsx
+ * <Tooltip content="Click to save" helpTopicId="saving-work">
+ *   <button>Save</button>
+ * </Tooltip>
+ * ```
+ */
+export function Tooltip({
+  children,
+  content,
+  position = 'top',
+  delay,
+  helpTopicId,
+  disabled = false,
+}: TooltipProps): ReactElement {
+  const { showTooltip, hideTooltip } = useTooltip();
+  const tooltipId = useId();
+  const elementRef = useRef<HTMLElement | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    if (disabled || !elementRef.current) return;
+
+    showTooltip(
+      {
+        id: tooltipId,
+        content,
+        position,
+        delay,
+        helpTopicId,
+      },
+      elementRef.current
+    );
+  }, [showTooltip, tooltipId, content, position, delay, helpTopicId, disabled]);
+
+  const handleMouseLeave = useCallback(() => {
+    hideTooltip(tooltipId);
+  }, [hideTooltip, tooltipId]);
+
+  const handleFocus = useCallback(() => {
+    if (disabled || !elementRef.current) return;
+
+    showTooltip(
+      {
+        id: tooltipId,
+        content,
+        position,
+        delay: 0, // Show immediately on focus
+        helpTopicId,
+      },
+      elementRef.current
+    );
+  }, [showTooltip, tooltipId, content, position, helpTopicId, disabled]);
+
+  const handleBlur = useCallback(() => {
+    hideTooltip(tooltipId);
+  }, [hideTooltip, tooltipId]);
+
+  // Clone child with added event handlers and ref
+  const child = children;
+
+  return (
+    <span
+      ref={(el) => {
+        elementRef.current = el;
+      }}
+      className="tooltip-wrapper"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      aria-describedby={disabled ? undefined : tooltipId}
+    >
+      {child}
+    </span>
+  );
+}
+
+export default TooltipProvider;

--- a/web/src/components/Help/helpContent.test.ts
+++ b/web/src/components/Help/helpContent.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for Help Content Data and Utility Functions
+ *
+ * @module components/Help/helpContent.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  HELP_CATEGORIES,
+  HELP_TOPICS,
+  FAQ_ITEMS,
+  getTopicsByCategory,
+  getTopicById,
+  getRelatedTopics,
+  searchTopics,
+  getFAQByCategory,
+  searchFAQs,
+  getCategoryById,
+  type HelpCategory,
+} from './helpContent';
+
+describe('helpContent', () => {
+  describe('HELP_CATEGORIES', () => {
+    it('contains all required categories', () => {
+      const expectedCategories: HelpCategory[] = [
+        'getting-started',
+        'analysis',
+        'suggestions',
+        'melody',
+        'recording',
+        'shortcuts',
+      ];
+
+      const actualCategories = HELP_CATEGORIES.map((c) => c.id);
+      expect(actualCategories).toEqual(expectedCategories);
+    });
+
+    it('each category has required fields', () => {
+      HELP_CATEGORIES.forEach((category) => {
+        expect(category.id).toBeDefined();
+        expect(category.title).toBeDefined();
+        expect(category.description).toBeDefined();
+        expect(category.icon).toBeDefined();
+        expect(typeof category.title).toBe('string');
+        expect(category.title.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('HELP_TOPICS', () => {
+    it('contains topics for each category', () => {
+      const categories = new Set(HELP_TOPICS.map((t) => t.category));
+      HELP_CATEGORIES.forEach((cat) => {
+        expect(categories.has(cat.id)).toBe(true);
+      });
+    });
+
+    it('each topic has required fields', () => {
+      HELP_TOPICS.forEach((topic) => {
+        expect(topic.id).toBeDefined();
+        expect(topic.title).toBeDefined();
+        expect(topic.category).toBeDefined();
+        expect(topic.summary).toBeDefined();
+        expect(topic.content).toBeDefined();
+        expect(topic.keywords).toBeDefined();
+        expect(Array.isArray(topic.keywords)).toBe(true);
+        expect(topic.keywords.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('all related topic IDs reference valid topics', () => {
+      const topicIds = new Set(HELP_TOPICS.map((t) => t.id));
+      HELP_TOPICS.forEach((topic) => {
+        if (topic.related) {
+          topic.related.forEach((relatedId) => {
+            expect(topicIds.has(relatedId)).toBe(true);
+          });
+        }
+      });
+    });
+  });
+
+  describe('FAQ_ITEMS', () => {
+    it('contains items for multiple categories', () => {
+      const categories = new Set(FAQ_ITEMS.map((item) => item.category));
+      expect(categories.size).toBeGreaterThan(3);
+    });
+
+    it('each FAQ item has required fields', () => {
+      FAQ_ITEMS.forEach((item) => {
+        expect(item.id).toBeDefined();
+        expect(item.question).toBeDefined();
+        expect(item.answer).toBeDefined();
+        expect(item.category).toBeDefined();
+        // Questions should end with ? or .
+        expect(item.question.endsWith('?') || item.question.endsWith('.')).toBe(true);
+        expect(item.answer.length).toBeGreaterThan(20);
+      });
+    });
+  });
+
+  describe('getTopicsByCategory', () => {
+    it('returns topics for getting-started category', () => {
+      const topics = getTopicsByCategory('getting-started');
+      expect(topics.length).toBeGreaterThan(0);
+      topics.forEach((topic) => {
+        expect(topic.category).toBe('getting-started');
+      });
+    });
+
+    it('returns topics for analysis category', () => {
+      const topics = getTopicsByCategory('analysis');
+      expect(topics.length).toBeGreaterThan(0);
+      topics.forEach((topic) => {
+        expect(topic.category).toBe('analysis');
+      });
+    });
+
+    it('returns empty array for non-existent category', () => {
+      const topics = getTopicsByCategory('non-existent' as HelpCategory);
+      expect(topics).toEqual([]);
+    });
+  });
+
+  describe('getTopicById', () => {
+    it('returns topic for valid ID', () => {
+      const topic = getTopicById('what-is-ghost-note');
+      expect(topic).toBeDefined();
+      expect(topic?.id).toBe('what-is-ghost-note');
+      expect(topic?.title).toBe('What is Ghost Note?');
+    });
+
+    it('returns undefined for invalid ID', () => {
+      const topic = getTopicById('non-existent-id');
+      expect(topic).toBeUndefined();
+    });
+  });
+
+  describe('getRelatedTopics', () => {
+    it('returns related topics for topic with related field', () => {
+      const relatedTopics = getRelatedTopics('what-is-ghost-note');
+      expect(relatedTopics.length).toBeGreaterThan(0);
+      // Should include workflow-overview and entering-poem
+      const relatedIds = relatedTopics.map((t) => t.id);
+      expect(relatedIds).toContain('workflow-overview');
+    });
+
+    it('returns empty array for topic without related field', () => {
+      // Find a topic without related or create this scenario
+      const topicWithoutRelated = HELP_TOPICS.find((t) => !t.related);
+      if (topicWithoutRelated) {
+        const relatedTopics = getRelatedTopics(topicWithoutRelated.id);
+        expect(relatedTopics).toEqual([]);
+      }
+    });
+
+    it('returns empty array for non-existent topic', () => {
+      const relatedTopics = getRelatedTopics('non-existent-id');
+      expect(relatedTopics).toEqual([]);
+    });
+  });
+
+  describe('searchTopics', () => {
+    it('returns empty array for empty query', () => {
+      expect(searchTopics('')).toEqual([]);
+      expect(searchTopics('   ')).toEqual([]);
+    });
+
+    it('finds topics by title', () => {
+      const results = searchTopics('Ghost Note');
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.some((t) => t.title.toLowerCase().includes('ghost note'))).toBe(true);
+    });
+
+    it('finds topics by keyword', () => {
+      const results = searchTopics('syllable');
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('finds topics by content', () => {
+      const results = searchTopics('CMU Pronouncing Dictionary');
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('is case-insensitive', () => {
+      const lowerResults = searchTopics('melody');
+      const upperResults = searchTopics('MELODY');
+      const mixedResults = searchTopics('MeLoDy');
+
+      expect(lowerResults.length).toBe(upperResults.length);
+      expect(lowerResults.length).toBe(mixedResults.length);
+    });
+
+    it('prioritizes title matches', () => {
+      const results = searchTopics('melody');
+      // Topics with "melody" in the title should appear first
+      const firstResult = results[0];
+      expect(
+        firstResult.title.toLowerCase().includes('melody') ||
+          firstResult.keywords.some((k) => k.includes('melody'))
+      ).toBe(true);
+    });
+  });
+
+  describe('getFAQByCategory', () => {
+    it('returns FAQs for getting-started category', () => {
+      const faqs = getFAQByCategory('getting-started');
+      expect(faqs.length).toBeGreaterThan(0);
+      faqs.forEach((faq) => {
+        expect(faq.category).toBe('getting-started');
+      });
+    });
+
+    it('returns FAQs for analysis category', () => {
+      const faqs = getFAQByCategory('analysis');
+      expect(faqs.length).toBeGreaterThan(0);
+      faqs.forEach((faq) => {
+        expect(faq.category).toBe('analysis');
+      });
+    });
+
+    it('returns empty array for category with no FAQs', () => {
+      // All categories should have at least some FAQs in our implementation
+      // but this tests the filtering logic
+      const faqs = getFAQByCategory('non-existent' as HelpCategory);
+      expect(faqs).toEqual([]);
+    });
+  });
+
+  describe('searchFAQs', () => {
+    it('returns empty array for empty query', () => {
+      expect(searchFAQs('')).toEqual([]);
+      expect(searchFAQs('   ')).toEqual([]);
+    });
+
+    it('finds FAQs by question text', () => {
+      const results = searchFAQs('poems work best');
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('finds FAQs by answer text', () => {
+      const results = searchFAQs('microphone permission');
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('is case-insensitive', () => {
+      const lowerResults = searchFAQs('microphone');
+      const upperResults = searchFAQs('MICROPHONE');
+
+      expect(lowerResults.length).toBe(upperResults.length);
+    });
+  });
+
+  describe('getCategoryById', () => {
+    it('returns category info for valid category ID', () => {
+      const category = getCategoryById('getting-started');
+      expect(category).toBeDefined();
+      expect(category?.id).toBe('getting-started');
+      expect(category?.title).toBe('Getting Started');
+    });
+
+    it('returns undefined for invalid category ID', () => {
+      const category = getCategoryById('non-existent' as HelpCategory);
+      expect(category).toBeUndefined();
+    });
+
+    it('returns correct info for all categories', () => {
+      HELP_CATEGORIES.forEach((cat) => {
+        const result = getCategoryById(cat.id);
+        expect(result).toEqual(cat);
+      });
+    });
+  });
+});

--- a/web/src/components/Help/helpContent.ts
+++ b/web/src/components/Help/helpContent.ts
@@ -1,0 +1,743 @@
+/**
+ * Help Content Data
+ *
+ * Centralized help content for all documentation topics in Ghost Note.
+ * This includes getting started guides, feature explanations, FAQs, and tips.
+ *
+ * @module components/Help/helpContent
+ */
+
+/**
+ * Individual help topic definition
+ */
+export interface HelpTopic {
+  /** Unique identifier for the topic */
+  id: string;
+  /** Display title */
+  title: string;
+  /** Topic category for grouping */
+  category: HelpCategory;
+  /** Short description for search/preview */
+  summary: string;
+  /** Full content (supports markdown-like formatting) */
+  content: string;
+  /** Keywords for search */
+  keywords: string[];
+  /** Related topic IDs */
+  related?: string[];
+}
+
+/**
+ * Help content categories
+ */
+export type HelpCategory =
+  | 'getting-started'
+  | 'analysis'
+  | 'suggestions'
+  | 'melody'
+  | 'recording'
+  | 'shortcuts';
+
+/**
+ * Category display information
+ */
+export interface CategoryInfo {
+  id: HelpCategory;
+  title: string;
+  description: string;
+  icon: string;
+}
+
+/**
+ * FAQ item definition
+ */
+export interface FAQItem {
+  id: string;
+  question: string;
+  answer: string;
+  category: HelpCategory;
+}
+
+/**
+ * Category metadata for display
+ */
+export const HELP_CATEGORIES: CategoryInfo[] = [
+  {
+    id: 'getting-started',
+    title: 'Getting Started',
+    description: 'Learn the basics of Ghost Note',
+    icon: 'rocket',
+  },
+  {
+    id: 'analysis',
+    title: 'Understanding Analysis',
+    description: 'How poem analysis works',
+    icon: 'chart',
+  },
+  {
+    id: 'suggestions',
+    title: 'Working with Suggestions',
+    description: 'Using and applying lyric suggestions',
+    icon: 'lightbulb',
+  },
+  {
+    id: 'melody',
+    title: 'Melody Customization',
+    description: 'Adjusting and playing melodies',
+    icon: 'music',
+  },
+  {
+    id: 'recording',
+    title: 'Recording Tips',
+    description: 'Recording your performance',
+    icon: 'microphone',
+  },
+  {
+    id: 'shortcuts',
+    title: 'Keyboard Shortcuts',
+    description: 'Speed up your workflow',
+    icon: 'keyboard',
+  },
+];
+
+/**
+ * All help topics
+ */
+export const HELP_TOPICS: HelpTopic[] = [
+  // Getting Started
+  {
+    id: 'what-is-ghost-note',
+    title: 'What is Ghost Note?',
+    category: 'getting-started',
+    summary: 'An introduction to Ghost Note and its purpose.',
+    content: `Ghost Note transforms poems into songs by analyzing the linguistic structure of your text and generating singable melodies that match the natural rhythm and emotion of your words.
+
+**Key Features:**
+- Automatic syllable and stress analysis
+- Rhyme scheme detection
+- Singability scoring
+- AI-powered melody generation
+- Voice recording studio
+
+Ghost Note helps poets, songwriters, and anyone who wants to hear their words come alive as music.`,
+    keywords: ['introduction', 'about', 'overview', 'purpose'],
+    related: ['workflow-overview', 'entering-poem'],
+  },
+  {
+    id: 'workflow-overview',
+    title: 'Workflow Overview',
+    category: 'getting-started',
+    summary: 'The step-by-step process from poem to song.',
+    content: `Ghost Note follows a simple five-step workflow:
+
+**1. Enter Your Poem**
+Paste or type your poem into the text area. The app will automatically detect stanzas and line breaks.
+
+**2. Analyze the Text**
+The analysis engine examines syllables, stress patterns, rhyme schemes, and emotional content to understand your poem's structure.
+
+**3. Review & Edit Lyrics**
+View analysis results and apply suggested improvements to make your lyrics more singable.
+
+**4. Generate Melody**
+Create a vocal melody line that aligns stressed syllables with strong beats and matches your poem's emotional arc.
+
+**5. Record Your Performance**
+Use the built-in recording studio to capture your vocal performance alongside the generated melody.`,
+    keywords: ['workflow', 'steps', 'process', 'how to use'],
+    related: ['entering-poem', 'understanding-analysis'],
+  },
+  {
+    id: 'entering-poem',
+    title: 'Entering Your Poem',
+    category: 'getting-started',
+    summary: 'How to input and format your poem.',
+    content: `**Entering Text**
+Simply paste your poem into the text area or type it directly. Ghost Note preserves your original formatting.
+
+**Formatting Tips:**
+- Use single line breaks between lines within a stanza
+- Use double line breaks (blank lines) to separate stanzas
+- Standard punctuation is preserved and helps with analysis
+
+**Sample Poems**
+Click "Try a Sample" to load one of several classic poems to experiment with before using your own work.
+
+**Character Limits**
+While there's no strict limit, Ghost Note works best with poems of 4-50 lines. Very long poems may take longer to analyze and generate melodies for.`,
+    keywords: ['input', 'text', 'paste', 'type', 'format', 'sample'],
+    related: ['workflow-overview', 'understanding-analysis'],
+  },
+
+  // Understanding Analysis
+  {
+    id: 'understanding-analysis',
+    title: 'How Analysis Works',
+    category: 'analysis',
+    summary: 'Overview of the poem analysis system.',
+    content: `Ghost Note analyzes your poem across several dimensions:
+
+**Syllable Counting**
+Each word is broken into syllables using the CMU Pronouncing Dictionary and phonetic rules.
+
+**Stress Patterns**
+Primary (1) and secondary (2) stress are identified for each syllable, helping create natural rhythm.
+
+**Meter Detection**
+The app identifies common meters like iambic (da-DUM), trochaic (DUM-da), and anapestic (da-da-DUM).
+
+**Rhyme Analysis**
+End rhymes are detected and classified as perfect, slant, or near rhymes, and the rhyme scheme is mapped (ABAB, AABB, etc.).
+
+**Singability Scoring**
+Each syllable receives a singability score based on vowel openness, consonant clusters, and sustainability.
+
+**Emotional Analysis**
+Sentiment and emotional keywords are analyzed to suggest appropriate musical modes and tempos.`,
+    keywords: ['analysis', 'syllable', 'stress', 'meter', 'rhyme', 'sentiment'],
+    related: ['stress-patterns', 'rhyme-schemes', 'singability-heatmap'],
+  },
+  {
+    id: 'stress-patterns',
+    title: 'Understanding Stress Patterns',
+    category: 'analysis',
+    summary: 'How syllable stress affects melody.',
+    content: `**What is Stress?**
+In English, some syllables are pronounced with more emphasis (stressed) while others are lighter (unstressed).
+
+**Notation:**
+- **1** = Primary stress (strongest emphasis)
+- **2** = Secondary stress (moderate emphasis)
+- **0** = Unstressed (lightest)
+
+**Example:**
+"beautiful" = BEA-u-ti-ful = 1-0-0-0
+"photography" = pho-TOG-ra-phy = 0-1-0-0
+
+**Why It Matters**
+For a song to sound natural, stressed syllables should fall on strong beats (typically beats 1 and 3 in 4/4 time). Misaligned stress sounds awkward when sung.
+
+**Visualization**
+The stress visualization shows each syllable's stress level with color intensity, helping you spot potential rhythm issues.`,
+    keywords: ['stress', 'syllable', 'emphasis', 'beat', 'rhythm'],
+    related: ['understanding-analysis', 'meter-display'],
+  },
+  {
+    id: 'rhyme-schemes',
+    title: 'Rhyme Scheme Analysis',
+    category: 'analysis',
+    summary: 'How rhyme patterns are detected.',
+    content: `**Rhyme Types:**
+- **Perfect rhyme**: Identical sounds from the stressed vowel onward (love/dove)
+- **Slant rhyme**: Similar but not identical sounds (love/move)
+- **Assonance**: Matching vowel sounds (love/come)
+- **Consonance**: Matching consonant sounds (love/live)
+
+**Scheme Notation:**
+Letters indicate which lines rhyme together:
+- ABAB = Alternating rhyme
+- AABB = Couplets
+- ABBA = Enclosed rhyme
+
+**Color Coding**
+The rhyme display uses matching colors to show which lines rhyme together, making patterns easy to see at a glance.
+
+**Internal Rhymes**
+Ghost Note also detects rhymes within lines, not just at line endings.`,
+    keywords: ['rhyme', 'scheme', 'pattern', 'perfect', 'slant', 'assonance'],
+    related: ['understanding-analysis', 'singability-heatmap'],
+  },
+  {
+    id: 'singability-heatmap',
+    title: 'Reading the Singability Heatmap',
+    category: 'analysis',
+    summary: 'Understanding singability scores.',
+    content: `**What is Singability?**
+Singability measures how easy a syllable is to sustain when sung. Some sounds are naturally easier to hold on long notes.
+
+**Scoring Factors:**
+- **Vowel openness**: Open vowels (ah, oh) score higher than closed (ee, oo)
+- **Consonant clusters**: Fewer consonants = easier to sing
+- **Sustainability**: Can this sound be held? (Yes: "love", No: "glimpsed")
+
+**Heatmap Colors:**
+- **Green**: High singability (easy to sing)
+- **Yellow**: Medium singability (some difficulty)
+- **Red**: Low singability (challenging spots)
+
+**Using the Heatmap**
+Red areas indicate words you might want to change for better singability. The suggestions panel offers alternatives for problem spots.`,
+    keywords: ['singability', 'heatmap', 'vowel', 'consonant', 'score'],
+    related: ['understanding-analysis', 'applying-suggestions'],
+  },
+  {
+    id: 'meter-display',
+    title: 'Understanding Meter Display',
+    category: 'analysis',
+    summary: 'How poetic meter is shown.',
+    content: `**Common Meters:**
+- **Iambic**: Unstressed-Stressed (da-DUM) - most common in English
+- **Trochaic**: Stressed-Unstressed (DUM-da)
+- **Anapestic**: Unstressed-Unstressed-Stressed (da-da-DUM)
+- **Dactylic**: Stressed-Unstressed-Unstressed (DUM-da-da)
+
+**Feet Count:**
+- Dimeter = 2 feet per line
+- Trimeter = 3 feet
+- Tetrameter = 4 feet
+- Pentameter = 5 feet (iambic pentameter is very common)
+
+**Meter Confidence**
+The confidence score shows how well your poem matches the detected meter. Lower confidence may indicate intentional variation or free verse.
+
+**Deviations**
+Red markers show where the actual stress pattern deviates from the expected meter, which may be intentional for emphasis.`,
+    keywords: ['meter', 'iambic', 'trochaic', 'feet', 'rhythm', 'pattern'],
+    related: ['stress-patterns', 'understanding-analysis'],
+  },
+
+  // Working with Suggestions
+  {
+    id: 'using-suggestions',
+    title: 'Using Lyric Suggestions',
+    category: 'suggestions',
+    summary: 'How the suggestion system works.',
+    content: `**What Are Suggestions?**
+Based on the analysis results, Ghost Note identifies potential issues and offers alternative words or phrases to improve singability.
+
+**Suggestion Types:**
+- **Singability**: Alternative words with easier-to-sing syllables
+- **Meter**: Words that better match the detected rhythm
+- **Rhyme**: Alternatives that create or improve rhyme patterns
+
+**Viewing Suggestions**
+Click on highlighted problem areas in the lyrics editor to see available suggestions. Each suggestion shows:
+- The original word or phrase
+- The suggested replacement
+- Why this change is recommended
+
+**Suggestion Priority**
+Suggestions are sorted by severity (high, medium, low) so you can focus on the most impactful changes first.`,
+    keywords: ['suggestions', 'alternatives', 'improvements', 'changes'],
+    related: ['applying-suggestions', 'singability-heatmap'],
+  },
+  {
+    id: 'applying-suggestions',
+    title: 'Applying Suggestions',
+    category: 'suggestions',
+    summary: 'How to accept or modify suggestions.',
+    content: `**Accepting a Suggestion**
+Click the "Apply" button next to a suggestion to replace the original text. The change is immediately reflected in the lyrics.
+
+**Preview Changes**
+Hover over a suggestion to see how it would look in context before applying.
+
+**Undo Changes**
+Use Cmd/Ctrl+Z to undo any applied suggestion. All changes are tracked in the version history.
+
+**Partial Acceptance**
+You can also manually edit the lyrics to use part of a suggestion or create your own variation.
+
+**Skipping Suggestions**
+Not all suggestions will fit your vision. Feel free to dismiss any that don't work for your piece - they're recommendations, not requirements.`,
+    keywords: ['apply', 'accept', 'undo', 'change', 'edit', 'dismiss'],
+    related: ['using-suggestions', 'version-history'],
+  },
+  {
+    id: 'version-history',
+    title: 'Version History',
+    category: 'suggestions',
+    summary: 'Tracking changes to your lyrics.',
+    content: `**Automatic Versioning**
+Every time you apply a suggestion or manually edit your lyrics, a new version is saved automatically.
+
+**Viewing History**
+Access version history through the menu or by pressing the history icon. Each version shows:
+- Timestamp of the change
+- Description of what changed
+- Diff view comparing to previous version
+
+**Reverting Changes**
+Click on any previous version to revert your lyrics to that state. This creates a new version, so you never lose work.
+
+**Comparing Versions**
+Use the diff view to see exactly what changed between versions, with additions highlighted in green and deletions in red.`,
+    keywords: ['version', 'history', 'undo', 'revert', 'diff', 'changes'],
+    related: ['applying-suggestions'],
+  },
+
+  // Melody Customization
+  {
+    id: 'melody-generation',
+    title: 'Melody Generation',
+    category: 'melody',
+    summary: 'How melodies are created.',
+    content: `**Stress-to-Beat Alignment**
+The melody generator aligns stressed syllables with strong beats (beats 1 and 3 in 4/4 time) for natural-sounding lyrics.
+
+**Emotional Matching**
+Based on sentiment analysis, the generator chooses:
+- **Mode**: Major for happier poems, minor for sadder ones
+- **Tempo**: Faster for energetic, slower for reflective
+- **Register**: High, middle, or low pitch range
+
+**Phrase Shaping**
+Each line follows a natural melodic arc, typically rising to a peak then falling to resolution.
+
+**ABC Notation**
+Melodies are stored in ABC notation, a text-based format that's easy to display and modify.`,
+    keywords: ['melody', 'generate', 'create', 'music', 'notes', 'abc'],
+    related: ['playback-controls', 'adjusting-tempo-key'],
+  },
+  {
+    id: 'playback-controls',
+    title: 'Playback Controls',
+    category: 'melody',
+    summary: 'Playing and navigating melodies.',
+    content: `**Basic Controls:**
+- **Play/Pause**: Space bar or play button
+- **Stop**: Escape key or stop button
+- **Seek**: Click anywhere on the progress bar
+
+**Loop Mode**
+Toggle loop to have the melody repeat continuously, useful for practicing or recording multiple takes.
+
+**Volume**
+Adjust the melody volume using the volume slider to balance with your voice when recording.
+
+**Follow Along**
+The notation display highlights the current position during playback, helping you follow along with the melody.`,
+    keywords: ['play', 'pause', 'stop', 'seek', 'loop', 'volume', 'playback'],
+    related: ['melody-generation', 'adjusting-tempo-key'],
+  },
+  {
+    id: 'adjusting-tempo-key',
+    title: 'Adjusting Tempo and Key',
+    category: 'melody',
+    summary: 'Customizing melody parameters.',
+    content: `**Tempo (BPM)**
+Adjust the tempo slider to speed up or slow down the melody. The range is typically 60-160 BPM.
+- Slower tempos suit reflective, sad pieces
+- Faster tempos work for energetic, happy pieces
+
+**Key Signature**
+Change the key to fit your vocal range:
+- Higher keys (G, A) for higher voices
+- Lower keys (F, E) for lower voices
+- Try different keys to find what feels comfortable
+
+**Time Signature**
+While automatically detected, you can override the time signature:
+- 4/4 for most standard meters
+- 3/4 for waltz-like feel
+- 6/8 for compound meters
+
+**Regenerate**
+After changing parameters, you may want to regenerate the melody to take full advantage of the new settings.`,
+    keywords: ['tempo', 'bpm', 'key', 'signature', 'speed', 'pitch'],
+    related: ['melody-generation', 'playback-controls'],
+  },
+
+  // Recording Tips
+  {
+    id: 'microphone-setup',
+    title: 'Microphone Setup',
+    category: 'recording',
+    summary: 'Setting up your microphone for recording.',
+    content: `**Browser Permissions**
+When you first access the recording studio, your browser will ask for microphone permission. Click "Allow" to enable recording.
+
+**Selecting a Microphone**
+If you have multiple microphones, use the dropdown to select the one you want to use. External microphones often produce better quality than built-in laptop mics.
+
+**Level Check**
+Watch the input level meter while speaking or singing. The meter should move without hitting the red zone, which indicates clipping.
+
+**Optimal Levels**
+- Green zone: Good level
+- Yellow zone: Strong but safe
+- Red zone: Too loud, reduce input or move back from mic
+
+**Environment Tips**
+- Record in a quiet room
+- Minimize background noise
+- Consider using headphones to avoid feedback`,
+    keywords: ['microphone', 'mic', 'setup', 'permission', 'level', 'input'],
+    related: ['recording-best-practices', 'exporting-recordings'],
+  },
+  {
+    id: 'recording-best-practices',
+    title: 'Recording Best Practices',
+    category: 'recording',
+    summary: 'Tips for better recordings.',
+    content: `**Before Recording:**
+- Warm up your voice
+- Practice with the melody a few times
+- Set a comfortable tempo
+- Adjust the key to your vocal range
+
+**During Recording:**
+- Stay at a consistent distance from the microphone
+- Listen to the melody through headphones
+- Don't worry about perfection - you can do multiple takes
+- Breathe naturally at phrase endings
+
+**Multiple Takes**
+Record multiple attempts and pick the best one. Each take is saved separately so you can compare.
+
+**Timing Tips**
+- Start recording before the melody begins
+- Wait for the melody to start, then sing along
+- Keep a steady rhythm aligned with the melody`,
+    keywords: ['recording', 'tips', 'practice', 'takes', 'quality'],
+    related: ['microphone-setup', 'exporting-recordings'],
+  },
+  {
+    id: 'exporting-recordings',
+    title: 'Exporting Recordings',
+    category: 'recording',
+    summary: 'Saving and sharing your recordings.',
+    content: `**Audio Formats**
+Recordings are saved as WAV files for high quality. You can convert to other formats (MP3, etc.) using external tools if needed.
+
+**Downloading**
+Click the download button next to any take to save it to your computer.
+
+**Take Management**
+- Rename takes to keep track of different versions
+- Delete takes you don't want to keep
+- Compare multiple takes before deciding which to keep
+
+**Sharing**
+Once downloaded, you can share your recordings via email, messaging apps, or upload to audio platforms.`,
+    keywords: ['export', 'download', 'save', 'share', 'audio', 'format'],
+    related: ['recording-best-practices'],
+  },
+
+  // Keyboard Shortcuts
+  {
+    id: 'playback-shortcuts',
+    title: 'Playback Shortcuts',
+    category: 'shortcuts',
+    summary: 'Keyboard shortcuts for melody playback.',
+    content: `**Playback Control:**
+- **Space** - Play/Pause melody
+- **Escape** - Stop playback
+
+These shortcuts work from anywhere in the app except when typing in text fields.
+
+**Tip:** Use Space to quickly toggle between play and pause while practicing your timing.`,
+    keywords: ['keyboard', 'shortcut', 'play', 'pause', 'stop', 'space'],
+    related: ['editing-shortcuts', 'navigation-shortcuts'],
+  },
+  {
+    id: 'editing-shortcuts',
+    title: 'Editing Shortcuts',
+    category: 'shortcuts',
+    summary: 'Keyboard shortcuts for editing lyrics.',
+    content: `**Editing:**
+- **Cmd/Ctrl + Z** - Undo last change
+- **Cmd/Ctrl + Shift + Z** - Redo
+- **Cmd/Ctrl + S** - Save/Export
+
+**Creation:**
+- **Cmd/Ctrl + Enter** - Generate melody
+- **R** - Start/Stop recording
+
+These shortcuts help speed up your workflow without reaching for the mouse.`,
+    keywords: ['keyboard', 'shortcut', 'undo', 'redo', 'save', 'edit'],
+    related: ['playback-shortcuts', 'navigation-shortcuts'],
+  },
+  {
+    id: 'navigation-shortcuts',
+    title: 'Navigation Shortcuts',
+    category: 'shortcuts',
+    summary: 'Keyboard shortcuts for navigation.',
+    content: `**Navigation:**
+- **Tab** - Move to next section
+- **Shift + Tab** - Move to previous section
+- **?** - Show keyboard shortcuts dialog
+
+**Section Order:**
+1. Poem Input
+2. Analysis
+3. Lyrics Editor
+4. Melody
+5. Recording
+
+Use Tab and Shift+Tab to quickly move between these sections.`,
+    keywords: ['keyboard', 'shortcut', 'navigation', 'tab', 'section'],
+    related: ['playback-shortcuts', 'editing-shortcuts'],
+  },
+];
+
+/**
+ * Frequently asked questions
+ */
+export const FAQ_ITEMS: FAQItem[] = [
+  {
+    id: 'faq-what-poems-work',
+    question: 'What kinds of poems work best with Ghost Note?',
+    answer: 'Ghost Note works best with poems that have a regular meter and clear line breaks. Poems with 4-50 lines in traditional forms (sonnets, ballads, etc.) produce excellent results. Free verse can also work, but the melody may be less structured.',
+    category: 'getting-started',
+  },
+  {
+    id: 'faq-no-analysis',
+    question: 'Why isn\'t my poem being analyzed?',
+    answer: 'Make sure you\'ve entered text in the poem input area and clicked "Analyze." The app needs at least a few words to perform analysis. Check that your browser isn\'t blocking JavaScript.',
+    category: 'analysis',
+  },
+  {
+    id: 'faq-red-singability',
+    question: 'What should I do about red singability scores?',
+    answer: 'Red scores indicate syllables that may be difficult to sing. Check the suggestions panel for alternative words. Common issues include consonant clusters (like "strength") and closed vowels on long notes.',
+    category: 'analysis',
+  },
+  {
+    id: 'faq-wrong-stress',
+    question: 'The stress pattern looks wrong for a word. Can I fix it?',
+    answer: 'The analysis uses the CMU Pronouncing Dictionary which covers most English words. Unusual words, names, or dialectal pronunciations may be incorrect. Currently, manual stress override isn\'t supported, but it\'s planned for a future release.',
+    category: 'analysis',
+  },
+  {
+    id: 'faq-ignore-suggestions',
+    question: 'Do I have to accept all suggestions?',
+    answer: 'Not at all! Suggestions are just that - suggestions. If a word is important to your poem\'s meaning or you prefer the original, keep it. The goal is to help, not to override your creative vision.',
+    category: 'suggestions',
+  },
+  {
+    id: 'faq-melody-sounds-wrong',
+    question: 'The melody doesn\'t match my poem\'s mood.',
+    answer: 'Try adjusting the key (major/minor) and tempo. Major keys sound happier while minor keys are more melancholic. You can also regenerate the melody after making these changes.',
+    category: 'melody',
+  },
+  {
+    id: 'faq-melody-too-high',
+    question: 'The melody is too high/low for my voice.',
+    answer: 'Use the key signature control to transpose the melody up or down. Keep trying different keys until you find one comfortable for your vocal range.',
+    category: 'melody',
+  },
+  {
+    id: 'faq-cant-hear-melody',
+    question: 'I can\'t hear the melody playing.',
+    answer: 'Check your browser\'s sound settings and system volume. Some browsers block autoplay audio - you may need to click the play button manually. Try refreshing the page if audio still doesn\'t work.',
+    category: 'melody',
+  },
+  {
+    id: 'faq-microphone-not-working',
+    question: 'My microphone isn\'t being detected.',
+    answer: 'Ensure you\'ve granted microphone permission in your browser. Check that your microphone is connected and selected as the input device in both the app and your system settings. Try refreshing the page.',
+    category: 'recording',
+  },
+  {
+    id: 'faq-recording-quality',
+    question: 'How can I improve my recording quality?',
+    answer: 'Use an external microphone if possible. Record in a quiet room without echo. Keep a consistent distance from the mic. Watch the level meter to avoid clipping (going into the red zone).',
+    category: 'recording',
+  },
+  {
+    id: 'faq-save-work',
+    question: 'How do I save my work?',
+    answer: 'Use Cmd/Ctrl+S or the Export button to save your project. You can export poems, lyrics, melodies (as ABC notation), and recordings. Projects are also auto-saved in your browser\'s local storage.',
+    category: 'getting-started',
+  },
+  {
+    id: 'faq-shortcuts-not-working',
+    question: 'Keyboard shortcuts aren\'t working.',
+    answer: 'Shortcuts are disabled when you\'re typing in a text field (except for Escape and Cmd+S). Click outside of any text input, then try the shortcut. Press "?" to see all available shortcuts.',
+    category: 'shortcuts',
+  },
+];
+
+/**
+ * Get topics by category
+ */
+export function getTopicsByCategory(category: HelpCategory): HelpTopic[] {
+  return HELP_TOPICS.filter((topic) => topic.category === category);
+}
+
+/**
+ * Get a topic by ID
+ */
+export function getTopicById(id: string): HelpTopic | undefined {
+  return HELP_TOPICS.find((topic) => topic.id === id);
+}
+
+/**
+ * Get related topics for a given topic
+ */
+export function getRelatedTopics(topicId: string): HelpTopic[] {
+  const topic = getTopicById(topicId);
+  if (!topic || !topic.related) {
+    return [];
+  }
+  return topic.related
+    .map((id) => getTopicById(id))
+    .filter((t): t is HelpTopic => t !== undefined);
+}
+
+/**
+ * Search topics by query
+ */
+export function searchTopics(query: string): HelpTopic[] {
+  const lowerQuery = query.toLowerCase().trim();
+  if (!lowerQuery) {
+    return [];
+  }
+
+  return HELP_TOPICS.filter((topic) => {
+    const searchableText = [
+      topic.title,
+      topic.summary,
+      topic.content,
+      ...topic.keywords,
+    ]
+      .join(' ')
+      .toLowerCase();
+
+    return searchableText.includes(lowerQuery);
+  }).sort((a, b) => {
+    // Prioritize title matches
+    const aTitle = a.title.toLowerCase().includes(lowerQuery);
+    const bTitle = b.title.toLowerCase().includes(lowerQuery);
+    if (aTitle && !bTitle) return -1;
+    if (!aTitle && bTitle) return 1;
+
+    // Then keyword matches
+    const aKeyword = a.keywords.some((k) => k.includes(lowerQuery));
+    const bKeyword = b.keywords.some((k) => k.includes(lowerQuery));
+    if (aKeyword && !bKeyword) return -1;
+    if (!aKeyword && bKeyword) return 1;
+
+    return 0;
+  });
+}
+
+/**
+ * Get FAQ items by category
+ */
+export function getFAQByCategory(category: HelpCategory): FAQItem[] {
+  return FAQ_ITEMS.filter((item) => item.category === category);
+}
+
+/**
+ * Search FAQs by query
+ */
+export function searchFAQs(query: string): FAQItem[] {
+  const lowerQuery = query.toLowerCase().trim();
+  if (!lowerQuery) {
+    return [];
+  }
+
+  return FAQ_ITEMS.filter((item) => {
+    const searchableText = [item.question, item.answer].join(' ').toLowerCase();
+    return searchableText.includes(lowerQuery);
+  });
+}
+
+/**
+ * Get category by ID
+ */
+export function getCategoryById(id: HelpCategory): CategoryInfo | undefined {
+  return HELP_CATEGORIES.find((cat) => cat.id === id);
+}

--- a/web/src/components/Help/index.ts
+++ b/web/src/components/Help/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Help Components
+ *
+ * Components for the in-app help and documentation system.
+ *
+ * @module components/Help
+ */
+
+// Main help panel
+export { HelpPanel } from './HelpPanel';
+export type { HelpPanelProps } from './HelpPanel';
+
+// Topic-specific help section
+export { HelpSection } from './HelpSection';
+export type { HelpSectionProps } from './HelpSection';
+
+// FAQ component
+export { FAQ } from './FAQ';
+export type { FAQProps } from './FAQ';
+
+// Tooltip system
+export { TooltipProvider, Tooltip, useTooltip } from './TooltipProvider';
+export type {
+  TooltipProviderProps,
+  TooltipProps,
+  TooltipPosition,
+  TooltipConfig,
+} from './TooltipProvider';
+
+// Help content data
+export {
+  HELP_CATEGORIES,
+  HELP_TOPICS,
+  FAQ_ITEMS,
+  getTopicsByCategory,
+  getTopicById,
+  getRelatedTopics,
+  searchTopics,
+  getFAQByCategory,
+  searchFAQs,
+  getCategoryById,
+} from './helpContent';
+
+export type {
+  HelpTopic,
+  HelpCategory,
+  CategoryInfo,
+  FAQItem,
+} from './helpContent';


### PR DESCRIPTION
## Summary
Implements a comprehensive in-app help and user documentation system for Ghost Note:

- **HelpPanel** - Sliding drawer with category navigation, topic search, and FAQ section
- **HelpSection** - Renders topic-specific help content with markdown-like formatting
- **TooltipProvider** - Context-aware tooltips with optional links to help topics
- **FAQ** - Accordion-style frequently asked questions component

## Documentation Topics
- Getting started with Ghost Note
- Understanding poem analysis
- Working with lyric suggestions
- Melody customization
- Recording tips
- Keyboard shortcuts

## Changes
- `web/src/components/Help/HelpPanel.tsx` - Main sliding help drawer component
- `web/src/components/Help/HelpSection.tsx` - Topic content renderer
- `web/src/components/Help/TooltipProvider.tsx` - Tooltip context provider
- `web/src/components/Help/FAQ.tsx` - FAQ accordion component
- `web/src/components/Help/helpContent.ts` - All documentation content
- `web/src/components/Help/index.ts` - Public exports
- `web/src/App.tsx` - Integration with HelpPanel
- CSS files for styling each component
- Test files with comprehensive coverage

## Testing
- [x] Unit tests pass (`npm test`) - 143 new tests added
- [x] Check passes (`npm run check`)
- [x] All 4677 total tests pass
- [x] No lint errors

## Notes
- Help panel is accessible via useUIStore's openModal('help') action
- Search functionality filters topics by title, summary, keywords, and content
- Related topics navigation allows users to explore connected help content
- Full ARIA accessibility support for screen readers
- Focus trap implementation for modal behavior

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)