### PR TITLE
docs(GH-155): Clarify that dev commands run from web/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ This project is designed to be used with:
 git clone https://github.com/yourusername/ghost-note.git
 cd ghost-note
 
-# Install dependencies (once web app is set up)
+# Navigate to web app directory
+cd web
+
+# Install dependencies
 npm install
 
 # Start development server
@@ -56,7 +59,7 @@ ghost-note/
 │       ├── generate-melody.md
 │       ├── suggest-changes.md
 │       └── status.md
-├── web/                   # Frontend application (coming soon)
+├── web/                   # Frontend application (React + Vite)
 └── lib/                   # Shared libraries (coming soon)
 ```
 
@@ -98,7 +101,7 @@ claude
 
 ### With Chrome Extension
 
-1. Run `npm run dev` to start local server
+1. Run `cd web && npm run dev` to start local server
 2. Open localhost in browser
 3. Connect Claude Chrome Extension
 4. Use for testing and debugging UI


### PR DESCRIPTION
## Summary
Updates README.md to clarify that development commands (`npm install`, `npm run dev`) should be run from the `web/` directory, not the repository root.

## Changes
- `README.md` - Updated Quick Start section to include `cd web` before npm commands
- `README.md` - Updated Chrome Extension section with `cd web && npm run dev`
- `README.md` - Updated project structure to show `web/` is active (React + Vite) instead of "coming soon"

## Testing
- [x] Verified web/package.json contains the dev scripts
- [x] Instructions now correctly guide users to the web/ directory

## Notes
Simple documentation fix to help new users successfully run the development server.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)