### PR TITLE
fix(GH-178): Disable service worker in dev mode

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -99,8 +99,7 @@ export default defineConfig({
         ],
       },
       devOptions: {
-        enabled: true,
-        type: 'module',
+        enabled: false,
       },
     }),
     // Bundle analyzer - generates stats.html after build (only when ANALYZE=true)


### PR DESCRIPTION
## Summary
Disables the service worker in development mode to fix the ENOENT error when running `npm run dev`.

## Changes
- `web/vite.config.ts` - Set `devOptions.enabled: false` in vite-plugin-pwa config

## Root Cause
The vite-plugin-pwa plugin was configured with `devOptions.enabled: true`, which caused it to look for `dev-dist/sw.js`. This file was not being generated, resulting in the ENOENT error.

## Testing
- [x] `npm run dev` - No ENOENT error, dev server starts successfully
- [x] `npm run lint` - Passes
- [x] `npm test -- --run` - All tests pass

## Notes
- Production PWA behavior is unchanged - the service worker is still generated and used in production builds
- The `type: 'module'` option was also removed as it's only relevant when `enabled: true`

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)