### PR TITLE
fix(GH-164): Fix poem selection dialog closing prematurely

### DIFF
--- a/web/src/components/PoemInput/SamplePoems.test.tsx
+++ b/web/src/components/PoemInput/SamplePoems.test.tsx
@@ -179,18 +179,20 @@ describe('SamplePoems', () => {
   });
 
   describe('selection', () => {
-    it('calls onSelect when poem is clicked', async () => {
+    it('clicking poem item selects it for preview without calling onSelect', async () => {
       const onSelect = vi.fn();
       const user = userEvent.setup();
       render(<SamplePoems {...defaultProps} onSelect={onSelect} />);
 
-      const firstPoem = samplePoems[0];
-      const firstItem = screen.getByTestId(`sample-poem-${firstPoem.id}`);
+      const secondPoem = samplePoems[1];
+      const secondItem = screen.getByTestId(`sample-poem-${secondPoem.id}`);
 
-      await user.click(firstItem);
+      await user.click(secondItem);
 
-      expect(onSelect).toHaveBeenCalledTimes(1);
-      expect(onSelect).toHaveBeenCalledWith(firstPoem);
+      // Clicking a poem item should NOT call onSelect - only preview it
+      expect(onSelect).not.toHaveBeenCalled();
+      // The clicked item should now be selected (has aria-selected)
+      expect(secondItem).toHaveAttribute('aria-selected', 'true');
     });
 
     it('calls onSelect when "Use This Poem" button is clicked', async () => {

--- a/web/src/components/PoemInput/SamplePoems.tsx
+++ b/web/src/components/PoemInput/SamplePoems.tsx
@@ -271,7 +271,7 @@ export function SamplePoems({
                 role="option"
                 aria-selected={selectedIndex === index}
                 className={`sample-poems-item ${selectedIndex === index ? 'selected' : ''}`}
-                onClick={() => handleSelectPoem(poem)}
+                onClick={() => setSelectedIndex(index)}
                 onMouseEnter={() => setHoveredIndex(index)}
                 onMouseLeave={() => setHoveredIndex(null)}
                 data-testid={`sample-poem-${poem.id}`}


### PR DESCRIPTION
## Summary
Fixed the poem selection dialog closing before users could click "Use This Poem" button.

## Changes
- `web/src/components/PoemInput/SamplePoems.tsx` - Changed poem item click to select for preview instead of immediately triggering onSelect
- `web/src/components/PoemInput/SamplePoems.test.tsx` - Updated test to verify new click behavior

## Root Cause
Clicking on a poem item was calling `handleSelectPoem(poem)` which triggered `onSelect`, causing the parent component to close the dialog. Users expected to click a poem to preview it, then click "Use This Poem" to confirm.

## Fix
Changed the poem item click handler from `onClick={() => handleSelectPoem(poem)}` to `onClick={() => setSelectedIndex(index)}`. Now:
- Clicking a poem item selects it for preview (updates `selectedIndex`)
- Only clicking "Use This Poem" button calls `onSelect` and closes the dialog

## Testing
- [x] Unit tests pass (`npm test`)
- [x] Linter passes (`npm run lint`)

Closes #164